### PR TITLE
bug: fix language bar icons

### DIFF
--- a/src/components/LanguageBar/index.tsx
+++ b/src/components/LanguageBar/index.tsx
@@ -31,23 +31,23 @@ const LANGUAGE_MAP: Record<Language, { name: string; icon: typeof Icon }> = {
   },
   python: {
     name: "Python",
-    icon: NodeIcon,
+    icon: PythonIcon,
   },
   java: {
     name: "Java",
-    icon: PythonIcon,
+    icon: JavaIcon,
   },
   js: {
     name: "Node.js",
-    icon: GoIcon,
+    icon: NodeIcon,
   },
   golang: {
     name: "Go",
-    icon: DotNetIcon,
+    icon: GoIcon,
   },
   dotnet: {
     name: ".NET",
-    icon: JavaIcon,
+    icon: DotNetIcon,
   },
 };
 


### PR DESCRIPTION
Silly mistake happened when combining separate `NAME_MAP` and `ICON_MAP` objects into a single `LANGUAGE_MAP`. Didn't realize the icons were pointing at the wrong assets 😅