### PR TITLE
docs(analytics): Desired analytics data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.enabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cSpell.enabled": true
-}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -9,20 +9,29 @@ This document describes that mechanism, detailing how, why, and what can be reco
 
 ## Recorded Data
 
-To understand which data should be recorded, we introduce questions we'd like to ask.
+To understand which data should be recorded, we introduce a few questions we'd like to ask.
 For each question, we explain why are we asking it, and which measurements are needed in order to answer it.
 
 ### Are users satisfied with the hub?
 
-This is the holy grail of questions, and most likely cannot be answered with a simple measurement. Nevertheless, we want get a
-general sense as to whether existing users are overall satisfied with the hub or not. To a first approximation, we can answer this by
-looking at the overall visits to the hub, and making sure we don't see a decline over time.
+We need to make sure users are happy with the overall experience of the application.
+To answer this, we need to understand whether existing users are abandoning the hub, or keep using it.
+
+Since we don't identify individual users, the only thing we can do is measure total hub visits, and make sure this value doesn't decrease over time.
+
+**Required metrics:**
+
+- `visits`: Number of distinct visits. (i.e main page + package pages)
 
 ### Are people aware of the hub?
 
-We want the construct hub to serve as many users as possible, which means making sure it is constantly being exposed to new people.
+The construct hub should serve as many users as possible, which means making sure it is constantly being exposed to new people.
 Since we don't attribute traffic to any specific user, the only thing we can do is look at overall visits over time, and ensure that
 it keeps increasing.
+
+**Required metrics:**
+
+- `visits`: Number of distinct visits. (i.e main page + package pages)
 
 ### Are users satisfied with the search experience?
 
@@ -45,6 +54,10 @@ This means we need to track user sessions as a whole. Specifically, we want to d
 
 If we see that most search journeys terminate at the *install* phase, we conclude users are finding what they're looking.
 
+**Required metrics:**
+
+- `journeys.search.success`: Number of journeys that start with a search query, and end in an install.
+
 ### Are users satisfied with the package pages?
 
 Continuous operation of construct libraries requires a reliable and clear source of documentation. This is offered by the specific package pages of the hub.
@@ -62,12 +75,20 @@ during a search journey. Specifically, we want to detect the following user jour
 
 If we see that most of these journeys are successful, we conclude users are satisfied with it.
 
+**Required metrics:**
+
+- `journeys.operate.success`: Number of journeys that start with a direct package page, and end in a successful interaction.
+
 ### Are people aware of package pages?
 
 As already mentioned, we want package pages to be the go to place for users operating construct libraries.
 For that to happen, package pages should be exposed to as many people as possible.
 
 To ensure this, we look at the direct visits to package pages, and make sure its value is increasing over time.
+
+**Required metrics:**
+
+- `packages.<package>.visits`: Number of distinct visits to specific package pages.
 
 ### Which constructs are missing from the ecosystem?
 
@@ -76,6 +97,10 @@ By detecting missing constructs, we can either explicitly act, or encourage the 
 To answer this, we want to identify hot search items that don't return any hits. For example, if we see `docker-compose` is being searched a lot,
 we can conclude that the community is looking for a `docker-compose` CDK. This can help detect entirely new domains that aren't being covered but should,
 as these will likely not manifest as feature requests in any of the existing CDKs.
+
+**Required metrics:**
+
+- `terms.<term>`: Number of search queries for `term`.
 
 ## High Level Design
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,77 +1,81 @@
-# Construct-Hub Analytics
+# Construct Hub Web Application Analytics
 
-This document describes the analytics mechanism we want the construct hub web application to offer. It explains what type of data can be recorded, and what are the expected insights that can be extracted from it.
+The construct hub web application is designed to help users find and interact with construct libraries.
 
-## What to track
+In order for its operators to understand whether it indeed serves its purpose, the application offers an analytics
+mechanism to extract insights from the traffic it sees.
 
-### Traffic Volume
+This document describes that mechanism, detailing how, why, and what can be recorded.
 
-We want to make sure the hub sees consistent and increasing traffic over time.
+## Recorded Data
 
-#### Metrics
+To understand which data should be recorded, we introduce questions we'd like to ask.
+For each question, we explain why are we asking it, and which measurements are needed in order to answer it.
 
-##### `pages.main.hits`
+### Are users satisfied with the hub?
 
-This metric measures page hits to the hub's main entrypoint.
+This is the holy grail of questions, and most likely cannot be answered with a simple measurement. Nevertheless, we want get a
+general sense as to whether existing users are overall satisfied with the hub or not. To a first approximation, we can answer this by
+looking at the overall visits to the hub, and making sure we don't see a decline over time.
 
-#### `pages.<package>.hits`
+### Are people aware of the hub?
 
-This metric measures page hits to a specific package page in the hub.
+We want the construct hub to serve as many users as possible, which means making sure it is constantly being exposed to new people.
+Since we don't attribute traffic to any specific user, the only thing we can do is look at overall visits over time, and ensure that
+it keeps increasing.
 
-#### Insights
+### Are users satisfied with the search experience?
 
-- Is the hub popular?
+Search is one of the core capabilities the hub offers. A poor search experience will likely cause users to discover less construct libraries,
+and will hurt the ecosystem. To answer this question, we first need to define what a good experience is.
 
-  > Stagnation in overall page hits might mean that new people are not being exposed to the site.
+Effectiveness of search engines is measured by the engagement of users with the search results.
+In our case, a successful engagement will result in the installation of a construct library.
 
-- Are users enjoying the hub?
+Since package installation doesn't happen via the hub, this is impossible to deterministically detect.
+Nevertheless, we approximate by making the following assertions:
 
-  > A drop in overall page hits might mean we are loosing users, because the overall experience is not good enough.
+- A user who clicked on the *Copy installation instructions* button, installed the package.
+- A user who spent more than X time on the package page following a search, installed the package.
 
-### Traffic Quality
+Tracking individual requests is not sufficient to detect these interactions. For example, a user who directly visits a package page should not be counted.
+This means we need to track user sessions as a whole. Specifically, we want to detect the following user journey:
 
-We want to make sure users have a productive experience with the hub. Given it is designed to find and operate construct libraries, we define a produtive experience as one of two user journeys:
+*search* --> *select* --> *install*
 
-- A user visits the main page and installs a construct library. We call this the *Install* journey. More concretely, it has the following stops:
+If we see that most search journeys terminate at the *install* phase, we conclude users are finding what they're looking.
 
-  **Visit** --> **Search** --> **Browse** --> **Select** --> **Install**
+### Are users satisfied with the package pages?
 
-  Since package installation doesn't happen via the hub, there is no bulletproof way for us to determine whether a user actually installed a package or not. Nevertheless, we try to approximate by making the following assertions:
+Continuous operation of construct libraries requires a reliable and clear source of documentation. This is offered by the specific package pages of the hub.
+An insufficient page will result in a poor experience as users develop against the construct library, and will cause general frustration.
 
-  - A user who clicked on the *Copy installation instructions* button, installed the package.
-  - A user who spent more than X time on the package page following a search, installed the package.
+To know if users are satisfied, we look at the engagement they have with the package pages.
+Since package pages involve mainly viewing at the page, we define a positive experience as:
 
-- A user visits a specific package page, and stays there to read documenation. We call this the *Operate* journey. More concretely, it has the following stops:
+- A user who spent more than X time on the package page following a direct visit, found it useful.
 
-  **Visit** --> **Operate**
+Tracking individual requests is not sufficient to detect this interactions since we want to exclude users who stumbled upon a package page
+during a search journey. Specifically, we want to detect the following user journey:
 
-  User interaction with the package package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
+*package-page* --> *stay*
 
-  - A user who spent more than X time on the package page, used it to operate the construct.
+If we see that most of these journeys are successful, we conclude users are satisfied with it.
 
-**Quality traffic is determined by the success rate of these journeys.**
+### Are people aware of package pages?
 
-#### Metrics
+As already mentioned, we want package pages to be the go to place for users operating construct libraries.
+For that to happen, package pages should be exposed to as many people as possible.
 
-##### `journeys.<journey>.stops.<stop>`
+To ensure this, we look at the direct visits to package pages, and make sure its value is increasing over time.
 
-This metric describes the final stop of each journey type. For example, `journeys.install.stops.browse` counts the number of install journeys that terminated in the *browse* stop, meaning the user did not click on any search result.
+### Which constructs are missing from the ecosystem?
 
-#### Insights
+By detecting missing constructs, we can either explicitly act, or encourage the community to act in order to fill those gaps.
 
-- Are users finding the libraries the're looking for? why not?
-
-  > If most journeys terminate in the browse/navigate stop, it can either mean our search results aren't good enough, or that the relevant constructs don't exist.
-
-- Do users find the package helpful?
-
-  > If users spend only a few seconds on the package page, it probably means they haven't found what the're looking for.
-
-### Ecosystem Statistics
-
-#### Metrics
-
-#### Insights
+To answer this, we want to identify hot search items that don't return any hits. For example, if we see `docker-compose` is being searched a lot,
+we can conclude that the community is looking for a `docker-compose` CDK. This can help detect entirely new domains that aren't being covered but should,
+as these will likely not manifest as feature requests in any of the existing CDKs.
 
 ## High Level Design
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -14,7 +14,7 @@ For each question, we explain why are we asking it, and which metrics are needed
 
 ### Are users satisfied with the hub?
 
-The overall experience with the hub should be positive.
+**Why:** The overall experience with the hub should be positive.
 
 To answer this, we need to understand whether existing users are abandoning the hub, or keep using it.
 Normally this is done by making sure that the amount of daily active users doesn't decrease over time.
@@ -27,7 +27,7 @@ that individual user traffic doesn't have a large variance.
 
 ### Are people aware of the hub?
 
-The hub should serve the entire ecosystem and consistently attract new users.
+**Why:** The hub should serve the entire ecosystem and consistently attract new users.
 
 To answer this, we need to understand whether new people are discovering the hub.
 Normally this is done by making sure that the amount of daily active users increases over time.
@@ -40,7 +40,7 @@ that individual user traffic doesn't have a large variance.
 
 ### Are users satisfied with the package pages?
 
-Continuous operation of construct libraries requires a reliable and clear source of documentation. This is offered by the specific package pages of the hub.
+**Why:** Continuous operation of construct libraries requires a reliable and clear source of documentation. This is offered by the specific package pages of the hub.
 We want to make sure users find it helpful.
 
 To answer this, we need to understand whether existing users are abandoning the package pages, or keep using it.
@@ -57,7 +57,7 @@ page to help them operate the construct library.
 
 ### Are people aware of package pages?
 
-Package pages should serve the entire ecosystem and consistently attract new users.
+**Why:** Package pages should serve the entire ecosystem and consistently attract new users.
 
 To answer this, we need to understand whether new people are discovering the package pages.
 Normally this is done by making sure that the amount of daily active users increases over time.
@@ -73,11 +73,11 @@ page to help them operate the construct library.
 
 ### Are users satisfied with the search experience?
 
-Search is one of the core capabilities the hub offers. A poor search experience will likely cause users to discover less construct libraries,
-and will hurt the ecosystem. To answer this question, we first need to define what a good experience is.
+**Why:** Search is one of the core capabilities the hub offers. A poor search experience will likely cause users to discover less construct libraries,
+and will hurt the ecosystem.
 
-Effectiveness of search engines is measured by the engagement of users with the search results.
-In our case, a successful engagement will result in the installation of a construct library.
+To answer this question, we first need to define what a good experience is. Effectiveness of search engines is measured by the
+engagement of users with the search results. In our case, a successful engagement will result in the installation of a construct library.
 
 Since package installation doesn't happen via the hub, this is impossible to deterministically detect.
 Nevertheless, we approximate by making the following assertions:
@@ -100,7 +100,7 @@ For that, we also want to identify which search phrases didn't result in an inst
 
 ### Which constructs are missing from the ecosystem?
 
-We want to make sure users are able to use construct libraries for all their application needs.
+**Why:** We want to make sure users are able to use construct libraries for all their application needs.
 By detecting missing constructs, we can either explicitly act, or encourage the community to act in order to fill those gaps.
 
 To answer this, we want to identify hot search phrases that don't return any hits. This can help detect entirely new domains that aren't being covered but should,

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -14,14 +14,14 @@ For each question, we explain why are we asking it, and which measurements are n
 
 ### Are users satisfied with the hub?
 
-We need to make sure users are happy with the overall experience of the application.
+We need to make sure users are happy with the overall experience of the hub.
 To answer this, we need to understand whether existing users are abandoning the hub, or keep using it.
 
 Since we don't identify individual users, the only thing we can do is measure total hub visits, and make sure this value doesn't decrease over time.
 
 **Required metrics:**
 
-- `visits`: Number of distinct visits. (i.e main page + package pages)
+- `visits.hub`: Number of distinct visits. (main page + package pages)
 
 ### Are people aware of the hub?
 
@@ -31,7 +31,7 @@ it keeps increasing.
 
 **Required metrics:**
 
-- `visits`: Number of distinct visits. (i.e main page + package pages)
+- `visits.hub`: Number of distinct visits. (main page + package pages)
 
 ### Are users satisfied with the search experience?
 
@@ -88,7 +88,7 @@ To ensure this, we look at the direct visits to package pages, and make sure its
 
 **Required metrics:**
 
-- `packages.<package>.visits`: Number of distinct visits to specific package pages.
+- `visits.packages.<package>`: Number of distinct visits to specific package pages.
 
 ### Which constructs are missing from the ecosystem?
 
@@ -100,7 +100,7 @@ as these will likely not manifest as feature requests in any of the existing CDK
 
 **Required metrics:**
 
-- `terms.<term>`: Number of search queries for `term`.
+- `search.terms.<term>`: Number of search queries for `term`.
 
 ## High Level Design
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -9,8 +9,8 @@ This document describes that mechanism, detailing how, why, and what can be reco
 
 ## Recorded Data
 
-To understand which data should be recorded, we introduce a few questions we'd like to ask.
-For each question, we explain why are we asking it, and which measurements are needed in order to answer it.
+To understand which data should be recorded, we work backwards from the questions we'd like to ask it.
+For each question, we explain why are we asking it, and which metrics are needed in order to answer it.
 
 ### Are users satisfied with the hub?
 
@@ -23,11 +23,11 @@ that individual user traffic doesn't have a large variance.
 
 **Required metrics:**
 
-- `visits.hub`: Number of distinct visits. (main page + package pages)
+- `visits.hub`: Number of distinct visits to the hub. (main page + package pages)
 
 ### Are people aware of the hub?
 
-The hub should serve the entire ecosystem, as well as consistently attract new users.
+The hub should serve the entire ecosystem and consistently attract new users.
 
 To answer this, we need to understand whether new people are discovering the hub.
 Normally this is done by making sure that the amount of daily active users increases over time.
@@ -36,12 +36,12 @@ that individual user traffic doesn't have a large variance.
 
 **Required metrics:**
 
-- `visits.hub`: Number of distinct visits. (main page + package pages)
+- `visits.hub`: Number of distinct visits to the hub. (main page + package pages)
 
 ### Are users satisfied with the package pages?
 
 Continuous operation of construct libraries requires a reliable and clear source of documentation. This is offered by the specific package pages of the hub.
-We want to get a sense whether users find it helpful.
+We want to make sure users find it helpful.
 
 To answer this, we need to understand whether existing users are abandoning the package pages, or keep using it.
 Normally this is done by making sure that the amount of daily active users doesn't decrease over time.
@@ -53,11 +53,11 @@ page to help them operate the construct library.
 
 **Required metrics:**
 
-- `visits.packages.<package>`: Number of distinct and direct visits to the `<package>` page.
+- `visits.packages.<package>`: Number of distinct and direct visits to a `<package>` page.
 
 ### Are people aware of package pages?
 
-Package pages should serve the entire ecosystem, as well as consistently attract new users.
+Package pages should serve the entire ecosystem and consistently attract new users.
 
 To answer this, we need to understand whether new people are discovering the package pages.
 Normally this is done by making sure that the amount of daily active users increases over time.
@@ -69,7 +69,7 @@ page to help them operate the construct library.
 
 **Required metrics:**
 
-- `visits.packages.<package>`: Number of distinct and direct visits to the `<package>` page.
+- `visits.packages.<package>`: Number of distinct and direct visits to a `<package>` page.
 
 ### Are users satisfied with the search experience?
 
@@ -90,9 +90,8 @@ This means we need to track user sessions as a whole. Specifically, we want to d
 
 *search* --> *select* --> *install*
 
-If we see that most search journeys terminate at the *install* phase, we conclude users are finding what they're looking.
-
-To improve the search experience, we want to identify which search phrases didn't result in an installation.
+If we see that a significant percentage of search journeys don't end in an install, we need to take corrective actions.
+For that, we also want to identify which search phrases didn't result in an installation so we can investigate why.
 
 **Required metrics:**
 
@@ -101,11 +100,12 @@ To improve the search experience, we want to identify which search phrases didn'
 
 ### Which constructs are missing from the ecosystem?
 
+We want to make sure users are able to use construct libraries for all their application needs.
 By detecting missing constructs, we can either explicitly act, or encourage the community to act in order to fill those gaps.
 
-To answer this, we want to identify hot search phrases that don't return any hits. For example, if we see `docker-compose` is being searched a lot,
-we can conclude that the community is looking for a `docker-compose` related constructs. This can help detect entirely new domains that aren't being covered but should,
-as these will likely not manifest as feature requests in any of the existing construct repositories.
+To answer this, we want to identify hot search phrases that don't return any hits. This can help detect entirely new domains that aren't being covered but should,
+as these will likely not manifest as feature requests in any of the existing construct repositories. For example, if we see `docker-compose` is being searched a lot,
+we can conclude that the community is looking for `docker-compose` related constructs.
 
 **Required metrics:**
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -7,6 +7,11 @@ mechanism to extract insights from the traffic it sees.
 
 This document describes that mechanism, detailing how, why, and what can be recorded.
 
+## Declaration of Intent
+
+As a general tenet, we are not interested in identifying individual user traffic. That is, it will not be possible to say which user
+searched or interacted with which construct. All we are interested in is aggregative stats to help improve the experience as a whole.
+
 ## Recorded Data
 
 To understand which data should be recorded, we work backwards from the questions we'd like to ask it.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -17,6 +17,9 @@ searched or interacted with which construct. All we are interested in is aggrega
 To understand which data should be recorded, we work backwards from the questions we'd like to ask it.
 For each question, we explain why are we asking it, and which metrics are needed in order to answer it.
 
+> Metrics are denoted using the common dot notation. It merely serves as a concise way to refer to measurements,
+> and does not infer any technical meaning. 
+
 ### Are users satisfied with the hub?
 
 **Why:** The overall experience with the hub should be positive.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -18,25 +18,20 @@ We want to make sure users have a productive experience with the hub. Given it i
 
 - A user visits the main page and installs a construct library. We call this the *Install* journey. More concretely, it has the following stops:
 
-    1. **Visit**: User visits the main page of the site.
-    2. **Search**: User inputs a search term.
-    3. **Browse**: User browses through the search results.
-    4. **Navigate**: User navigates to a specific package page.
-    5. **Install**: User installs the construct library.
+  **Visit** --> **Search** --> **Browse** --> **Navigate** --> **Install**
 
-        Since package installation doesn't happen via the hub, there is no bulletproof way for us to determine whether a user actually installed a package or not. Nevertheless, we try to approximate by making the following assertions:
+  Since package installation doesn't happen via the hub, there is no bulletproof way for us to determine whether a user actually installed a package or not. Nevertheless, we try to approximate by making the following assertions:
 
-        - A user who clicked on the *Copy installation instructions* button, installed the package.
-        - A user who spent more than X time on the package page, installed the package.
+  - A user who clicked on the *Copy installation instructions* button, installed the package.
+  - A user who spent more than X time on the package page, installed the package.
 
 - A user visits a specific package page, and stays there to read documenation. We call this the *Operate* journey. More concretely, it has the following stops:
 
-    1. **Visit**: User visits a specific package page.
-    2. **Operate**: User interacts with the page since it helps to operate the construct.
+  **Visit** --> **Operate**
 
-        User interaction with the package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
+  User interaction with the package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
 
-        - A user who spent more than X time on the package page, used it to operate the construct.
+  - A user who spent more than X time on the package page, used it to operate the construct.
 
 Quality traffic is defined by the success rate of these journeys.
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,16 +1,32 @@
 # Construct-Hub Analytics
 
-This document details the analytics capabilities offered by the construct hub web application.
+This document describes the analytics mechanism we want the construct hub web application to offer. It explains what type of data can be recorded, and what are the expected insights that can be extracted from it.
 
 ## What to track
 
 ### Traffic Volume
 
-We want to make sure the hub sees consistent and increasing traffic over time. To the end, we track the following metrics:
+We want to make sure the hub sees consistent and increasing traffic over time.
 
 #### Metrics
 
+##### `pages.main.hits`
+
+This metric measures page hits to the hub's main entrypoint.
+
+#### `pages.<package>.hits`
+
+This metric measures page hits to a specific package page in the hub.
+
 #### Insights
+
+- Is the hub popular?
+
+  > Stagnation in overall page hits might mean that new people are not being exposed to the site.
+
+- Are users enjoying the hub?
+
+  > A drop in overall page hits might mean we are loosing users, because the overall experience is not good enough.
 
 ### Traffic Quality
 
@@ -18,36 +34,30 @@ We want to make sure users have a productive experience with the hub. Given it i
 
 - A user visits the main page and installs a construct library. We call this the *Install* journey. More concretely, it has the following stops:
 
-  **Visit** --> **Search** --> **Browse** --> **Navigate** --> **Install**
+  **Visit** --> **Search** --> **Browse** --> **Select** --> **Install**
 
   Since package installation doesn't happen via the hub, there is no bulletproof way for us to determine whether a user actually installed a package or not. Nevertheless, we try to approximate by making the following assertions:
 
   - A user who clicked on the *Copy installation instructions* button, installed the package.
-  - A user who spent more than X time on the package page, installed the package.
+  - A user who spent more than X time on the package page following a search, installed the package.
 
 - A user visits a specific package page, and stays there to read documenation. We call this the *Operate* journey. More concretely, it has the following stops:
 
   **Visit** --> **Operate**
 
-  User interaction with the package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
+  User interaction with the package package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
 
   - A user who spent more than X time on the package page, used it to operate the construct.
 
-Quality traffic is defined by the success rate of these journeys.
+**Quality traffic is determined by the success rate of these journeys.**
 
 #### Metrics
 
 ##### `journeys.<journey>.stops.<stop>`
 
-This metric describes the final stop of each journey type.
-
-For example, `journeys.search.stops.browse` counts the number of search journeys that
-terminated in the *browse* stop, meaning the user did not click on
-any search result.
+This metric describes the final stop of each journey type. For example, `journeys.install.stops.browse` counts the number of install journeys that terminated in the *browse* stop, meaning the user did not click on any search result.
 
 #### Insights
-
-Given this data, we will be able to extract the following insights:
 
 - Are users finding the libraries the're looking for? why not?
 
@@ -56,6 +66,12 @@ Given this data, we will be able to extract the following insights:
 - Do users find the package helpful?
 
   > If users spend only a few seconds on the package page, it probably means they haven't found what the're looking for.
+
+### Ecosystem Statistics
+
+#### Metrics
+
+#### Insights
 
 ## High Level Design
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -8,45 +8,49 @@ This document details the analytics capabilities offered by the construct hub we
 
 We want to make sure the hub sees consistent and increasing traffic over time. To the end, we track the following metrics:
 
+#### Metrics
+
+#### Insights
+
 ### Traffic Quality
 
 We want to make sure users have a productive experience with the hub. Given it is designed to find and operate construct libraries, we define a produtive experience as one of two user journeys:
 
-#### Install
+- A user visits the main page and installs a construct library. We call this the *Install* journey. More concretely, it has the following stops:
 
-A user visits the main page and winds up installing a construct library. More concretely, this journey has the following stops:
+    1. **Visit**: User visits the main page of the site.
+    2. **Search**: User inputs a search term.
+    3. **Browse**: User browses through the search results.
+    4. **Navigate**: User navigates to a specific package page.
+    5. **Install**: User installs the construct library.
 
-1. **Visit**: User visits the main page of the site.
-2. **Search**: User inputs a search term.
-3. **Browse**: User browses through the search results.
-4. **Navigate**: User navigates to a specific package page.
-5. **Install**: User installs the construct library.
+        Since package installation doesn't happen via the hub, there is no bulletproof way for us to determine whether a user actually installed a package or not. Nevertheless, we try to approximate by making the following assertions:
 
-    Since package installation doesn't happen via the hub, there is no bulletproof way for us to determine whether a user actually installed a package or not. Nevertheless, we try to approximate by making the following assertions:
+        - A user who clicked on the *Copy installation instructions* button, installed the package.
+        - A user who spent more than X time on the package page, installed the package.
 
-    - A user who clicked on the *Copy installation instructions* button, installed the package.
-    - A user who spent more than X time on the package page, installed the package.
+- A user visits a specific package page, and stays there to read documenation. We call this the *Operate* journey. More concretely, it has the following stops:
 
-#### Operate
+    1. **Visit**: User visits a specific package page.
+    2. **Operate**: User interacts with the page since it helps to operate the construct.
 
-A user visits a specific package page, and stays there to read documenation.
+        User interaction with the package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
 
-1. **Visit**: User visits a specific package page.
-2. **Operate**: User interacts with the page since it helps to operate the construct.
+        - A user who spent more than X time on the package page, used it to operate the construct.
 
-    User interaction with the package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
+Quality traffic is defined by the success rate of these journeys.
 
-    - A user who spent more than X time on the package page, used it to operate the construct.
+#### Metrics
 
-Quality traffic is defined by the success rate of these journeys, we track the following metric:
-
-- `journeys.<journey>.stops.<stop>`
+##### `journeys.<journey>.stops.<stop>`
 
 This metric describes the final stop of each journey type.
 
 For example, `journeys.search.stops.browse` counts the number of search journeys that
 terminated in the *browse* stop, meaning the user did not click on
 any search result.
+
+#### Insights
 
 Given this data, we will be able to extract the following insights:
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -14,10 +14,12 @@ For each question, we explain why are we asking it, and which measurements are n
 
 ### Are users satisfied with the hub?
 
-We need to make sure users are happy with the overall experience of the hub.
-To answer this, we need to understand whether existing users are abandoning the hub, or keep using it.
+The overall experience with the hub should be positive.
 
-Since we don't identify individual users, the only thing we can do is measure total hub visits, and make sure this value doesn't decrease over time.
+To answer this, we need to understand whether existing users are abandoning the hub, or keep using it.
+Normally this is done by making sure that the amount of daily active users doesn't decrease over time.
+Since we don't identify individual users, we approximate by looking at the total number of distinct visits to the hub, assuming
+that individual user traffic doesn't have a large variance.
 
 **Required metrics:**
 
@@ -25,13 +27,49 @@ Since we don't identify individual users, the only thing we can do is measure to
 
 ### Are people aware of the hub?
 
-The construct hub should serve as many users as possible, which means making sure it is constantly being exposed to new people.
-Since we don't attribute traffic to any specific user, the only thing we can do is look at overall visits over time, and ensure that
-it keeps increasing.
+The hub should serve the entire ecosystem, as well as consistently attract new users.
+
+To answer this, we need to understand whether new people are discovering the hub.
+Normally this is done by making sure that the amount of daily active users increases over time.
+Since we don't identify individual users, we approximate by looking at the total number of distinct visits to the hub, assuming
+that individual user traffic doesn't have a large variance.
 
 **Required metrics:**
 
 - `visits.hub`: Number of distinct visits. (main page + package pages)
+
+### Are users satisfied with the package pages?
+
+Continuous operation of construct libraries requires a reliable and clear source of documentation. This is offered by the specific package pages of the hub.
+We want to get a sense whether users find it helpful.
+
+To answer this, we need to understand whether existing users are abandoning the package pages, or keep using it.
+Normally this is done by making sure that the amount of daily active users doesn't decrease over time.
+Since we don't identify individual users, we approximate by looking at the total number of distinct visits to package pages, assuming
+that individual user traffic doesn't have a large variance.
+
+Note that in this case, we are not interested in users who stumble upon a package page during a search, but rather users who intentionally visit the package
+page to help them operate the construct library.
+
+**Required metrics:**
+
+- `visits.packages.<package>`: Number of distinct and direct visits to the `<package>` page.
+
+### Are people aware of package pages?
+
+Package pages should serve the entire ecosystem, as well as consistently attract new users.
+
+To answer this, we need to understand whether new people are discovering the package pages.
+Normally this is done by making sure that the amount of daily active users increases over time.
+Since we don't identify individual users, we approximate by looking at the total number of distinct visits to package pages, assuming
+that individual user traffic doesn't have a large variance.
+
+Note that in this case, we are not interested in users who stumble upon a package page during a search, but rather users who intentionally visit the package
+page to help them operate the construct library.
+
+**Required metrics:**
+
+- `visits.packages.<package>`: Number of distinct and direct visits to the `<package>` page.
 
 ### Are users satisfied with the search experience?
 
@@ -54,53 +92,24 @@ This means we need to track user sessions as a whole. Specifically, we want to d
 
 If we see that most search journeys terminate at the *install* phase, we conclude users are finding what they're looking.
 
+To improve the search experience, we want to identify which search phrases didn't result in an installation.
+
 **Required metrics:**
 
 - `journeys.search.success`: Number of journeys that start with a search query, and end in an install.
-
-### Are users satisfied with the package pages?
-
-Continuous operation of construct libraries requires a reliable and clear source of documentation. This is offered by the specific package pages of the hub.
-An insufficient page will result in a poor experience as users develop against the construct library, and will cause general frustration.
-
-To know if users are satisfied, we look at the engagement they have with the package pages.
-Since package pages involve mainly viewing at the page, we define a positive experience as:
-
-- A user who spent more than X time on the package page following a direct visit, found it useful.
-
-Tracking individual requests is not sufficient to detect this interactions since we want to exclude users who stumbled upon a package page
-during a search journey. Specifically, we want to detect the following user journey:
-
-*package-page* --> *stay*
-
-If we see that most of these journeys are successful, we conclude users are satisfied with it.
-
-**Required metrics:**
-
-- `journeys.operate.success`: Number of journeys that start with a direct package page, and end in a successful interaction.
-
-### Are people aware of package pages?
-
-As already mentioned, we want package pages to be the go to place for users operating construct libraries.
-For that to happen, package pages should be exposed to as many people as possible.
-
-To ensure this, we look at the direct visits to package pages, and make sure its value is increasing over time.
-
-**Required metrics:**
-
-- `visits.packages.<package>`: Number of distinct visits to specific package pages.
+- `journeys.search.phrases.<phrase>.fail`: Number of journeys that searched for `phrase` and didn't end in an install.
 
 ### Which constructs are missing from the ecosystem?
 
 By detecting missing constructs, we can either explicitly act, or encourage the community to act in order to fill those gaps.
 
-To answer this, we want to identify hot search items that don't return any hits. For example, if we see `docker-compose` is being searched a lot,
-we can conclude that the community is looking for a `docker-compose` CDK. This can help detect entirely new domains that aren't being covered but should,
-as these will likely not manifest as feature requests in any of the existing CDKs.
+To answer this, we want to identify hot search phrases that don't return any hits. For example, if we see `docker-compose` is being searched a lot,
+we can conclude that the community is looking for a `docker-compose` related constructs. This can help detect entirely new domains that aren't being covered but should,
+as these will likely not manifest as feature requests in any of the existing construct repositories.
 
 **Required metrics:**
 
-- `search.terms.<term>`: Number of search queries for `term`.
+- `search.phrases.<phrase>`: Number of search queries for `phrase`.
 
 ## High Level Design
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,63 @@
+# Construct-Hub Analytics
+
+This document details the analytics capabilities offered by the construct hub web application.
+
+## What to track
+
+### Traffic Volume
+
+We want to make sure the hub sees consistent and increasing traffic over time. To the end, we track the following metrics:
+
+### Traffic Quality
+
+We want to make sure users have a productive experience with the hub. Given it is designed to find and operate construct libraries, we define a produtive experience as one of two user journeys:
+
+#### Install
+
+A user visits the main page and winds up installing a construct library. More concretely, this journey has the following stops:
+
+1. **Visit**: User visits the main page of the site.
+2. **Search**: User inputs a search term.
+3. **Browse**: User browses through the search results.
+4. **Navigate**: User navigates to a specific package page.
+5. **Install**: User installs the construct library.
+
+    Since package installation doesn't happen via the hub, there is no bulletproof way for us to determine whether a user actually installed a package or not. Nevertheless, we try to approximate by making the following assertions:
+
+    - A user who clicked on the *Copy installation instructions* button, installed the package.
+    - A user who spent more than X time on the package page, installed the package.
+
+#### Operate
+
+A user visits a specific package page, and stays there to read documenation.
+
+1. **Visit**: User visits a specific package page.
+2. **Operate**: User interacts with the page since it helps to operate the construct.
+
+    User interaction with the package is hard to determine because most of it will probably be looking at documentation. To that end, we make the following assertion:
+
+    - A user who spent more than X time on the package page, used it to operate the construct.
+
+Quality traffic is defined by the success rate of these journeys, we track the following metric:
+
+- `journeys.<journey>.stops.<stop>`
+
+This metric describes the final stop of each journey type.
+
+For example, `journeys.search.stops.browse` counts the number of search journeys that
+terminated in the *browse* stop, meaning the user did not click on
+any search result.
+
+Given this data, we will be able to extract the following insights:
+
+- Are users finding the libraries the're looking for? why not?
+
+  > If most journeys terminate in the browse/navigate stop, it can either mean our search results aren't good enough, or that the relevant constructs don't exist.
+
+- Do users find the package helpful?
+
+  > If users spend only a few seconds on the package page, it probably means they haven't found what the're looking for.
+
+## High Level Design
+
+TBD


### PR DESCRIPTION
This PR introduces a long lived analytics document that describes our analytics mechanism. 
Currently only includes which data we'd like to record, backed solely on client side capabilities of the app. 

The question still remains how to actually store the data, which will be addressed in a subsequent PR. 

Related to https://github.com/cdklabs/construct-hub-webapp/issues/8.