### PR TITLE
fix(docgen): specifying a submodule results in an empty reference

### DIFF
--- a/src/__fixtures__/assemblies/constructs@10.0.0/jsii.json
+++ b/src/__fixtures__/assemblies/constructs@10.0.0/jsii.json
@@ -1,0 +1,1203 @@
+{
+  "author": {
+    "name": "Amazon Web Services",
+    "organization": true,
+    "roles": [
+      "author"
+    ],
+    "url": "https://aws.amazon.com"
+  },
+  "description": "A programming model for software-defined state",
+  "docs": {
+    "stability": "stable"
+  },
+  "homepage": "https://github.com/aws/constructs",
+  "jsiiVersion": "1.26.0 (build 7d76e02)",
+  "keywords": [
+    "aws",
+    "cdk",
+    "constructs",
+    "jsii"
+  ],
+  "license": "Apache-2.0",
+  "metadata": {
+    "jsii": {
+      "pacmak": {
+        "hasDefaultInterfaces": true
+      }
+    }
+  },
+  "name": "constructs",
+  "readme": {
+    "markdown": "# Constructs Programming Model\n\n> Software-defined state\n\n![Release](https://github.com/aws/constructs/workflows/Release/badge.svg)\n[![npm version](https://badge.fury.io/js/constructs.svg)](https://badge.fury.io/js/constructs)\n[![PyPI version](https://badge.fury.io/py/constructs.svg)](https://badge.fury.io/py/constructs)\n[![NuGet version](https://badge.fury.io/nu/Constructs.svg)](https://badge.fury.io/nu/Constructs)\n[![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.constructs/constructs/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/software.constructs/constructs)\n\n## What are constructs?\n\nConstructs are classes which define a \"piece of system state\". Constructs can be composed together to form higher-level building blocks which represent more complex state.\n\nConstructs are often used to represent the _desired state_ of cloud applications. For example, in the AWS CDK, which is used to define the desired state for AWS infrastructure using CloudFormation, the lowest-level construct represents a _resource definition_ in a CloudFormation template. These resources are composed to represent higher-level logical units of a cloud application, etc.\n\n## Contributing\n\nThis project has adopted the [Amazon Open Source Code of\nConduct](https://aws.github.io/code-of-conduct).\n\nWe welcome community contributions and pull requests. See our [contribution\nguide](./CONTRIBUTING.md) for more information on how to report issues, set up a\ndevelopment environment and submit code.\n\n## License\n\nThis project is distributed under the [Apache License, Version 2.0](./LICENSE).\n"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/constructs.git"
+  },
+  "schema": "jsii/0.10.0",
+  "targets": {
+    "dotnet": {
+      "namespace": "Constructs",
+      "packageId": "Constructs"
+    },
+    "go": {
+      "moduleName": "github.com/aws/constructs-go"
+    },
+    "java": {
+      "maven": {
+        "artifactId": "constructs",
+        "groupId": "software.constructs"
+      },
+      "package": "software.constructs"
+    },
+    "js": {
+      "npm": "constructs"
+    },
+    "python": {
+      "distName": "constructs",
+      "module": "constructs"
+    }
+  },
+  "types": {
+    "constructs.Construct": {
+      "assembly": "constructs",
+      "docs": {
+        "remarks": "All constructs besides the root construct must be created within the scope of\nanother construct.",
+        "stability": "stable",
+        "summary": "Represents the building block of the construct graph."
+      },
+      "fqn": "constructs.Construct",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Creates a new construct node."
+        },
+        "locationInModule": {
+          "filename": "src/construct.ts",
+          "line": 448
+        },
+        "parameters": [
+          {
+            "docs": {
+              "summary": "The scope in which to define this construct."
+            },
+            "name": "scope",
+            "type": {
+              "fqn": "constructs.Construct"
+            }
+          },
+          {
+            "docs": {
+              "remarks": "Must be unique amongst siblings. If\nthe ID includes a path separator (`/`), then it will be replaced by double\ndash `--`.",
+              "summary": "The scoped construct ID."
+            },
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          }
+        ]
+      },
+      "interfaces": [
+        "constructs.IConstruct"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/construct.ts",
+        "line": 422
+      },
+      "methods": [
+        {
+          "docs": {
+            "deprecated": "use `x instanceof Construct` instead",
+            "returns": "true if `x` is an object created from a class which extends `Construct`.",
+            "stability": "deprecated",
+            "summary": "Checks if `x` is a construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 430
+          },
+          "name": "isConstruct",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "Any object."
+              },
+              "name": "x",
+              "type": {
+                "primitive": "any"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns a string representation of this construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 460
+          },
+          "name": "toString",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "Construct",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The tree node."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 437
+          },
+          "name": "node",
+          "overrides": "constructs.IConstruct",
+          "type": {
+            "fqn": "constructs.Node"
+          }
+        }
+      ]
+    },
+    "constructs.ConstructOrder": {
+      "assembly": "constructs",
+      "docs": {
+        "stability": "stable",
+        "summary": "In what order to return constructs."
+      },
+      "fqn": "constructs.ConstructOrder",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "src/construct.ts",
+        "line": 483
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Depth-first, pre-order."
+          },
+          "name": "PREORDER"
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Depth-first, post-order (leaf nodes first)."
+          },
+          "name": "POSTORDER"
+        }
+      ],
+      "name": "ConstructOrder"
+    },
+    "constructs.Dependable": {
+      "abstract": true,
+      "assembly": "constructs",
+      "docs": {
+        "example": "// Usage\nconst roots = DependableTrait.get(construct).dependencyRoots;\n\n// Definition\nDependableTrait.implement(construct, {\n  get dependencyRoots() { return []; }\n});",
+        "remarks": "Traits are interfaces that are privately implemented by objects. Instead of\nshowing up in the public interface of a class, they need to be queried\nexplicitly. This is used to implement certain framework features that are\nnot intended to be used by Construct consumers, and so should be hidden\nfrom accidental use.",
+        "stability": "experimental",
+        "summary": "Trait for IDependable."
+      },
+      "fqn": "constructs.Dependable",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/dependency.ts",
+        "line": 76
+      },
+      "methods": [
+        {
+          "docs": {
+            "deprecated": "use `of`",
+            "stability": "deprecated",
+            "summary": "Return the matching Dependable for the given class instance."
+          },
+          "locationInModule": {
+            "filename": "src/dependency.ts",
+            "line": 102
+          },
+          "name": "get",
+          "parameters": [
+            {
+              "name": "instance",
+              "type": {
+                "fqn": "constructs.IDependable"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "fqn": "constructs.Dependable"
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "Turn any object into an IDependable."
+          },
+          "locationInModule": {
+            "filename": "src/dependency.ts",
+            "line": 80
+          },
+          "name": "implement",
+          "parameters": [
+            {
+              "name": "instance",
+              "type": {
+                "fqn": "constructs.IDependable"
+              }
+            },
+            {
+              "name": "trait",
+              "type": {
+                "fqn": "constructs.Dependable"
+              }
+            }
+          ],
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "Return the matching Dependable for the given class instance."
+          },
+          "locationInModule": {
+            "filename": "src/dependency.ts",
+            "line": 90
+          },
+          "name": "of",
+          "parameters": [
+            {
+              "name": "instance",
+              "type": {
+                "fqn": "constructs.IDependable"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "fqn": "constructs.Dependable"
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "Dependable",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "remarks": "All resources under all returned constructs are included in the ordering\ndependency.",
+            "stability": "experimental",
+            "summary": "The set of constructs that form the root of this dependable."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/dependency.ts",
+            "line": 112
+          },
+          "name": "dependencyRoots",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "constructs.IConstruct"
+              },
+              "kind": "array"
+            }
+          }
+        }
+      ]
+    },
+    "constructs.DependencyGroup": {
+      "assembly": "constructs",
+      "docs": {
+        "remarks": "This class can be used when a set of constructs which are disjoint in the\nconstruct tree needs to be combined to be used as a single dependable.",
+        "stability": "experimental",
+        "summary": "A set of constructs to be used as a dependable."
+      },
+      "fqn": "constructs.DependencyGroup",
+      "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
+        "locationInModule": {
+          "filename": "src/dependency.ts",
+          "line": 29
+        },
+        "parameters": [
+          {
+            "name": "deps",
+            "type": {
+              "fqn": "constructs.IDependable"
+            },
+            "variadic": true
+          }
+        ],
+        "variadic": true
+      },
+      "interfaces": [
+        "constructs.IDependable"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/dependency.ts",
+        "line": 26
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "Add a construct to the dependency roots."
+          },
+          "locationInModule": {
+            "filename": "src/dependency.ts",
+            "line": 48
+          },
+          "name": "add",
+          "parameters": [
+            {
+              "name": "scopes",
+              "type": {
+                "fqn": "constructs.IDependable"
+              },
+              "variadic": true
+            }
+          ],
+          "variadic": true
+        }
+      ],
+      "name": "DependencyGroup"
+    },
+    "constructs.IConstruct": {
+      "assembly": "constructs",
+      "docs": {
+        "stability": "stable",
+        "summary": "Represents a construct."
+      },
+      "fqn": "constructs.IConstruct",
+      "interfaces": [
+        "constructs.IDependable"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/construct.ts",
+        "line": 9
+      },
+      "name": "IConstruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The tree node."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 13
+          },
+          "name": "node",
+          "type": {
+            "fqn": "constructs.Node"
+          }
+        }
+      ]
+    },
+    "constructs.IDependable": {
+      "assembly": "constructs",
+      "docs": {
+        "remarks": "The presence of this interface indicates that an object has\nan `IDependableTrait` implementation.\n\nThis interface can be used to take an (ordering) dependency on a set of\nconstructs. An ordering dependency implies that the resources represented by\nthose constructs are deployed before the resources depending ON them are\ndeployed.",
+        "stability": "stable",
+        "summary": "Trait marker for classes that can be depended upon."
+      },
+      "fqn": "constructs.IDependable",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/dependency.ts",
+        "line": 14
+      },
+      "name": "IDependable"
+    },
+    "constructs.IValidation": {
+      "assembly": "constructs",
+      "docs": {
+        "remarks": "Implement this interface in order for the construct to be able to validate itself.",
+        "stability": "stable",
+        "summary": "Implement this interface in order for the construct to be able to validate itself."
+      },
+      "fqn": "constructs.IValidation",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/construct.ts",
+        "line": 468
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "remarks": "This method can be implemented by derived constructs in order to perform\nvalidation logic. It is called on all constructs before synthesis.\nValidate the current construct.\n\nThis method can be implemented by derived constructs in order to perform\nvalidation logic. It is called on all constructs before synthesis.",
+            "returns": "An array of validation error messages, or an empty array if there the construct is valid.",
+            "stability": "stable",
+            "summary": "Validate the current construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 477
+          },
+          "name": "validate",
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "array"
+              }
+            }
+          }
+        }
+      ],
+      "name": "IValidation"
+    },
+    "constructs.MetadataEntry": {
+      "assembly": "constructs",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "An entry in the construct metadata table."
+      },
+      "fqn": "constructs.MetadataEntry",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/metadata.ts",
+        "line": 4
+      },
+      "name": "MetadataEntry",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The data."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/metadata.ts",
+            "line": 13
+          },
+          "name": "data",
+          "type": {
+            "primitive": "any"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The metadata entry type."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/metadata.ts",
+            "line": 8
+          },
+          "name": "type",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- no trace information",
+            "remarks": "Only available if `addMetadata()` is called with `stackTrace: true`.",
+            "stability": "stable",
+            "summary": "Stack trace at the point of adding the metadata."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/metadata.ts",
+            "line": 22
+          },
+          "name": "trace",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "array"
+            }
+          }
+        }
+      ]
+    },
+    "constructs.MetadataOptions": {
+      "assembly": "constructs",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Options for `construct.addMetadata()`."
+      },
+      "fqn": "constructs.MetadataOptions",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/construct.ts",
+        "line": 523
+      },
+      "name": "MetadataOptions",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "stability": "stable",
+            "summary": "Include stack trace with metadata entry."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 528
+          },
+          "name": "stackTrace",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "addMetadata()",
+            "remarks": "This option is ignored unless `stackTrace` is `true`.",
+            "stability": "stable",
+            "summary": "A JavaScript function to begin tracing from."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 537
+          },
+          "name": "traceFromFunction",
+          "optional": true,
+          "type": {
+            "primitive": "any"
+          }
+        }
+      ]
+    },
+    "constructs.Node": {
+      "assembly": "constructs",
+      "docs": {
+        "stability": "stable",
+        "summary": "Represents the construct node in the scope tree."
+      },
+      "fqn": "constructs.Node",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/construct.ts",
+          "line": 58
+        },
+        "parameters": [
+          {
+            "name": "host",
+            "type": {
+              "fqn": "constructs.Construct"
+            }
+          },
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "constructs.IConstruct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/construct.ts",
+        "line": 19
+      },
+      "methods": [
+        {
+          "docs": {
+            "deprecated": "use `construct.node` instead",
+            "stability": "deprecated",
+            "summary": "Returns the node associated with a construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 31
+          },
+          "name": "of",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "the construct."
+              },
+              "name": "construct",
+              "type": {
+                "fqn": "constructs.IConstruct"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "fqn": "constructs.Node"
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "remarks": "An `IDependable`",
+            "stability": "stable",
+            "summary": "Add an ordering dependency on another construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 303
+          },
+          "name": "addDependency",
+          "parameters": [
+            {
+              "name": "deps",
+              "type": {
+                "fqn": "constructs.IDependable"
+              },
+              "variadic": true
+            }
+          ],
+          "variadic": true
+        },
+        {
+          "docs": {
+            "remarks": "Entries are arbitrary values and will also include a stack trace to allow tracing back to\nthe code location for when the entry was added. It can be used, for example, to include source\nmapping in CloudFormation templates to improve diagnostics.",
+            "stability": "stable",
+            "summary": "Adds a metadata entry to this construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 245
+          },
+          "name": "addMetadata",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "a string denoting the type of metadata."
+              },
+              "name": "type",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "docs": {
+                "remarks": "If null/undefined, metadata will not be added.",
+                "summary": "the value of the metadata (can be a Token)."
+              },
+              "name": "data",
+              "type": {
+                "primitive": "any"
+              }
+            },
+            {
+              "docs": {
+                "summary": "options."
+              },
+              "name": "options",
+              "optional": true,
+              "type": {
+                "fqn": "constructs.MetadataOptions"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "remarks": "When `node.validate()` is called, the `validate()` method will be called on\nall validations and all errors will be returned.",
+            "stability": "stable",
+            "summary": "Adds a validation to this construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 343
+          },
+          "name": "addValidation",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The validation object."
+              },
+              "name": "validation",
+              "type": {
+                "fqn": "constructs.IValidation"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Return this construct and all of its children in the given order."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 177
+          },
+          "name": "findAll",
+          "parameters": [
+            {
+              "name": "order",
+              "optional": true,
+              "type": {
+                "fqn": "constructs.ConstructOrder"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "fqn": "constructs.IConstruct"
+                },
+                "kind": "array"
+              }
+            }
+          }
+        },
+        {
+          "docs": {
+            "remarks": "Throws an error if the child is not found.",
+            "returns": "Child with the given id.",
+            "stability": "stable",
+            "summary": "Return a direct child by id."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 123
+          },
+          "name": "findChild",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "Identifier of direct child."
+              },
+              "name": "id",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "fqn": "constructs.IConstruct"
+            }
+          }
+        },
+        {
+          "docs": {
+            "remarks": "After this\ncall, no more children can be added to this construct or to any children.",
+            "stability": "stable",
+            "summary": "Locks this construct from allowing more children to be added."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 376
+          },
+          "name": "lock"
+        },
+        {
+          "docs": {
+            "remarks": "Context must be set before any children are added, since children may consult context info during construction.\nIf the key already exists, it will be overridden.",
+            "stability": "stable",
+            "summary": "This can be used to set contextual values."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 204
+          },
+          "name": "setContext",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The context key."
+              },
+              "name": "key",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "docs": {
+                "summary": "The context value."
+              },
+              "name": "value",
+              "type": {
+                "primitive": "any"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "returns": "the child if found, or undefined",
+            "stability": "stable",
+            "summary": "Return a direct child by id, or undefined."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 111
+          },
+          "name": "tryFindChild",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "Identifier of direct child."
+              },
+              "name": "id",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "optional": true,
+            "type": {
+              "fqn": "constructs.IConstruct"
+            }
+          }
+        },
+        {
+          "docs": {
+            "remarks": "Context is usually initialized at the root, but can be overridden at any point in the tree.",
+            "returns": "The context value or `undefined` if there is no context value for thie key.",
+            "stability": "stable",
+            "summary": "Retrieves a value from tree context."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 220
+          },
+          "name": "tryGetContext",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The context key."
+              },
+              "name": "key",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "any"
+            }
+          }
+        },
+        {
+          "docs": {
+            "returns": "Whether a child with the given name was deleted.",
+            "stability": "experimental",
+            "summary": "Remove the child with the given name, if present."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 329
+          },
+          "name": "tryRemoveChild",
+          "parameters": [
+            {
+              "name": "childName",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          }
+        },
+        {
+          "docs": {
+            "remarks": "Invokes the `validate()` method on all validations added through\n`addValidation()`.",
+            "returns": "an array of validation error messages associated with this\nconstruct.",
+            "stability": "stable",
+            "summary": "Validates this construct."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 356
+          },
+          "name": "validate",
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "array"
+              }
+            }
+          }
+        }
+      ],
+      "name": "Node",
+      "properties": [
+        {
+          "const": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Separator used to delimit construct path components."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 23
+          },
+          "name": "PATH_SEP",
+          "static": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "docs": {
+            "example": "c83a2846e506bcc5f10682b564084bca2d275709ee",
+            "remarks": "Addresses are 42 characters hexadecimal strings. They begin with \"c8\"\nfollowed by 40 lowercase hexadecimal characters (0-9a-f).\n\nAddresses are calculated using a SHA-1 of the components of the construct\npath.\n\nTo enable refactorings of construct trees, constructs with the ID `Default`\nwill be excluded from the calculation. In those cases constructs in the\nsame tree may have the same addreess.",
+            "stability": "stable",
+            "summary": "Returns an opaque tree-unique address for this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 97
+          },
+          "name": "addr",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "All direct children of this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 170
+          },
+          "name": "children",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "constructs.IConstruct"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Return all dependencies registered on this node (non-recursive)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 312
+          },
+          "name": "dependencies",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "constructs.IConstruct"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "remarks": "This is a a scope-unique id. To obtain an app-unique id for this construct, use `uniqueId`.",
+            "stability": "stable",
+            "summary": "The id of this construct within the current scope."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 47
+          },
+          "name": "id",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns true if this construct or the scopes in which it is defined are locked."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 286
+          },
+          "name": "locked",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "docs": {
+            "remarks": "This can be used, for example, to implement support for deprecation notices, source mapping, etc.",
+            "stability": "stable",
+            "summary": "An immutable array of metadata objects associated with this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 231
+          },
+          "name": "metadata",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "constructs.MetadataEntry"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "remarks": "Components are separated by '/'.",
+            "stability": "stable",
+            "summary": "The full, absolute path of this construct in the tree."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 77
+          },
+          "name": "path",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "docs": {
+            "returns": "The root of the construct tree.",
+            "stability": "stable",
+            "summary": "Returns the root of the construct tree."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 278
+          },
+          "name": "root",
+          "type": {
+            "fqn": "constructs.IConstruct"
+          }
+        },
+        {
+          "docs": {
+            "returns": "a list of parent scopes. The last element in the list will always\nbe the current construct and the first element will be the root of the\ntree.",
+            "stability": "stable",
+            "summary": "All parent scopes of this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 262
+          },
+          "name": "scopes",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "constructs.IConstruct"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "remarks": "The value is `undefined` at the root of the construct scope tree.",
+            "stability": "stable",
+            "summary": "Returns the scope in which this construct is defined."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 40
+          },
+          "name": "scope",
+          "optional": true,
+          "type": {
+            "fqn": "constructs.IConstruct"
+          }
+        },
+        {
+          "docs": {
+            "custom": {
+              "throws": "if there is more than one child"
+            },
+            "remarks": "This is usually the construct that provides the bulk of the underlying functionality.\nUseful for modifications of the underlying construct that are not available at the higher levels.\nOverride the defaultChild property.\n\nThis should only be used in the cases where the correct\ndefault child is not named 'Resource' or 'Default' as it\nshould be.\n\nIf you set this to undefined, the default behavior of finding\nthe child named 'Resource' or 'Default' will be used.",
+            "returns": "a construct or undefined if there is no default child",
+            "stability": "stable",
+            "summary": "Returns the child construct that has the id `Default` or `Resource\"`."
+          },
+          "locationInModule": {
+            "filename": "src/construct.ts",
+            "line": 139
+          },
+          "name": "defaultChild",
+          "optional": true,
+          "type": {
+            "fqn": "constructs.IConstruct"
+          }
+        }
+      ]
+    }
+  },
+  "version": "10.0.0",
+  "fingerprint": "KVn01hdoTaKTKgUg6Va2HeSxXYW7h1QIRkumGnzjVzs="
+}

--- a/src/api/docgen/transpile/transpile.ts
+++ b/src/api/docgen/transpile/transpile.ts
@@ -500,10 +500,11 @@ export abstract class TranspileBase implements Transpile {
 
     const fqn = [moduleLike.name];
 
+    // TODO - these should also probably be transliterated.
+    // for python it just happens to work
     if (type.namespace) {
       fqn.push(type.namespace);
     }
-
     fqn.push(type.name);
 
     return {

--- a/src/api/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/src/api/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`python snapshot 1`] = `
+exports[`python snapshot - root module 1`] = `
 "# Amazon ECR Construct Library
 <!--BEGIN STABILITY BANNER-->
 
@@ -2563,6 +2563,10054 @@ Rule applies to tagged images.
 #### \`UNTAGGED\` <span data-heading-title=\\"\`UNTAGGED\`\\" data-heading-id=\\"awscdkawsecrtagstatusuntagged\\"></span>
 
 Rule applies to untagged images.
+
+---
+
+"
+`;
+
+exports[`python snapshot - submodules 1`] = `
+"# Amazon EKS Construct Library
+<!--BEGIN STABILITY BANNER-->
+
+---
+
+![cfn-resources: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
+
+![cdk-constructs: Stable](https://img.shields.io/badge/cdk--constructs-stable-success.svg?style=for-the-badge)
+
+---
+
+<!--END STABILITY BANNER-->
+
+This construct library allows you to define [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com/eks/) clusters.
+In addition, the library also supports defining Kubernetes resource manifests within EKS clusters.
+
+## Table Of Contents
+
+* [Quick Start](#quick-start)
+* [API Reference](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-eks-readme.html)
+* [Architectural Overview](#architectural-overview)
+* [Provisioning clusters](#provisioning-clusters)
+  * [Managed node groups](#managed-node-groups)
+  * [Fargate Profiles](#fargate-profiles)
+  * [Self-managed nodes](#self-managed-nodes)
+  * [Endpoint Access](#endpoint-access)
+  * [VPC Support](#vpc-support)
+  * [Kubectl Support](#kubectl-support)
+  * [ARM64 Support](#arm64-support)
+  * [Masters Role](#masters-role)
+  * [Encryption](#encryption)
+* [Permissions and Security](#permissions-and-security)
+* [Applying Kubernetes Resources](#applying-kubernetes-resources)
+  * [Kubernetes Manifests](#kubernetes-manifests)
+  * [Helm Charts](#helm-charts)
+  * [CDK8s Charts](#cdk8s-charts)
+* [Patching Kubernetes Resources](#patching-kubernetes-resources)
+* [Querying Kubernetes Resources](#querying-kubernetes-resources)
+* [Using existing clusters](#using-existing-clusters)
+* [Known Issues and Limitations](#known-issues-and-limitations)
+
+## Quick Start
+
+This example defines an Amazon EKS cluster with the following configuration:
+
+* Dedicated VPC with default configuration (Implicitly created using [ec2.Vpc](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-ec2-readme.html#vpc))
+* A Kubernetes pod with a container based on the [paulbouwer/hello-kubernetes](https://github.com/paulbouwer/hello-kubernetes) image.
+
+\`\`\`ts
+// provisiong a cluster
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+});
+
+// apply a kubernetes manifest to the cluster
+cluster.addManifest('mypod', {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name: 'mypod' },
+  spec: {
+    containers: [
+      {
+        name: 'hello',
+        image: 'paulbouwer/hello-kubernetes:1.5',
+        ports: [ { containerPort: 8080 } ]
+      }
+    ]
+  }
+});
+\`\`\`
+
+In order to interact with your cluster through \`kubectl\`, you can use the \`aws eks update-kubeconfig\` [AWS CLI command](https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html)
+to configure your local kubeconfig. The EKS module will define a CloudFormation output in your stack which contains the command to run. For example:
+
+\`\`\`plaintext
+Outputs:
+ClusterConfigCommand43AAE40F = aws eks update-kubeconfig --name cluster-xxxxx --role-arn arn:aws:iam::112233445566:role/yyyyy
+\`\`\`
+
+Execute the \`aws eks update-kubeconfig ...\` command in your terminal to create or update a local kubeconfig context:
+
+\`\`\`console
+$ aws eks update-kubeconfig --name cluster-xxxxx --role-arn arn:aws:iam::112233445566:role/yyyyy
+Added new context arn:aws:eks:rrrrr:112233445566:cluster/cluster-xxxxx to /home/boom/.kube/config
+\`\`\`
+
+And now you can simply use \`kubectl\`:
+
+\`\`\`console
+$ kubectl get all -n kube-system
+NAME                           READY   STATUS    RESTARTS   AGE
+pod/aws-node-fpmwv             1/1     Running   0          21m
+pod/aws-node-m9htf             1/1     Running   0          21m
+pod/coredns-5cb4fb54c7-q222j   1/1     Running   0          23m
+pod/coredns-5cb4fb54c7-v9nxx   1/1     Running   0          23m
+...
+\`\`\`
+
+## Architectural Overview
+
+The following is a qualitative diagram of the various possible components involved in the cluster deployment.
+
+\`\`\`text
+ +-----------------------------------------------+               +-----------------+
+ |                 EKS Cluster                   |    kubectl    |                 |
+ |-----------------------------------------------|<-------------+| Kubectl Handler |
+ |                                               |               |                 |
+ |                                               |               +-----------------+
+ | +--------------------+    +-----------------+ |
+ | |                    |    |                 | |
+ | | Managed Node Group |    | Fargate Profile | |               +-----------------+
+ | |                    |    |                 | |               |                 |
+ | +--------------------+    +-----------------+ |               | Cluster Handler |
+ |                                               |               |                 |
+ +-----------------------------------------------+               +-----------------+
+    ^                                   ^                          +
+    |                                   |                          |
+    | connect self managed capacity     |                          | aws-sdk
+    |                                   | create/update/delete     |
+    +                                   |                          v
+ +--------------------+                 +              +-------------------+
+ |                    |                 --------------+| eks.amazonaws.com |
+ | Auto Scaling Group |                                +-------------------+
+ |                    |
+ +--------------------+
+\`\`\`
+
+In a nutshell:
+
+* \`EKS Cluster\` - The cluster endpoint created by EKS.
+* \`Managed Node Group\` - EC2 worker nodes managed by EKS.
+* \`Fargate Profile\` - Fargate worker nodes managed by EKS.
+* \`Auto Scaling Group\` - EC2 worker nodes managed by the user.
+* \`KubectlHandler\` - Lambda function for invoking \`kubectl\` commands on the cluster - created by CDK.
+* \`ClusterHandler\` - Lambda function for interacting with EKS API to manage the cluster lifecycle - created by CDK.
+
+A more detailed breakdown of each is provided further down this README.
+
+## Provisioning clusters
+
+Creating a new cluster is done using the \`Cluster\` or \`FargateCluster\` constructs. The only required property is the kubernetes \`version\`.
+
+\`\`\`ts
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+});
+\`\`\`
+
+You can also use \`FargateCluster\` to provision a cluster that uses only fargate workers.
+
+\`\`\`ts
+new eks.FargateCluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+});
+\`\`\`
+
+> **NOTE: Only 1 cluster per stack is supported.** If you have a use-case for multiple clusters per stack, or would like to understand more about this limitation, see <https://github.com/aws/aws-cdk/issues/10073>.
+
+Below you'll find a few important cluster configuration options. First of which is Capacity.
+Capacity is the amount and the type of worker nodes that are available to the cluster for deploying resources. Amazon EKS offers 3 ways of configuring capacity, which you can combine as you like:
+
+### Managed node groups
+
+Amazon EKS managed node groups automate the provisioning and lifecycle management of nodes (Amazon EC2 instances) for Amazon EKS Kubernetes clusters.
+With Amazon EKS managed node groups, you don’t need to separately provision or register the Amazon EC2 instances that provide compute capacity to run your Kubernetes applications. You can create, update, or terminate nodes for your cluster with a single operation. Nodes run using the latest Amazon EKS optimized AMIs in your AWS account while node updates and terminations gracefully drain nodes to ensure that your applications stay available.
+
+> For more details visit [Amazon EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html).
+
+**Managed Node Groups are the recommended way to allocate cluster capacity.**
+
+By default, this library will allocate a managed node group with 2 *m5.large* instances (this instance type suits most common use-cases, and is good value for money).
+
+At cluster instantiation time, you can customize the number of instances and their type:
+
+\`\`\`ts
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  defaultCapacity: 5,
+  defaultCapacityInstance: ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.SMALL),
+});
+\`\`\`
+
+To access the node group that was created on your behalf, you can use \`cluster.defaultNodegroup\`.
+
+Additional customizations are available post instantiation. To apply them, set the default capacity to 0, and use the \`cluster.addNodegroupCapacity\` method:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  defaultCapacity: 0,
+});
+
+cluster.addNodegroupCapacity('custom-node-group', {
+  instanceTypes: [new ec2.InstanceType('m5.large')],
+  minSize: 4,
+  diskSize: 100,
+  amiType: eks.NodegroupAmiType.AL2_X86_64_GPU,
+  ...
+});
+\`\`\`
+
+#### Spot Instances Support
+
+Use \`capacityType\` to create managed node groups comprised of spot instances. To maximize the availability of your applications while using
+Spot Instances, we recommend that you configure a Spot managed node group to use multiple instance types with the \`instanceTypes\` property.
+
+> For more details visit [Managed node group capacity types](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types).
+
+
+\`\`\`ts
+cluster.addNodegroupCapacity('extra-ng-spot', {
+  instanceTypes: [
+    new ec2.InstanceType('c5.large'),
+    new ec2.InstanceType('c5a.large'),
+    new ec2.InstanceType('c5d.large'),
+  ],
+  minSize: 3,
+  capacityType: eks.CapacityType.SPOT,
+});
+
+\`\`\`
+
+#### Launch Template Support
+
+You can specify a launch template that the node group will use. For example, this can be useful if you want to use
+a custom AMI or add custom user data.
+
+When supplying a custom user data script, it must be encoded in the MIME multi-part archive format, since Amazon EKS merges with its own user data. Visit the [Launch Template Docs](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data)
+for mode details.
+
+\`\`\`ts
+const userData = \`MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary=\\"==MYBOUNDARY==\\"
+
+--==MYBOUNDARY==
+Content-Type: text/x-shellscript; charset=\\"us-ascii\\"
+
+#!/bin/bash
+echo \\"Running custom user data script\\"
+
+--==MYBOUNDARY==--\\\\\\\\
+\`;
+const lt = new ec2.CfnLaunchTemplate(this, 'LaunchTemplate', {
+  launchTemplateData: {
+    instanceType: 't3.small',
+    userData: Fn.base64(userData),
+  },
+});
+cluster.addNodegroupCapacity('extra-ng', {
+  launchTemplateSpec: {
+    id: lt.ref,
+    version: lt.attrLatestVersionNumber,
+  },
+});
+
+\`\`\`
+
+Note that when using a custom AMI, Amazon EKS doesn't merge any user data. Which means you do not need the multi-part encoding. and are responsible for supplying the required bootstrap commands for nodes to join the cluster.
+In the following example, \`/ect/eks/bootstrap.sh\` from the AMI will be used to bootstrap the node.
+
+\`\`\`ts
+const userData = ec2.UserData.forLinux();
+userData.addCommands(
+  'set -o xtrace',
+  \`/etc/eks/bootstrap.sh \${cluster.clusterName}\`,
+);
+const lt = new ec2.CfnLaunchTemplate(this, 'LaunchTemplate', {
+  launchTemplateData: {
+    imageId: 'some-ami-id', // custom AMI
+    instanceType: 't3.small',
+    userData: Fn.base64(userData.render()),
+  },
+});
+cluster.addNodegroupCapacity('extra-ng', {
+  launchTemplateSpec: {
+    id: lt.ref,
+    version: lt.attrLatestVersionNumber,
+  },
+});
+\`\`\`
+
+You may specify one \`instanceType\` in the launch template or multiple \`instanceTypes\` in the node group, **but not both**.
+
+> For more details visit [Launch Template Support](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).
+
+Graviton 2 instance types are supported including \`c6g\`, \`m6g\`, \`r6g\` and \`t4g\`.
+
+### Fargate profiles
+
+AWS Fargate is a technology that provides on-demand, right-sized compute
+capacity for containers. With AWS Fargate, you no longer have to provision,
+configure, or scale groups of virtual machines to run containers. This removes
+the need to choose server types, decide when to scale your node groups, or
+optimize cluster packing.
+
+You can control which pods start on Fargate and how they run with Fargate
+Profiles, which are defined as part of your Amazon EKS cluster.
+
+See [Fargate Considerations](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations) in the AWS EKS User Guide.
+
+You can add Fargate Profiles to any EKS cluster defined in your CDK app
+through the \`addFargateProfile()\` method. The following example adds a profile
+that will match all pods from the \\"default\\" namespace:
+
+\`\`\`ts
+cluster.addFargateProfile('MyProfile', {
+  selectors: [ { namespace: 'default' } ]
+});
+\`\`\`
+
+You can also directly use the \`FargateProfile\` construct to create profiles under different scopes:
+
+\`\`\`ts
+new eks.FargateProfile(scope, 'MyProfile', {
+  cluster,
+  ...
+});
+\`\`\`
+
+To create an EKS cluster that **only** uses Fargate capacity, you can use \`FargateCluster\`.
+The following code defines an Amazon EKS cluster with a default Fargate Profile that matches all pods from the \\"kube-system\\" and \\"default\\" namespaces. It is also configured to [run CoreDNS on Fargate](https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html#fargate-gs-coredns).
+
+\`\`\`ts
+const cluster = new eks.FargateCluster(this, 'MyCluster', {
+  version: eks.KubernetesVersion.V1_19,
+});
+\`\`\`
+
+**NOTE**: Classic Load Balancers and Network Load Balancers are not supported on
+pods running on Fargate. For ingress, we recommend that you use the [ALB Ingress
+Controller](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html)
+on Amazon EKS (minimum version v1.1.4).
+
+### Self-managed nodes
+
+Another way of allocating capacity to an EKS cluster is by using self-managed nodes.
+EC2 instances that are part of the auto-scaling group will serve as worker nodes for the cluster.
+This type of capacity is also commonly referred to as *EC2 Capacity** or *EC2 Nodes*.
+
+For a detailed overview please visit [Self Managed Nodes](https://docs.aws.amazon.com/eks/latest/userguide/worker.html).
+
+Creating an auto-scaling group and connecting it to the cluster is done using the \`cluster.addAutoScalingGroupCapacity\` method:
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('frontend-nodes', {
+  instanceType: new ec2.InstanceType('t2.medium'),
+  minCapacity: 3,
+  vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC }
+});
+\`\`\`
+
+To connect an already initialized auto-scaling group, use the \`cluster.connectAutoScalingGroupCapacity()\` method:
+
+\`\`\`ts
+const asg = new ec2.AutoScalingGroup(...);
+cluster.connectAutoScalingGroupCapacity(asg);
+\`\`\`
+
+In both cases, the [cluster security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#cluster-sg) will be automatically attached to
+the auto-scaling group, allowing for traffic to flow freely between managed and self-managed nodes.
+
+> **Note:** The default \`updateType\` for auto-scaling groups does not replace existing nodes. Since security groups are determined at launch time, self-managed nodes that were provisioned with version \`1.78.0\` or lower, will not be updated.
+> To apply the new configuration on all your self-managed nodes, you'll need to replace the nodes using the \`UpdateType.REPLACING_UPDATE\` policy for the [\`updateType\`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-autoscaling.AutoScalingGroup.html#updatetypespan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan) property.
+
+You can customize the [/etc/eks/boostrap.sh](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh) script, which is responsible
+for bootstrapping the node to the EKS cluster. For example, you can use \`kubeletExtraArgs\` to add custom node labels or taints.
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('spot', {
+  instanceType: new ec2.InstanceType('t3.large'),
+  minCapacity: 2,
+  bootstrapOptions: {
+    kubeletExtraArgs: '--node-labels foo=bar,goo=far',
+    awsApiRetryAttempts: 5
+  }
+});
+\`\`\`
+
+To disable bootstrapping altogether (i.e. to fully customize user-data), set \`bootstrapEnabled\` to \`false\`.
+You can also configure the cluster to use an auto-scaling group as the default capacity:
+
+\`\`\`ts
+cluster = new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  defaultCapacityType: eks.DefaultCapacityType.EC2,
+});
+\`\`\`
+
+This will allocate an auto-scaling group with 2 *m5.large* instances (this instance type suits most common use-cases, and is good value for money).
+To access the \`AutoScalingGroup\` that was created on your behalf, you can use \`cluster.defaultCapacity\`.
+You can also independently create an \`AutoScalingGroup\` and connect it to the cluster using the \`cluster.connectAutoScalingGroupCapacity\` method:
+
+\`\`\`ts
+const asg = new ec2.AutoScalingGroup(...)
+cluster.connectAutoScalingGroupCapacity(asg);
+\`\`\`
+
+This will add the necessary user-data to access the apiserver and configure all connections, roles, and tags needed for the instances in the auto-scaling group to properly join the cluster.
+
+#### Spot Instances
+
+When using self-managed nodes, you can configure the capacity to use spot instances, greatly reducing capacity cost.
+To enable spot capacity, use the \`spotPrice\` property:
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('spot', {
+  spotPrice: '0.1094',
+  instanceType: new ec2.InstanceType('t3.large'),
+  maxCapacity: 10
+});
+\`\`\`
+
+> Spot instance nodes will be labeled with \`lifecycle=Ec2Spot\` and tainted with \`PreferNoSchedule\`.
+
+The [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) \`DaemonSet\` will be
+installed from [Amazon EKS Helm chart repository](https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler) on these nodes.
+The termination handler ensures that the Kubernetes control plane responds appropriately to events that
+can cause your EC2 instance to become unavailable, such as [EC2 maintenance events](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instances-status-check_sched.html)
+and [EC2 Spot interruptions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html) and helps gracefully stop all pods running on spot nodes that are about to be
+terminated.
+
+> Handler Version: [1.7.0](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.7.0)
+>
+> Chart Version: [0.9.5](https://github.com/aws/eks-charts/blob/v0.0.28/stable/aws-node-termination-handler/Chart.yaml)
+
+To disable the installation of the termination handler, set the \`spotInterruptHandler\` property to \`false\`. This applies both to \`addAutoScalingGroupCapacity\` and \`connectAutoScalingGroupCapacity\`.
+
+#### Bottlerocket
+
+[Bottlerocket](https://aws.amazon.com/bottlerocket/) is a Linux-based open-source operating system that is purpose-built by Amazon Web Services for running containers on virtual machines or bare metal hosts.
+At this moment, \`Bottlerocket\` is only supported when using self-managed auto-scaling groups.
+
+> **NOTICE**: Bottlerocket is only available in [some supported AWS regions](https://github.com/bottlerocket-os/bottlerocket/blob/develop/QUICKSTART-EKS.md#finding-an-ami).
+
+The following example will create an auto-scaling group of 2 \`t3.small\` Linux instances running with the \`Bottlerocket\` AMI.
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('BottlerocketNodes', {
+  instanceType: new ec2.InstanceType('t3.small'),
+  minCapacity:  2,
+  machineImageType: eks.MachineImageType.BOTTLEROCKET
+});
+\`\`\`
+
+The specific Bottlerocket AMI variant will be auto selected according to the k8s version for the \`x86_64\` architecture.
+For example, if the Amazon EKS cluster version is \`1.17\`, the Bottlerocket AMI variant will be auto selected as
+\`aws-k8s-1.17\` behind the scene.
+
+> See [Variants](https://github.com/bottlerocket-os/bottlerocket/blob/develop/README.md#variants) for more details.
+
+Please note Bottlerocket does not allow to customize bootstrap options and \`bootstrapOptions\` properties is not supported when you create the \`Bottlerocket\` capacity.
+
+### Endpoint Access
+
+When you create a new cluster, Amazon EKS creates an endpoint for the managed Kubernetes API server that you use to communicate with your cluster (using Kubernetes management tools such as \`kubectl\`)
+
+By default, this API server endpoint is public to the internet, and access to the API server is secured using a combination of
+AWS Identity and Access Management (IAM) and native Kubernetes [Role Based Access Control](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) (RBAC).
+
+You can configure the [cluster endpoint access](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html) by using the \`endpointAccess\` property:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+  endpointAccess: eks.EndpointAccess.PRIVATE // No access outside of your VPC.
+});
+\`\`\`
+
+The default value is \`eks.EndpointAccess.PUBLIC_AND_PRIVATE\`. Which means the cluster endpoint is accessible from outside of your VPC, but worker node traffic and \`kubectl\` commands issued by this library stay within your VPC.
+
+### VPC Support
+
+You can specify the VPC of the cluster using the \`vpc\` and \`vpcSubnets\` properties:
+
+\`\`\`ts
+const vpc = new ec2.Vpc(this, 'Vpc');
+
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  vpc,
+  vpcSubnets: [{ subnetType: ec2.SubnetType.PRIVATE }]
+});
+\`\`\`
+
+> Note: Isolated VPCs (i.e with no internet access) are not currently supported. See https://github.com/aws/aws-cdk/issues/12171
+
+If you do not specify a VPC, one will be created on your behalf, which you can then access via \`cluster.vpc\`. The cluster VPC will be associated to any EKS managed capacity (i.e Managed Node Groups and Fargate Profiles).
+
+If you allocate self managed capacity, you can specify which subnets should the auto-scaling group use:
+
+\`\`\`ts
+const vpc = new ec2.Vpc(this, 'Vpc');
+cluster.addAutoScalingGroupCapacity('nodes', {
+  vpcSubnets: { subnets: vpc.privateSubnets }
+});
+\`\`\`
+
+There are two additional components you might want to provision within the VPC.
+
+#### Kubectl Handler
+
+The \`KubectlHandler\` is a Lambda function responsible to issuing \`kubectl\` and \`helm\` commands against the cluster when you add resource manifests to the cluster.
+
+The handler association to the VPC is derived from the \`endpointAccess\` configuration. The rule of thumb is: *If the cluster VPC can be associated, it will be*.
+
+Breaking this down, it means that if the endpoint exposes private access (via \`EndpointAccess.PRIVATE\` or \`EndpointAccess.PUBLIC_AND_PRIVATE\`), and the VPC contains **private** subnets, the Lambda function will be provisioned inside the VPC and use the private subnets to interact with the cluster. This is the common use-case.
+
+If the endpoint does not expose private access (via \`EndpointAccess.PUBLIC\`) **or** the VPC does not contain private subnets, the function will not be provisioned within the VPC.
+
+#### Cluster Handler
+
+The \`ClusterHandler\` is a Lambda function responsible to interact with the EKS API in order to control the cluster lifecycle. To provision this function inside the VPC, set the \`placeClusterHandlerInVpc\` property to \`true\`. This will place the function inside the private subnets of the VPC based on the selection strategy specified in the [\`vpcSubnets\`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-eks.Cluster.html#vpcsubnetsspan-classapi-icon-api-icon-experimental-titlethis-api-element-is-experimental-it-may-change-without-noticespan) property.
+
+You can configure the environment of this function by specifying it at cluster instantiation. For example, this can be useful in order to configure an http proxy:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+  clusterHandlerEnvironment: {
+    'http_proxy': 'http://proxy.myproxy.com'
+  }
+});
+\`\`\`
+
+### Kubectl Support
+
+The resources are created in the cluster by running \`kubectl apply\` from a python lambda function.
+
+#### Environment
+
+You can configure the environment of this function by specifying it at cluster instantiation. For example, this can be useful in order to configure an http proxy:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+  kubectlEnvironment: {
+    'http_proxy': 'http://proxy.myproxy.com'
+  }
+});
+\`\`\`
+
+#### Runtime
+
+The kubectl handler uses \`kubectl\`, \`helm\` and the \`aws\` CLI in order to
+interact with the cluster. These are bundled into AWS Lambda layers included in
+the \`@aws-cdk/lambda-layer-awscli\` and \`@aws-cdk/lambda-layer-kubectl\` modules.
+
+You can specify a custom \`lambda.LayerVersion\` if you wish to use a different
+version of these tools. The handler expects the layer to include the following
+three executables:
+
+\`\`\`text
+helm/helm
+kubectl/kubectl
+awscli/aws
+\`\`\`
+
+See more information in the
+[Dockerfile](https://github.com/aws/aws-cdk/tree/master/packages/%40aws-cdk/lambda-layer-awscli/layer) for @aws-cdk/lambda-layer-awscli
+and the
+[Dockerfile](https://github.com/aws/aws-cdk/tree/master/packages/%40aws-cdk/lambda-layer-kubectl/layer) for @aws-cdk/lambda-layer-kubectl.
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'KubectlLayer', {
+  code: lambda.Code.fromAsset('layer.zip'),
+});
+\`\`\`
+
+Now specify when the cluster is defined:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'MyCluster', {
+  kubectlLayer: layer,
+});
+
+// or
+const cluster = eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
+  kubectlLayer: layer,
+});
+\`\`\`
+
+#### Memory
+
+By default, the kubectl provider is configured with 1024MiB of memory. You can use the \`kubectlMemory\` option to specify the memory size for the AWS Lambda function:
+
+\`\`\`ts
+import { Size } from 'aws-cdk-lib';
+
+new eks.Cluster(this, 'MyCluster', {
+  kubectlMemory: Size.gibibytes(4)
+});
+
+// or
+eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
+  kubectlMemory: Size.gibibytes(4)
+});
+\`\`\`
+
+### ARM64 Support
+
+Instance types with \`ARM64\` architecture are supported in both managed nodegroup and self-managed capacity. Simply specify an ARM64 \`instanceType\` (such as \`m6g.medium\`), and the latest
+Amazon Linux 2 AMI for ARM64 will be automatically selected.
+
+\`\`\`ts
+// add a managed ARM64 nodegroup
+cluster.addNodegroupCapacity('extra-ng-arm', {
+  instanceTypes: [new ec2.InstanceType('m6g.medium')],
+  minSize: 2,
+});
+
+// add a self-managed ARM64 nodegroup
+cluster.addAutoScalingGroupCapacity('self-ng-arm', {
+  instanceType: new ec2.InstanceType('m6g.medium'),
+  minCapacity: 2,
+})
+\`\`\`
+
+### Masters Role
+
+When you create a cluster, you can specify a \`mastersRole\`. The \`Cluster\` construct will associate this role with the \`system:masters\` [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) group, giving it super-user access to the cluster.
+
+\`\`\`ts
+const role = new iam.Role(...);
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  mastersRole: role,
+});
+\`\`\`
+
+If you do not specify it, a default role will be created on your behalf, that can be assumed by anyone in the account with \`sts:AssumeRole\` permissions for this role.
+
+This is the role you see as part of the stack outputs mentioned in the [Quick Start](#quick-start).
+
+\`\`\`console
+$ aws eks update-kubeconfig --name cluster-xxxxx --role-arn arn:aws:iam::112233445566:role/yyyyy
+Added new context arn:aws:eks:rrrrr:112233445566:cluster/cluster-xxxxx to /home/boom/.kube/config
+\`\`\`
+
+### Encryption
+
+When you create an Amazon EKS cluster, envelope encryption of Kubernetes secrets using the AWS Key Management Service (AWS KMS) can be enabled.
+The documentation on [creating a cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html)
+can provide more details about the customer master key (CMK) that can be used for the encryption.
+
+You can use the \`secretsEncryptionKey\` to configure which key the cluster will use to encrypt Kubernetes secrets. By default, an AWS Managed key will be used.
+
+> This setting can only be specified when the cluster is created and cannot be updated.
+
+\`\`\`ts
+const secretsKey = new kms.Key(this, 'SecretsKey');
+const cluster = new eks.Cluster(this, 'MyCluster', {
+  secretsEncryptionKey: secretsKey,
+  // ...
+});
+\`\`\`
+
+You can also use a similar configuration for running a cluster built using the FargateCluster construct.
+
+\`\`\`ts
+const secretsKey = new kms.Key(this, 'SecretsKey');
+const cluster = new eks.FargateCluster(this, 'MyFargateCluster', {
+  secretsEncryptionKey: secretsKey
+});
+\`\`\`
+
+The Amazon Resource Name (ARN) for that CMK can be retrieved.
+
+\`\`\`ts
+const clusterEncryptionConfigKeyArn = cluster.clusterEncryptionConfigKeyArn;
+\`\`\`
+
+## Permissions and Security
+
+Amazon EKS provides several mechanism of securing the cluster and granting permissions to specific IAM users and roles.
+
+### AWS IAM Mapping
+
+As described in the [Amazon EKS User Guide](https://docs.aws.amazon.com/en_us/eks/latest/userguide/add-user-role.html), you can map AWS IAM users and roles to [Kubernetes Role-based access control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac).
+
+The Amazon EKS construct manages the *aws-auth* \`ConfigMap\` Kubernetes resource on your behalf and exposes an API through the \`cluster.awsAuth\` for mapping
+users, roles and accounts.
+
+Furthermore, when auto-scaling group capacity is added to the cluster, the IAM instance role of the auto-scaling group will be automatically mapped to RBAC so nodes can connect to the cluster. No manual mapping is required.
+
+For example, let's say you want to grant an IAM user administrative privileges on your cluster:
+
+\`\`\`ts
+const adminUser = new iam.User(this, 'Admin');
+cluster.awsAuth.addUserMapping(adminUser, { groups: [ 'system:masters' ]});
+\`\`\`
+
+A convenience method for mapping a role to the \`system:masters\` group is also available:
+
+\`\`\`ts
+cluster.awsAuth.addMastersRole(role)
+\`\`\`
+
+### Cluster Security Group
+
+When you create an Amazon EKS cluster, a [cluster security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html)
+is automatically created as well. This security group is designed to allow all traffic from the control plane and managed node groups to flow freely
+between each other.
+
+The ID for that security group can be retrieved after creating the cluster.
+
+\`\`\`ts
+const clusterSecurityGroupId = cluster.clusterSecurityGroupId;
+\`\`\`
+
+### Node SSH Access
+
+If you want to be able to SSH into your worker nodes, you must already have an SSH key in the region you're connecting to and pass it when
+you add capacity to the cluster. You must also be able to connect to the hosts (meaning they must have a public IP and you
+should be allowed to connect to them on port 22):
+
+See [SSH into nodes](test/example.ssh-into-nodes.lit.ts) for a code example.
+
+If you want to SSH into nodes in a private subnet, you should set up a bastion host in a public subnet. That setup is recommended, but is
+unfortunately beyond the scope of this documentation.
+
+### Service Accounts
+
+With services account you can provide Kubernetes Pods access to AWS resources.
+
+\`\`\`ts
+// add service account
+const sa = cluster.addServiceAccount('MyServiceAccount');
+
+const bucket = new Bucket(this, 'Bucket');
+bucket.grantReadWrite(serviceAccount);
+
+const mypod = cluster.addManifest('mypod', {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name: 'mypod' },
+  spec: {
+    serviceAccountName: sa.serviceAccountName
+    containers: [
+      {
+        name: 'hello',
+        image: 'paulbouwer/hello-kubernetes:1.5',
+        ports: [ { containerPort: 8080 } ],
+
+      }
+    ]
+  }
+});
+
+// create the resource after the service account.
+mypod.node.addDependency(sa);
+
+// print the IAM role arn for this service account
+new cdk.CfnOutput(this, 'ServiceAccountIamRole', { value: sa.role.roleArn })
+\`\`\`
+
+Note that using \`sa.serviceAccountName\` above **does not** translate into a resource dependency.
+This is why an explicit dependency is needed. See <https://github.com/aws/aws-cdk/issues/9910> for more details.
+
+You can also add service accounts to existing clusters.
+To do so, pass the \`openIdConnectProvider\` property when you import the cluster into the application.
+
+\`\`\`ts
+// you can import an existing provider
+const provider = eks.OpenIdConnectProvider.fromOpenIdConnectProviderArn(this, 'Provider', 'arn:aws:iam::123456:oidc-provider/oidc.eks.eu-west-1.amazonaws.com/id/AB123456ABC');
+
+// or create a new one using an existing issuer url
+const provider = new eks.OpenIdConnectProvider(this, 'Provider', issuerUrl);
+
+const cluster = eks.Cluster.fromClusterAttributes({
+  clusterName: 'Cluster',
+  openIdConnectProvider: provider,
+  kubectlRoleArn: 'arn:aws:iam::123456:role/service-role/k8sservicerole',
+});
+
+const sa = cluster.addServiceAccount('MyServiceAccount');
+
+const bucket = new Bucket(this, 'Bucket');
+bucket.grantReadWrite(serviceAccount);
+
+// ...
+\`\`\`
+
+Note that adding service accounts requires running \`kubectl\` commands against the cluster.
+This means you must also pass the \`kubectlRoleArn\` when importing the cluster.
+See [Using existing Clusters](https://github.com/aws/aws-cdk/tree/master/packages/@aws-cdk/aws-eks#using-existing-clusters).
+
+## Applying Kubernetes Resources
+
+The library supports several popular resource deployment mechanisms, among which are:
+
+### Kubernetes Manifests
+
+The \`KubernetesManifest\` construct or \`cluster.addManifest\` method can be used
+to apply Kubernetes resource manifests to this cluster.
+
+> When using \`cluster.addManifest\`, the manifest construct is defined within the cluster's stack scope. If the manifest contains
+> attributes from a different stack which depend on the cluster stack, a circular dependency will be created and you will get a synth time error.
+> To avoid this, directly use \`new KubernetesManifest\` to create the manifest in the scope of the other stack.
+
+The following examples will deploy the [paulbouwer/hello-kubernetes](https://github.com/paulbouwer/hello-kubernetes)
+service on the cluster:
+
+\`\`\`ts
+const appLabel = { app: \\"hello-kubernetes\\" };
+
+const deployment = {
+  apiVersion: \\"apps/v1\\",
+  kind: \\"Deployment\\",
+  metadata: { name: \\"hello-kubernetes\\" },
+  spec: {
+    replicas: 3,
+    selector: { matchLabels: appLabel },
+    template: {
+      metadata: { labels: appLabel },
+      spec: {
+        containers: [
+          {
+            name: \\"hello-kubernetes\\",
+            image: \\"paulbouwer/hello-kubernetes:1.5\\",
+            ports: [ { containerPort: 8080 } ]
+          }
+        ]
+      }
+    }
+  }
+};
+
+const service = {
+  apiVersion: \\"v1\\",
+  kind: \\"Service\\",
+  metadata: { name: \\"hello-kubernetes\\" },
+  spec: {
+    type: \\"LoadBalancer\\",
+    ports: [ { port: 80, targetPort: 8080 } ],
+    selector: appLabel
+  }
+};
+
+// option 1: use a construct
+new KubernetesManifest(this, 'hello-kub', {
+  cluster,
+  manifest: [ deployment, service ]
+});
+
+// or, option2: use \`addManifest\`
+cluster.addManifest('hello-kub', service, deployment);
+\`\`\`
+
+#### Adding resources from a URL
+
+The following example will deploy the resource manifest hosting on remote server:
+
+\`\`\`ts
+import * as yaml from 'js-yaml';
+import * as request from 'sync-request';
+
+const manifestUrl = 'https://url/of/manifest.yaml';
+const manifest = yaml.safeLoadAll(request('GET', manifestUrl).getBody());
+cluster.addManifest('my-resource', ...manifest);
+\`\`\`
+
+#### Dependencies
+
+There are cases where Kubernetes resources must be deployed in a specific order.
+For example, you cannot define a resource in a Kubernetes namespace before the
+namespace was created.
+
+You can represent dependencies between \`KubernetesManifest\`s using
+\`resource.node.addDependency()\`:
+
+\`\`\`ts
+const namespace = cluster.addManifest('my-namespace', {
+  apiVersion: 'v1',
+  kind: 'Namespace',
+  metadata: { name: 'my-app' }
+});
+
+const service = cluster.addManifest('my-service', {
+  metadata: {
+    name: 'myservice',
+    namespace: 'my-app'
+  },
+  spec: // ...
+});
+
+service.node.addDependency(namespace); // will apply \`my-namespace\` before \`my-service\`.
+\`\`\`
+
+**NOTE:** when a \`KubernetesManifest\` includes multiple resources (either directly
+or through \`cluster.addManifest()\`) (e.g. \`cluster.addManifest('foo', r1, r2,
+r3,...)\`), these resources will be applied as a single manifest via \`kubectl\`
+and will be applied sequentially (the standard behavior in \`kubectl\`).
+
+---
+
+Since Kubernetes manifests are implemented as CloudFormation resources in the
+CDK. This means that if the manifest is deleted from your code (or the stack is
+deleted), the next \`cdk deploy\` will issue a \`kubectl delete\` command and the
+Kubernetes resources in that manifest will be deleted.
+
+#### Resource Pruning
+
+When a resource is deleted from a Kubernetes manifest, the EKS module will
+automatically delete these resources by injecting a _prune label_ to all
+manifest resources. This label is then passed to [\`kubectl apply --prune\`].
+
+[\`kubectl apply --prune\`]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+Pruning is enabled by default but can be disabled through the \`prune\` option
+when a cluster is defined:
+
+\`\`\`ts
+new Cluster(this, 'MyCluster', {
+  prune: false
+});
+\`\`\`
+
+#### Manifests Validation
+
+The \`kubectl\` CLI supports applying a manifest by skipping the validation.
+This can be accomplished by setting the \`skipValidation\` flag to \`true\` in the \`KubernetesManifest\` props.
+
+\`\`\`ts
+new eks.KubernetesManifest(this, 'HelloAppWithoutValidation', {
+  cluster: this.cluster,
+  manifest: [ deployment, service ],
+  skipValidation: true,
+});
+\`\`\`
+
+### Helm Charts
+
+The \`HelmChart\` construct or \`cluster.addHelmChart\` method can be used
+to add Kubernetes resources to this cluster using Helm.
+
+> When using \`cluster.addHelmChart\`, the manifest construct is defined within the cluster's stack scope. If the manifest contains
+> attributes from a different stack which depend on the cluster stack, a circular dependency will be created and you will get a synth time error.
+> To avoid this, directly use \`new HelmChart\` to create the chart in the scope of the other stack.
+
+The following example will install the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) to your cluster using Helm.
+
+\`\`\`ts
+// option 1: use a construct
+new HelmChart(this, 'NginxIngress', {
+  cluster,
+  chart: 'nginx-ingress',
+  repository: 'https://helm.nginx.com/stable',
+  namespace: 'kube-system'
+});
+
+// or, option2: use \`addHelmChart\`
+cluster.addHelmChart('NginxIngress', {
+  chart: 'nginx-ingress',
+  repository: 'https://helm.nginx.com/stable',
+  namespace: 'kube-system'
+});
+\`\`\`
+
+Helm charts will be installed and updated using \`helm upgrade --install\`, where a few parameters
+are being passed down (such as \`repo\`, \`values\`, \`version\`, \`namespace\`, \`wait\`, \`timeout\`, etc).
+This means that if the chart is added to CDK with the same release name, it will try to update
+the chart in the cluster.
+
+Helm charts are implemented as CloudFormation resources in CDK.
+This means that if the chart is deleted from your code (or the stack is
+deleted), the next \`cdk deploy\` will issue a \`helm uninstall\` command and the
+Helm chart will be deleted.
+
+When there is no \`release\` defined, a unique ID will be allocated for the release based
+on the construct path.
+
+By default, all Helm charts will be installed concurrently. In some cases, this
+could cause race conditions where two Helm charts attempt to deploy the same
+resource or if Helm charts depend on each other. You can use
+\`chart.node.addDependency()\` in order to declare a dependency order between
+charts:
+
+\`\`\`ts
+const chart1 = cluster.addHelmChart(...);
+const chart2 = cluster.addHelmChart(...);
+
+chart2.node.addDependency(chart1);
+\`\`\`
+
+#### CDK8s Charts
+
+[CDK8s](https://cdk8s.io/) is an open-source library that enables Kubernetes manifest authoring using familiar programming languages. It is founded on the same technologies as the AWS CDK, such as [\`constructs\`](https://github.com/aws/constructs) and [\`jsii\`](https://github.com/aws/jsii).
+
+> To learn more about cdk8s, visit the [Getting Started](https://github.com/awslabs/cdk8s/tree/master/docs/getting-started) tutorials.
+
+The EKS module natively integrates with cdk8s and allows you to apply cdk8s charts on AWS EKS clusters via the \`cluster.addCdk8sChart\` method.
+
+In addition to \`cdk8s\`, you can also use [\`cdk8s+\`](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-plus), which provides higher level abstraction for the core kubernetes api objects.
+You can think of it like the \`L2\` constructs for Kubernetes. Any other \`cdk8s\` based libraries are also supported, for example [\`cdk8s-debore\`](https://github.com/toricls/cdk8s-debore).
+
+To get started, add the following dependencies to your \`package.json\` file:
+
+\`\`\`json
+\\"dependencies\\": {
+  \\"cdk8s\\": \\"0.30.0\\",
+  \\"cdk8s-plus\\": \\"0.30.0\\",
+  \\"constructs\\": \\"3.0.4\\"
+}
+\`\`\`
+
+> Note that the version of \`cdk8s\` must be \`>=0.30.0\`.
+
+Similarly to how you would create a stack by extending \`@aws-cdk/core.Stack\`, we recommend you create a chart of your own that extends \`cdk8s.Chart\`,
+and add your kubernetes resources to it. You can use \`aws-cdk\` construct attributes and properties inside your \`cdk8s\` construct freely.
+
+In this example we create a chart that accepts an \`s3.Bucket\` and passes its name to a kubernetes pod as an environment variable.
+
+Notice that the chart must accept a \`constructs.Construct\` type as its scope, not an \`@aws-cdk/core.Construct\` as you would normally use.
+For this reason, to avoid possible confusion, we will create the chart in a separate file:
+
+\`+ my-chart.ts\`
+
+\`\`\`ts
+import { aws_s3 as s3 } from 'aws-cdk-lib';
+import * as constructs from 'constructs';
+import * as cdk8s from 'cdk8s';
+import * as kplus from 'cdk8s-plus';
+
+export interface MyChartProps {
+  readonly bucket: s3.Bucket;
+}
+
+export class MyChart extends cdk8s.Chart {
+  constructor(scope: constructs.Construct, id: string, props: MyChartProps) {
+    super(scope, id);
+
+    new kplus.Pod(this, 'Pod', {
+      spec: {
+        containers: [
+          new kplus.Container({
+            image: 'my-image',
+            env: {
+              BUCKET_NAME: kplus.EnvValue.fromValue(props.bucket.bucketName),
+            },
+          }),
+        ],
+      },
+    });
+  }
+}
+\`\`\`
+
+Then, in your AWS CDK app:
+
+\`\`\`ts
+import { aws_s3 as s3 } from 'aws-cdk-lib';
+import * as cdk8s from 'cdk8s';
+import { MyChart } from './my-chart';
+
+// some bucket..
+const bucket = new s3.Bucket(this, 'Bucket');
+
+// create a cdk8s chart and use \`cdk8s.App\` as the scope.
+const myChart = new MyChart(new cdk8s.App(), 'MyChart', { bucket });
+
+// add the cdk8s chart to the cluster
+cluster.addCdk8sChart('my-chart', myChart);
+\`\`\`
+
+##### Custom CDK8s Constructs
+
+You can also compose a few stock \`cdk8s+\` constructs into your own custom construct. However, since mixing scopes between \`aws-cdk\` and \`cdk8s\` is currently not supported, the \`Construct\` class
+you'll need to use is the one from the [\`constructs\`](https://github.com/aws/constructs) module, and not from \`@aws-cdk/core\` like you normally would.
+This is why we used \`new cdk8s.App()\` as the scope of the chart above.
+
+\`\`\`ts
+import * as constructs from 'constructs';
+import * as cdk8s from 'cdk8s';
+import * as kplus from 'cdk8s-plus';
+
+export interface LoadBalancedWebService {
+  readonly port: number;
+  readonly image: string;
+  readonly replicas: number;
+}
+
+export class LoadBalancedWebService extends constructs.Construct {
+  constructor(scope: constructs.Construct, id: string, props: LoadBalancedWebService) {
+    super(scope, id);
+
+    const deployment = new kplus.Deployment(chart, 'Deployment', {
+      spec: {
+        replicas: props.replicas,
+        podSpecTemplate: {
+          containers: [ new kplus.Container({ image: props.image }) ]
+        }
+      },
+    });
+
+    deployment.expose({port: props.port, serviceType: kplus.ServiceType.LOAD_BALANCER})
+
+  }
+}
+\`\`\`
+
+##### Manually importing k8s specs and CRD's
+
+If you find yourself unable to use \`cdk8s+\`, or just like to directly use the \`k8s\` native objects or CRD's, you can do so by manually importing them using the \`cdk8s-cli\`.
+
+See [Importing kubernetes objects](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-cli#import) for detailed instructions.
+
+## Patching Kubernetes Resources
+
+The \`KubernetesPatch\` construct can be used to update existing kubernetes
+resources. The following example can be used to patch the \`hello-kubernetes\`
+deployment from the example above with 5 replicas.
+
+\`\`\`ts
+new KubernetesPatch(this, 'hello-kub-deployment-label', {
+  cluster,
+  resourceName: \\"deployment/hello-kubernetes\\",
+  applyPatch: { spec: { replicas: 5 } },
+  restorePatch: { spec: { replicas: 3 } }
+})
+\`\`\`
+
+## Querying Kubernetes Resources
+
+The \`KubernetesObjectValue\` construct can be used to query for information about kubernetes objects,
+and use that as part of your CDK application.
+
+For example, you can fetch the address of a [\`LoadBalancer\`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) type service:
+
+\`\`\`ts
+// query the load balancer address
+const myServiceAddress = new KubernetesObjectValue(this, 'LoadBalancerAttribute', {
+  cluster: cluster,
+  objectType: 'service',
+  objectName: 'my-service',
+  jsonPath: '.status.loadBalancer.ingress[0].hostname', // https://kubernetes.io/docs/reference/kubectl/jsonpath/
+});
+
+// pass the address to a lambda function
+const proxyFunction = new lambda.Function(this, 'ProxyFunction', {
+  ...
+  environment: {
+    myServiceAddress: myServiceAddress.value
+  },
+})
+\`\`\`
+
+Specifically, since the above use-case is quite common, there is an easier way to access that information:
+
+\`\`\`ts
+const loadBalancerAddress = cluster.getServiceLoadBalancerAddress('my-service');
+\`\`\`
+
+## Using existing clusters
+
+The Amazon EKS library allows defining Kubernetes resources such as [Kubernetes
+manifests](#kubernetes-resources) and [Helm charts](#helm-charts) on clusters
+that are not defined as part of your CDK app.
+
+First, you'll need to \\"import\\" a cluster to your CDK app. To do that, use the
+\`eks.Cluster.fromClusterAttributes()\` static method:
+
+\`\`\`ts
+const cluster = eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
+  clusterName: 'my-cluster-name',
+  kubectlRoleArn: 'arn:aws:iam::1111111:role/iam-role-that-has-masters-access',
+});
+\`\`\`
+
+Then, you can use \`addManifest\` or \`addHelmChart\` to define resources inside
+your Kubernetes cluster. For example:
+
+\`\`\`ts
+cluster.addManifest('Test', {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'myconfigmap',
+  },
+  data: {
+    Key: 'value',
+    Another: '123454',
+  },
+});
+\`\`\`
+
+At the minimum, when importing clusters for \`kubectl\` management, you will need
+to specify:
+
+* \`clusterName\` - the name of the cluster.
+* \`kubectlRoleArn\` - the ARN of an IAM role mapped to the \`system:masters\` RBAC
+  role. If the cluster you are importing was created using the AWS CDK, the
+  CloudFormation stack has an output that includes an IAM role that can be used.
+  Otherwise, you can create an IAM role and map it to \`system:masters\` manually.
+  The trust policy of this role should include the the
+  \`arn:aws::iam::\${accountId}:root\` principal in order to allow the execution
+  role of the kubectl resource to assume it.
+
+If the cluster is configured with private-only or private and restricted public
+Kubernetes [endpoint access](#endpoint-access), you must also specify:
+
+* \`kubectlSecurityGroupId\` - the ID of an EC2 security group that is allowed
+  connections to the cluster's control security group. For example, the EKS managed [cluster security group](#cluster-security-group).
+* \`kubectlPrivateSubnetIds\` - a list of private VPC subnets IDs that will be used
+  to access the Kubernetes endpoint.
+
+## Known Issues and Limitations
+
+* [One cluster per stack](https://github.com/aws/aws-cdk/issues/10073)
+* [Service Account dependencies](https://github.com/aws/aws-cdk/issues/9910)
+* [Support isolated VPCs](https://github.com/aws/aws-cdk/issues/12171)
+
+# API Reference <span data-heading-title=\\"API Reference\\" data-heading-id=\\"api-reference\\"></span>
+
+## Constructs <span data-heading-title=\\"Constructs\\" data-heading-id=\\"constructs\\"></span>
+
+### AwsAuth <span data-heading-title=\\"AwsAuth\\" data-heading-id=\\"awscdkawseksawsauth\\"></span>
+
+Manages mapping between IAM users and roles to Kubernetes RBAC configuration.
+
+> https://docs.aws.amazon.com/en_us/eks/latest/userguide/add-user-role.html
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawseksawsauthinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.AwsAuth(scope: Construct, 
+                id: str, 
+                cluster: Cluster)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`add_account\` <span data-heading-title=\\"\`add_account\`\\" data-heading-id=\\"awscdkawseksawsauthaddaccount\\"></span>
+
+\`\`\`python
+def add_account(account_id: str)
+\`\`\`
+
+###### \`account_id\`<sup>Required</sup> <span data-heading-title=\\"\`account_id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthaccountid\\"></span>
+
+- *Type:* \`str\`
+
+account number.
+
+---
+
+##### \`add_masters_role\` <span data-heading-title=\\"\`add_masters_role\`\\" data-heading-id=\\"awscdkawseksawsauthaddmastersrole\\"></span>
+
+\`\`\`python
+def add_masters_role(role: IRole, 
+                     username: str = None)
+\`\`\`
+
+###### \`role\`<sup>Required</sup> <span data-heading-title=\\"\`role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+The IAM role to add.
+
+---
+
+###### \`username\`<sup>Optional</sup> <span data-heading-title=\\"\`username\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksawsauthusername\\"></span>
+
+- *Type:* \`str\`
+
+Optional user (defaults to the role ARN).
+
+---
+
+##### \`add_role_mapping\` <span data-heading-title=\\"\`add_role_mapping\`\\" data-heading-id=\\"awscdkawseksawsauthaddrolemapping\\"></span>
+
+\`\`\`python
+def add_role_mapping(role: IRole, 
+                     groups: typing.List[str], 
+                     username: str = None)
+\`\`\`
+
+###### \`role\`<sup>Required</sup> <span data-heading-title=\\"\`role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+The IAM role to map.
+
+---
+
+###### \`groups\`<sup>Required</sup> <span data-heading-title=\\"\`groups\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthmappinggroups\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+A list of groups within Kubernetes to which the role is mapped.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+###### \`username\`<sup>Optional</sup> <span data-heading-title=\\"\`username\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksawsauthmappingusername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* By default, the user name is the ARN of the IAM role.
+
+The user name within Kubernetes to map to the IAM role.
+
+---
+
+##### \`add_user_mapping\` <span data-heading-title=\\"\`add_user_mapping\`\\" data-heading-id=\\"awscdkawseksawsauthaddusermapping\\"></span>
+
+\`\`\`python
+def add_user_mapping(user: IUser, 
+                     groups: typing.List[str], 
+                     username: str = None)
+\`\`\`
+
+###### \`user\`<sup>Required</sup> <span data-heading-title=\\"\`user\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthuser\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IUser\`](#aws_cdk.aws_iam.IUser)
+
+The IAM user to map.
+
+---
+
+###### \`groups\`<sup>Required</sup> <span data-heading-title=\\"\`groups\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthmappinggroups\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+A list of groups within Kubernetes to which the role is mapped.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+###### \`username\`<sup>Optional</sup> <span data-heading-title=\\"\`username\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksawsauthmappingusername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* By default, the user name is the ARN of the IAM role.
+
+The user name within Kubernetes to map to the IAM role.
+
+---
+
+
+
+
+### CfnAddon <span data-heading-title=\\"CfnAddon\\" data-heading-id=\\"awscdkawsekscfnaddon\\"></span>
+
+- *Implements:* [\`aws_cdk.IInspectable\`](#aws_cdk.IInspectable)
+
+A CloudFormation \`AWS::EKS::Addon\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekscfnaddoninitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnAddon(scope: Construct, 
+                 id: str, 
+                 addon_name: str, 
+                 cluster_name: str, 
+                 addon_version: str = None, 
+                 resolve_conflicts: str = None, 
+                 service_account_role_arn: str = None, 
+                 tags: typing.List[CfnTag] = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonid\\"></span>
+
+- *Type:* \`str\`
+
+scoped id of the resource.
+
+---
+
+##### \`addon_name\`<sup>Required</sup> <span data-heading-title=\\"\`addon_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsaddonname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.AddonName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname)
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername)
+
+---
+
+##### \`addon_version\`<sup>Optional</sup> <span data-heading-title=\\"\`addon_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsaddonversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.AddonVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion)
+
+---
+
+##### \`resolve_conflicts\`<sup>Optional</sup> <span data-heading-title=\\"\`resolve_conflicts\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsresolveconflicts\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ResolveConflicts\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts)
+
+---
+
+##### \`service_account_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`service_account_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsserviceaccountrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ServiceAccountRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropstags\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
+
+\`AWS::EKS::Addon.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags)
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`inspect\` <span data-heading-title=\\"\`inspect\`\\" data-heading-id=\\"awscdkawsekscfnaddoninspect\\"></span>
+
+\`\`\`python
+def inspect(inspector: TreeInspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <span data-heading-title=\\"\`inspector\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddoninspector\\"></span>
+
+- *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`attr_arn\`<sup>Required</sup> <span data-heading-title=\\"\`attr_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonattrarn\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`tags\`<sup>Required</sup> <span data-heading-title=\\"\`tags\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddontags\\"></span>
+
+- *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
+
+\`AWS::EKS::Addon.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags)
+
+---
+
+##### \`addon_name\`<sup>Required</sup> <span data-heading-title=\\"\`addon_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonaddonname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.AddonName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname)
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername)
+
+---
+
+##### \`addon_version\`<sup>Optional</sup> <span data-heading-title=\\"\`addon_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonaddonversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.AddonVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion)
+
+---
+
+##### \`resolve_conflicts\`<sup>Optional</sup> <span data-heading-title=\\"\`resolve_conflicts\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonresolveconflicts\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ResolveConflicts\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts)
+
+---
+
+##### \`service_account_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`service_account_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonserviceaccountrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ServiceAccountRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn)
+
+---
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <span data-heading-title=\\"\`CFN_RESOURCE_TYPE_NAME\`\\" data-heading-id=\\"awscdkawsekscfnaddoncfnresourcetypename\\"></span>
+
+- *Type:* \`str\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnCluster <span data-heading-title=\\"CfnCluster\\" data-heading-id=\\"awscdkawsekscfncluster\\"></span>
+
+- *Implements:* [\`aws_cdk.IInspectable\`](#aws_cdk.IInspectable)
+
+A CloudFormation \`AWS::EKS::Cluster\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekscfnclusterinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnCluster(scope: Construct, 
+                   id: str, 
+                   resources_vpc_config: typing.Union[ResourcesVpcConfigProperty, IResolvable], 
+                   role_arn: str, 
+                   encryption_config: typing.Union[IResolvable, typing.List[typing.Union[EncryptionConfigProperty, IResolvable]]] = None, 
+                   kubernetes_network_config: typing.Union[KubernetesNetworkConfigProperty, IResolvable] = None, 
+                   name: str = None, 
+                   version: str = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterid\\"></span>
+
+- *Type:* \`str\`
+
+scoped id of the resource.
+
+---
+
+##### \`resources_vpc_config\`<sup>Required</sup> <span data-heading-title=\\"\`resources_vpc_config\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsresourcesvpcconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Cluster.ResourcesVpcConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig)
+
+---
+
+##### \`role_arn\`<sup>Required</sup> <span data-heading-title=\\"\`role_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.RoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn)
+
+---
+
+##### \`encryption_config\`<sup>Optional</sup> <span data-heading-title=\\"\`encryption_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsencryptionconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::Cluster.EncryptionConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig)
+
+---
+
+##### \`kubernetes_network_config\`<sup>Optional</sup> <span data-heading-title=\\"\`kubernetes_network_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropskubernetesnetworkconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig)
+
+---
+
+##### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version)
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`inspect\` <span data-heading-title=\\"\`inspect\`\\" data-heading-id=\\"awscdkawsekscfnclusterinspect\\"></span>
+
+\`\`\`python
+def inspect(inspector: TreeInspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <span data-heading-title=\\"\`inspector\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterinspector\\"></span>
+
+- *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`attr_arn\`<sup>Required</sup> <span data-heading-title=\\"\`attr_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterattrarn\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`attr_certificate_authority_data\`<sup>Required</sup> <span data-heading-title=\\"\`attr_certificate_authority_data\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterattrcertificateauthoritydata\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`attr_cluster_security_group_id\`<sup>Required</sup> <span data-heading-title=\\"\`attr_cluster_security_group_id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterattrclustersecuritygroupid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`attr_encryption_config_key_arn\`<sup>Required</sup> <span data-heading-title=\\"\`attr_encryption_config_key_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterattrencryptionconfigkeyarn\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`attr_endpoint\`<sup>Required</sup> <span data-heading-title=\\"\`attr_endpoint\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterattrendpoint\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`attr_open_id_connect_issuer_url\`<sup>Required</sup> <span data-heading-title=\\"\`attr_open_id_connect_issuer_url\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterattropenidconnectissuerurl\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`resources_vpc_config\`<sup>Required</sup> <span data-heading-title=\\"\`resources_vpc_config\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterresourcesvpcconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Cluster.ResourcesVpcConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig)
+
+---
+
+##### \`role_arn\`<sup>Required</sup> <span data-heading-title=\\"\`role_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.RoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn)
+
+---
+
+##### \`encryption_config\`<sup>Optional</sup> <span data-heading-title=\\"\`encryption_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterencryptionconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::Cluster.EncryptionConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig)
+
+---
+
+##### \`kubernetes_network_config\`<sup>Optional</sup> <span data-heading-title=\\"\`kubernetes_network_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterkubernetesnetworkconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig)
+
+---
+
+##### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version)
+
+---
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <span data-heading-title=\\"\`CFN_RESOURCE_TYPE_NAME\`\\" data-heading-id=\\"awscdkawsekscfnclustercfnresourcetypename\\"></span>
+
+- *Type:* \`str\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnFargateProfile <span data-heading-title=\\"CfnFargateProfile\\" data-heading-id=\\"awscdkawsekscfnfargateprofile\\"></span>
+
+- *Implements:* [\`aws_cdk.IInspectable\`](#aws_cdk.IInspectable)
+
+A CloudFormation \`AWS::EKS::FargateProfile\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekscfnfargateprofileinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnFargateProfile(scope: Construct, 
+                          id: str, 
+                          cluster_name: str, 
+                          pod_execution_role_arn: str, 
+                          selectors: typing.Union[IResolvable, typing.List[typing.Union[SelectorProperty, IResolvable]]], 
+                          fargate_profile_name: str = None, 
+                          subnets: typing.List[str] = None, 
+                          tags: typing.List[CfnTag] = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilescope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofileid\\"></span>
+
+- *Type:* \`str\`
+
+scoped id of the resource.
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropsclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername)
+
+---
+
+##### \`pod_execution_role_arn\`<sup>Required</sup> <span data-heading-title=\\"\`pod_execution_role_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropspodexecutionrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.PodExecutionRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn)
+
+---
+
+##### \`selectors\`<sup>Required</sup> <span data-heading-title=\\"\`selectors\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropsselectors\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::FargateProfile.Selectors\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors)
+
+---
+
+##### \`fargate_profile_name\`<sup>Optional</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropsfargateprofilename\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.FargateProfileName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropssubnets\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::FargateProfile.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropstags\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
+
+\`AWS::EKS::FargateProfile.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags)
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`inspect\` <span data-heading-title=\\"\`inspect\`\\" data-heading-id=\\"awscdkawsekscfnfargateprofileinspect\\"></span>
+
+\`\`\`python
+def inspect(inspector: TreeInspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <span data-heading-title=\\"\`inspector\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofileinspector\\"></span>
+
+- *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`attr_arn\`<sup>Required</sup> <span data-heading-title=\\"\`attr_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofileattrarn\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`tags\`<sup>Required</sup> <span data-heading-title=\\"\`tags\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofiletags\\"></span>
+
+- *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
+
+\`AWS::EKS::FargateProfile.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags)
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofileclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername)
+
+---
+
+##### \`pod_execution_role_arn\`<sup>Required</sup> <span data-heading-title=\\"\`pod_execution_role_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepodexecutionrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.PodExecutionRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn)
+
+---
+
+##### \`selectors\`<sup>Required</sup> <span data-heading-title=\\"\`selectors\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofileselectors\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::FargateProfile.Selectors\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors)
+
+---
+
+##### \`fargate_profile_name\`<sup>Optional</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilefargateprofilename\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.FargateProfileName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilesubnets\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::FargateProfile.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets)
+
+---
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <span data-heading-title=\\"\`CFN_RESOURCE_TYPE_NAME\`\\" data-heading-id=\\"awscdkawsekscfnfargateprofilecfnresourcetypename\\"></span>
+
+- *Type:* \`str\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnNodegroup <span data-heading-title=\\"CfnNodegroup\\" data-heading-id=\\"awscdkawsekscfnnodegroup\\"></span>
+
+- *Implements:* [\`aws_cdk.IInspectable\`](#aws_cdk.IInspectable)
+
+A CloudFormation \`AWS::EKS::Nodegroup\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekscfnnodegroupinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnNodegroup(scope: Construct, 
+                     id: str, 
+                     cluster_name: str, 
+                     node_role: str, 
+                     subnets: typing.List[str], 
+                     ami_type: str = None, 
+                     capacity_type: str = None, 
+                     disk_size: typing.Union[int, float] = None, 
+                     force_update_enabled: typing.Union[bool, IResolvable] = None, 
+                     instance_types: typing.List[str] = None, 
+                     labels: typing.Any = None, 
+                     launch_template: typing.Union[LaunchTemplateSpecificationProperty, IResolvable] = None, 
+                     nodegroup_name: str = None, 
+                     release_version: str = None, 
+                     remote_access: typing.Union[RemoteAccessProperty, IResolvable] = None, 
+                     scaling_config: typing.Union[ScalingConfigProperty, IResolvable] = None, 
+                     tags: typing.Any = None, 
+                     taints: typing.Union[IResolvable, typing.List[typing.Union[TaintProperty, IResolvable]]] = None, 
+                     version: str = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupid\\"></span>
+
+- *Type:* \`str\`
+
+scoped id of the resource.
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername)
+
+---
+
+##### \`node_role\`<sup>Required</sup> <span data-heading-title=\\"\`node_role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsnoderole\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.NodeRole\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole)
+
+---
+
+##### \`subnets\`<sup>Required</sup> <span data-heading-title=\\"\`subnets\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropssubnets\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::Nodegroup.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets)
+
+---
+
+##### \`ami_type\`<sup>Optional</sup> <span data-heading-title=\\"\`ami_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsamitype\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.AmiType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype)
+
+---
+
+##### \`capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropscapacitytype\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.CapacityType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype)
+
+---
+
+##### \`disk_size\`<sup>Optional</sup> <span data-heading-title=\\"\`disk_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsdisksize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+
+\`AWS::EKS::Nodegroup.DiskSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize)
+
+---
+
+##### \`force_update_enabled\`<sup>Optional</sup> <span data-heading-title=\\"\`force_update_enabled\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsforceupdateenabled\\"></span>
+
+- *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled)
+
+---
+
+##### \`instance_types\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_types\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsinstancetypes\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::Nodegroup.InstanceTypes\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes)
+
+---
+
+##### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropslabels\\"></span>
+
+- *Type:* \`typing.Any\`
+
+\`AWS::EKS::Nodegroup.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels)
+
+---
+
+##### \`launch_template\`<sup>Optional</sup> <span data-heading-title=\\"\`launch_template\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropslaunchtemplate\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.LaunchTemplate\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate)
+
+---
+
+##### \`nodegroup_name\`<sup>Optional</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsnodegroupname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.NodegroupName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname)
+
+---
+
+##### \`release_version\`<sup>Optional</sup> <span data-heading-title=\\"\`release_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsreleaseversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.ReleaseVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion)
+
+---
+
+##### \`remote_access\`<sup>Optional</sup> <span data-heading-title=\\"\`remote_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsremoteaccess\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.RemoteAccess\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess)
+
+---
+
+##### \`scaling_config\`<sup>Optional</sup> <span data-heading-title=\\"\`scaling_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsscalingconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.ScalingConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropstags\\"></span>
+
+- *Type:* \`typing.Any\`
+
+\`AWS::EKS::Nodegroup.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags)
+
+---
+
+##### \`taints\`<sup>Optional</sup> <span data-heading-title=\\"\`taints\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropstaints\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::Nodegroup.Taints\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints)
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version)
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`inspect\` <span data-heading-title=\\"\`inspect\`\\" data-heading-id=\\"awscdkawsekscfnnodegroupinspect\\"></span>
+
+\`\`\`python
+def inspect(inspector: TreeInspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <span data-heading-title=\\"\`inspector\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupinspector\\"></span>
+
+- *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`attr_arn\`<sup>Required</sup> <span data-heading-title=\\"\`attr_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupattrarn\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`attr_cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`attr_cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupattrclustername\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`attr_nodegroup_name\`<sup>Required</sup> <span data-heading-title=\\"\`attr_nodegroup_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupattrnodegroupname\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`tags\`<sup>Required</sup> <span data-heading-title=\\"\`tags\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouptags\\"></span>
+
+- *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
+
+\`AWS::EKS::Nodegroup.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags)
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername)
+
+---
+
+##### \`labels\`<sup>Required</sup> <span data-heading-title=\\"\`labels\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouplabels\\"></span>
+
+- *Type:* \`typing.Any\`
+
+\`AWS::EKS::Nodegroup.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels)
+
+---
+
+##### \`node_role\`<sup>Required</sup> <span data-heading-title=\\"\`node_role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupnoderole\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.NodeRole\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole)
+
+---
+
+##### \`subnets\`<sup>Required</sup> <span data-heading-title=\\"\`subnets\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupsubnets\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::Nodegroup.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets)
+
+---
+
+##### \`ami_type\`<sup>Optional</sup> <span data-heading-title=\\"\`ami_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupamitype\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.AmiType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype)
+
+---
+
+##### \`capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupcapacitytype\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.CapacityType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype)
+
+---
+
+##### \`disk_size\`<sup>Optional</sup> <span data-heading-title=\\"\`disk_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupdisksize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+
+\`AWS::EKS::Nodegroup.DiskSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize)
+
+---
+
+##### \`force_update_enabled\`<sup>Optional</sup> <span data-heading-title=\\"\`force_update_enabled\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupforceupdateenabled\\"></span>
+
+- *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled)
+
+---
+
+##### \`instance_types\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_types\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupinstancetypes\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::Nodegroup.InstanceTypes\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes)
+
+---
+
+##### \`launch_template\`<sup>Optional</sup> <span data-heading-title=\\"\`launch_template\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouplaunchtemplate\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.LaunchTemplate\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate)
+
+---
+
+##### \`nodegroup_name\`<sup>Optional</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupnodegroupname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.NodegroupName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname)
+
+---
+
+##### \`release_version\`<sup>Optional</sup> <span data-heading-title=\\"\`release_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupreleaseversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.ReleaseVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion)
+
+---
+
+##### \`remote_access\`<sup>Optional</sup> <span data-heading-title=\\"\`remote_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupremoteaccess\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.RemoteAccess\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess)
+
+---
+
+##### \`scaling_config\`<sup>Optional</sup> <span data-heading-title=\\"\`scaling_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupscalingconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.ScalingConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig)
+
+---
+
+##### \`taints\`<sup>Optional</sup> <span data-heading-title=\\"\`taints\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouptaints\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::Nodegroup.Taints\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints)
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version)
+
+---
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <span data-heading-title=\\"\`CFN_RESOURCE_TYPE_NAME\`\\" data-heading-id=\\"awscdkawsekscfnnodegroupcfnresourcetypename\\"></span>
+
+- *Type:* \`str\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### Cluster <span data-heading-title=\\"Cluster\\" data-heading-id=\\"awscdkawsekscluster\\"></span>
+
+- *Implements:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+A Cluster represents a managed Kubernetes Service (EKS).
+
+This is a fully managed cluster of API Servers (control-plane)
+The user is still required to create the worker nodes.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawseksclusterinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.Cluster(scope: Construct, 
+                id: str, 
+                version: KubernetesVersion, 
+                cluster_name: str = None, 
+                output_cluster_name: bool = None, 
+                output_config_command: bool = None, 
+                role: IRole = None, 
+                security_group: ISecurityGroup = None, 
+                vpc: IVpc = None, 
+                vpc_subnets: typing.List[SubnetSelection] = None, 
+                cluster_handler_environment: typing.Mapping[str] = None, 
+                core_dns_compute_type: CoreDnsComputeType = None, 
+                endpoint_access: EndpointAccess = None, 
+                kubectl_environment: typing.Mapping[str] = None, 
+                kubectl_layer: ILayerVersion = None, 
+                kubectl_memory: Size = None, 
+                masters_role: IRole = None, 
+                output_masters_role_arn: bool = None, 
+                place_cluster_handler_in_vpc: bool = None, 
+                prune: bool = None, 
+                secrets_encryption_key: IKey = None, 
+                default_capacity: typing.Union[int, float] = None, 
+                default_capacity_instance: InstanceType = None, 
+                default_capacity_type: DefaultCapacityType = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+a Construct, most likely a cdk.Stack created.
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+the id of the Construct to create.
+
+---
+
+##### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsversion\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsclustername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`output_cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`output_cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsoutputclustername\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`output_config_command\`<sup>Optional</sup> <span data-heading-title=\\"\`output_config_command\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsoutputconfigcommand\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <span data-heading-title=\\"\`role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropssecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsvpcsubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`cluster_handler_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_handler_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsclusterhandlerenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`core_dns_compute_type\`<sup>Optional</sup> <span data-heading-title=\\"\`core_dns_compute_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropscorednscomputetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpoint_access\`<sup>Optional</sup> <span data-heading-title=\\"\`endpoint_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsendpointaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropskubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropskubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropskubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`masters_role\`<sup>Optional</sup> <span data-heading-title=\\"\`masters_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsmastersrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`output_masters_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`output_masters_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsoutputmastersrolearn\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`place_cluster_handler_in_vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsplaceclusterhandlerinvpc\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secrets_encryption_key\`<sup>Optional</sup> <span data-heading-title=\\"\`secrets_encryption_key\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropssecretsencryptionkey\\"></span>
+
+- *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`default_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`default_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsdefaultcapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 2
+
+Number of instances to allocate as an initial capacity for this cluster.
+
+Instance type can be configured through \`defaultCapacityInstanceType\`,
+which defaults to \`m5.large\`.
+
+Use \`cluster.addAutoScalingGroupCapacity\` to add additional customized capacity. Set this
+to \`0\` is you wish to avoid the initial capacity allocation.
+
+---
+
+##### \`default_capacity_instance\`<sup>Optional</sup> <span data-heading-title=\\"\`default_capacity_instance\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsdefaultcapacityinstance\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
+- *Default:* m5.large
+
+The instance type to use for the default capacity.
+
+This will only be taken
+into account if \`defaultCapacity\` is > 0.
+
+---
+
+##### \`default_capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`default_capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsdefaultcapacitytype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.DefaultCapacityType\`](#aws_cdk.aws_eks.DefaultCapacityType)
+- *Default:* NODEGROUP
+
+The default capacity type for the cluster.
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`add_auto_scaling_group_capacity\` <span data-heading-title=\\"\`add_auto_scaling_group_capacity\`\\" data-heading-id=\\"awscdkawseksclusteraddautoscalinggroupcapacity\\"></span>
+
+\`\`\`python
+def add_auto_scaling_group_capacity(id: str, 
+                                    allow_all_outbound: bool = None, 
+                                    associate_public_ip_address: bool = None, 
+                                    auto_scaling_group_name: str = None, 
+                                    block_devices: typing.List[BlockDevice] = None, 
+                                    cooldown: Duration = None, 
+                                    desired_capacity: typing.Union[int, float] = None, 
+                                    group_metrics: typing.List[GroupMetrics] = None, 
+                                    health_check: HealthCheck = None, 
+                                    ignore_unmodified_size_properties: bool = None, 
+                                    instance_monitoring: Monitoring = None, 
+                                    key_name: str = None, 
+                                    max_capacity: typing.Union[int, float] = None, 
+                                    max_instance_lifetime: Duration = None, 
+                                    min_capacity: typing.Union[int, float] = None, 
+                                    new_instances_protected_from_scale_in: bool = None, 
+                                    notifications: typing.List[NotificationConfiguration] = None, 
+                                    signals: Signals = None, 
+                                    spot_price: str = None, 
+                                    update_policy: UpdatePolicy = None, 
+                                    vpc_subnets: SubnetSelection = None, 
+                                    instance_type: InstanceType, 
+                                    bootstrap_enabled: bool = None, 
+                                    bootstrap_options: BootstrapOptions = None, 
+                                    machine_image_type: MachineImageType = None, 
+                                    map_role: bool = None, 
+                                    spot_interrupt_handler: bool = None)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+###### \`allow_all_outbound\`<sup>Optional</sup> <span data-heading-title=\\"\`allow_all_outbound\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsallowalloutbound\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Whether the instances can initiate connections to anywhere by default.
+
+---
+
+###### \`associate_public_ip_address\`<sup>Optional</sup> <span data-heading-title=\\"\`associate_public_ip_address\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsassociatepublicipaddress\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* Use subnet setting.
+
+Whether instances in the Auto Scaling Group should have public IP addresses associated with them.
+
+---
+
+###### \`auto_scaling_group_name\`<sup>Optional</sup> <span data-heading-title=\\"\`auto_scaling_group_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsautoscalinggroupname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Auto generated by CloudFormation
+
+The name of the Auto Scaling group.
+
+This name must be unique per Region per account.
+
+---
+
+###### \`block_devices\`<sup>Optional</sup> <span data-heading-title=\\"\`block_devices\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsblockdevices\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_autoscaling.BlockDevice\`](#aws_cdk.aws_autoscaling.BlockDevice)]
+- *Default:* Uses the block device mapping of the AMI
+
+Specifies how block devices are exposed to the instance. You can specify virtual devices and EBS volumes.
+
+Each instance that is launched has an associated root device volume,
+either an Amazon EBS volume or an instance store volume.
+You can use block device mappings to specify additional EBS volumes or
+instance store volumes to attach to an instance when it is launched.
+
+> https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
+
+---
+
+###### \`cooldown\`<sup>Optional</sup> <span data-heading-title=\\"\`cooldown\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionscooldown\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Default scaling cooldown for this AutoScalingGroup.
+
+---
+
+###### \`desired_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`desired_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsdesiredcapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* minCapacity, and leave unchanged during deployment
+
+Initial amount of instances in the fleet.
+
+If this is set to a number, every deployment will reset the amount of
+instances to this number. It is recommended to leave this value blank.
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-desiredcapacity
+
+---
+
+###### \`group_metrics\`<sup>Optional</sup> <span data-heading-title=\\"\`group_metrics\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsgroupmetrics\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_autoscaling.GroupMetrics\`](#aws_cdk.aws_autoscaling.GroupMetrics)]
+- *Default:* no group metrics will be reported
+
+Enable monitoring for group metrics, these metrics describe the group rather than any of its instances.
+
+To report all group metrics use \`GroupMetrics.all()\`
+Group metrics are reported in a granularity of 1 minute at no additional charge.
+
+---
+
+###### \`health_check\`<sup>Optional</sup> <span data-heading-title=\\"\`health_check\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionshealthcheck\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.HealthCheck\`](#aws_cdk.aws_autoscaling.HealthCheck)
+- *Default:* HealthCheck.ec2 with no grace period
+
+Configuration for health checks.
+
+---
+
+###### \`ignore_unmodified_size_properties\`<sup>Optional</sup> <span data-heading-title=\\"\`ignore_unmodified_size_properties\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsignoreunmodifiedsizeproperties\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+If the ASG has scheduled actions, don't reset unchanged group sizes.
+
+Only used if the ASG has scheduled actions (which may scale your ASG up
+or down regardless of cdk deployments). If true, the size of the group
+will only be reset if it has been changed in the CDK app. If false, the
+sizes will always be changed back to what they were in the CDK app
+on deployment.
+
+---
+
+###### \`instance_monitoring\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_monitoring\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsinstancemonitoring\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.Monitoring\`](#aws_cdk.aws_autoscaling.Monitoring)
+- *Default:* Monitoring.DETAILED
+
+Controls whether instances in this group are launched with detailed or basic monitoring.
+
+When detailed monitoring is enabled, Amazon CloudWatch generates metrics every minute and your account
+is charged a fee. When you disable detailed monitoring, CloudWatch generates metrics every 5 minutes.
+
+> https://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-monitoring.html#enable-as-instance-metrics
+
+---
+
+###### \`key_name\`<sup>Optional</sup> <span data-heading-title=\\"\`key_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionskeyname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* No SSH access will be possible.
+
+Name of SSH keypair to grant access to instances.
+
+---
+
+###### \`max_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`max_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmaxcapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* desiredCapacity
+
+Maximum number of instances in the fleet.
+
+---
+
+###### \`max_instance_lifetime\`<sup>Optional</sup> <span data-heading-title=\\"\`max_instance_lifetime\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmaxinstancelifetime\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* none
+
+The maximum amount of time that an instance can be in service.
+
+The maximum duration applies
+to all current and future instances in the group. As an instance approaches its maximum duration,
+it is terminated and replaced, and cannot be used again.
+
+You must specify a value of at least 604,800 seconds (7 days). To clear a previously set value,
+leave this property undefined.
+
+> https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html
+
+---
+
+###### \`min_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`min_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmincapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 1
+
+Minimum number of instances in the fleet.
+
+---
+
+###### \`new_instances_protected_from_scale_in\`<sup>Optional</sup> <span data-heading-title=\\"\`new_instances_protected_from_scale_in\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsnewinstancesprotectedfromscalein\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Whether newly-launched instances are protected from termination by Amazon EC2 Auto Scaling when scaling in.
+
+By default, Auto Scaling can terminate an instance at any time after launch
+when scaling in an Auto Scaling Group, subject to the group's termination
+policy. However, you may wish to protect newly-launched instances from
+being scaled in if they are going to run critical applications that should
+not be prematurely terminated.
+
+This flag must be enabled if the Auto Scaling Group will be associated with
+an ECS Capacity Provider with managed termination protection.
+
+---
+
+###### \`notifications\`<sup>Optional</sup> <span data-heading-title=\\"\`notifications\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsnotifications\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_autoscaling.NotificationConfiguration\`](#aws_cdk.aws_autoscaling.NotificationConfiguration)]
+- *Default:* No fleet change notifications will be sent.
+
+Configure autoscaling group to send notifications about fleet changes to an SNS topic(s).
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-notificationconfigurations
+
+---
+
+###### \`signals\`<sup>Optional</sup> <span data-heading-title=\\"\`signals\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionssignals\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.Signals\`](#aws_cdk.aws_autoscaling.Signals)
+- *Default:* Do not wait for signals
+
+Configure waiting for signals during deployment.
+
+Use this to pause the CloudFormation deployment to wait for the instances
+in the AutoScalingGroup to report successful startup during
+creation and updates. The UserData script needs to invoke \`cfn-signal\`
+with a success or failure code after it is done setting up the instance.
+
+Without waiting for signals, the CloudFormation deployment will proceed as
+soon as the AutoScalingGroup has been created or updated but before the
+instances in the group have been started.
+
+For example, to have instances wait for an Elastic Load Balancing health check before
+they signal success, add a health-check verification by using the
+cfn-init helper script. For an example, see the verify_instance_health
+command in the Auto Scaling rolling updates sample template:
+
+https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/AutoScaling/AutoScalingRollingUpdates.yaml
+
+---
+
+###### \`spot_price\`<sup>Optional</sup> <span data-heading-title=\\"\`spot_price\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsspotprice\\"></span>
+
+- *Type:* \`str\`
+- *Default:* none
+
+The maximum hourly price (in USD) to be paid for any Spot Instance launched to fulfill the request.
+
+Spot Instances are
+launched when the price you specify exceeds the current Spot market price.
+
+---
+
+###### \`update_policy\`<sup>Optional</sup> <span data-heading-title=\\"\`update_policy\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsupdatepolicy\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.UpdatePolicy\`](#aws_cdk.aws_autoscaling.UpdatePolicy)
+- *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
+
+What to do when an AutoScalingGroup's instance configuration is changed.
+
+This is applied when any of the settings on the ASG are changed that
+affect how the instances should be created (VPC, instance type, startup
+scripts, etc.). It indicates how the existing instances should be
+replaced with new instances matching the new config. By default, nothing
+is done and only new instances are launched with the new config.
+
+---
+
+###### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsvpcsubnets\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* All Private subnets.
+
+Where to place instances within the VPC.
+
+---
+
+###### \`instance_type\`<sup>Required</sup> <span data-heading-title=\\"\`instance_type\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsinstancetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
+
+Instance type of the instances to start.
+
+---
+
+###### \`bootstrap_enabled\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_enabled\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsbootstrapenabled\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Configures the EC2 user-data script for instances in this autoscaling group to bootstrap the node (invoke \`/etc/eks/bootstrap.sh\`) and associate it with the EKS cluster.
+
+If you wish to provide a custom user data script, set this to \`false\` and
+manually invoke \`autoscalingGroup.addUserData()\`.
+
+---
+
+###### \`bootstrap_options\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_options\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsbootstrapoptions\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
+- *Default:* none
+
+EKS node bootstrapping options.
+
+---
+
+###### \`machine_image_type\`<sup>Optional</sup> <span data-heading-title=\\"\`machine_image_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmachineimagetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
+- *Default:* MachineImageType.AMAZON_LINUX_2
+
+Machine image type.
+
+---
+
+###### \`map_role\`<sup>Optional</sup> <span data-heading-title=\\"\`map_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmaprole\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true if the cluster has kubectl enabled (which is the default).
+
+Will automatically update the aws-auth ConfigMap to map the IAM instance role to RBAC.
+
+This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
+
+---
+
+###### \`spot_interrupt_handler\`<sup>Optional</sup> <span data-heading-title=\\"\`spot_interrupt_handler\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsspotinterrupthandler\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Installs the AWS spot instance interrupt handler on the cluster if it's not already added.
+
+Only relevant if \`spotPrice\` is used.
+
+---
+
+##### \`add_cdk8s_chart\` <span data-heading-title=\\"\`add_cdk8s_chart\`\\" data-heading-id=\\"awscdkawseksclusteraddcdk8schart\\"></span>
+
+\`\`\`python
+def add_cdk8s_chart(id: str, 
+                    chart: Construct)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+logical id of this chart.
+
+---
+
+###### \`chart\`<sup>Required</sup> <span data-heading-title=\\"\`chart\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterchart\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+the cdk8s chart.
+
+---
+
+##### \`add_fargate_profile\` <span data-heading-title=\\"\`add_fargate_profile\`\\" data-heading-id=\\"awscdkawseksclusteraddfargateprofile\\"></span>
+
+\`\`\`python
+def add_fargate_profile(id: str, 
+                        selectors: typing.List[Selector], 
+                        fargate_profile_name: str = None, 
+                        pod_execution_role: IRole = None, 
+                        subnet_selection: SubnetSelection = None, 
+                        vpc: IVpc = None)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+the id of this profile.
+
+---
+
+###### \`selectors\`<sup>Required</sup> <span data-heading-title=\\"\`selectors\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionsselectors\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
+
+The selectors to match for pods to use this Fargate profile.
+
+Each selector
+must have an associated namespace. Optionally, you can also specify labels
+for a namespace.
+
+At least one selector is required and you may specify up to five selectors.
+
+---
+
+###### \`fargate_profile_name\`<sup>Optional</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionsfargateprofilename\\"></span>
+
+- *Type:* \`str\`
+- *Default:* generated
+
+The name of the Fargate profile.
+
+---
+
+###### \`pod_execution_role\`<sup>Optional</sup> <span data-heading-title=\\"\`pod_execution_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionspodexecutionrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role will be automatically created
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+> https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html
+
+---
+
+###### \`subnet_selection\`<sup>Optional</sup> <span data-heading-title=\\"\`subnet_selection\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionssubnetselection\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* all private subnets of the VPC are selected.
+
+Select which subnets to launch your pods into.
+
+At this time, pods running
+on Fargate are not assigned public IP addresses, so only private subnets
+(with no direct route to an Internet Gateway) are allowed.
+
+---
+
+###### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* all private subnets used by theEKS cluster
+
+The VPC from which to select subnets to launch your pods into.
+
+By default, all private subnets are selected. You can customize this using
+\`subnetSelection\`.
+
+---
+
+##### \`add_helm_chart\` <span data-heading-title=\\"\`add_helm_chart\`\\" data-heading-id=\\"awscdkawseksclusteraddhelmchart\\"></span>
+
+\`\`\`python
+def add_helm_chart(id: str, 
+                   chart: str, 
+                   create_namespace: bool = None, 
+                   namespace: str = None, 
+                   release: str = None, 
+                   repository: str = None, 
+                   timeout: Duration = None, 
+                   values: typing.Mapping[typing.Any] = None, 
+                   version: str = None, 
+                   wait: bool = None)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+logical id of this chart.
+
+---
+
+###### \`chart\`<sup>Required</sup> <span data-heading-title=\\"\`chart\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionschart\\"></span>
+
+- *Type:* \`str\`
+
+The name of the chart.
+
+---
+
+###### \`create_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`create_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionscreatenamespace\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+###### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+###### \`release\`<sup>Optional</sup> <span data-heading-title=\\"\`release\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsrelease\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+###### \`repository\`<sup>Optional</sup> <span data-heading-title=\\"\`repository\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsrepository\\"></span>
+
+- *Type:* \`str\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+###### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+###### \`values\`<sup>Optional</sup> <span data-heading-title=\\"\`values\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsvalues\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+###### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+###### \`wait\`<sup>Optional</sup> <span data-heading-title=\\"\`wait\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionswait\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+##### \`add_manifest\` <span data-heading-title=\\"\`add_manifest\`\\" data-heading-id=\\"awscdkawseksclusteraddmanifest\\"></span>
+
+\`\`\`python
+def add_manifest(id: str, 
+                 manifest: typing.Mapping[typing.Any])
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+logical id of this manifest.
+
+---
+
+###### \`manifest\`<sup>Required</sup> <span data-heading-title=\\"\`manifest\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclustermanifest\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+
+a list of Kubernetes resource specifications.
+
+---
+
+##### \`add_nodegroup_capacity\` <span data-heading-title=\\"\`add_nodegroup_capacity\`\\" data-heading-id=\\"awscdkawseksclusteraddnodegroupcapacity\\"></span>
+
+\`\`\`python
+def add_nodegroup_capacity(id: str, 
+                           ami_type: NodegroupAmiType = None, 
+                           capacity_type: CapacityType = None, 
+                           desired_size: typing.Union[int, float] = None, 
+                           disk_size: typing.Union[int, float] = None, 
+                           force_update: bool = None, 
+                           instance_types: typing.List[InstanceType] = None, 
+                           labels: typing.Mapping[str] = None, 
+                           launch_template_spec: LaunchTemplateSpec = None, 
+                           max_size: typing.Union[int, float] = None, 
+                           min_size: typing.Union[int, float] = None, 
+                           nodegroup_name: str = None, 
+                           node_role: IRole = None, 
+                           release_version: str = None, 
+                           remote_access: NodegroupRemoteAccess = None, 
+                           subnets: SubnetSelection = None, 
+                           tags: typing.Mapping[str] = None)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+The ID of the nodegroup.
+
+---
+
+###### \`ami_type\`<sup>Optional</sup> <span data-heading-title=\\"\`ami_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsamitype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
+- *Default:* auto-determined from the instanceTypes property.
+
+The AMI type for your node group.
+
+---
+
+###### \`capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionscapacitytype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
+- *Default:* ON_DEMAND
+
+The capacity type of the nodegroup.
+
+---
+
+###### \`desired_size\`<sup>Optional</sup> <span data-heading-title=\\"\`desired_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsdesiredsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 2
+
+The current number of worker nodes that the managed node group should maintain.
+
+If not specified,
+the nodewgroup will initially create \`minSize\` instances.
+
+---
+
+###### \`disk_size\`<sup>Optional</sup> <span data-heading-title=\\"\`disk_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsdisksize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 20
+
+The root device disk size (in GiB) for your node group instances.
+
+---
+
+###### \`force_update\`<sup>Optional</sup> <span data-heading-title=\\"\`force_update\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsforceupdate\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.
+
+If an update fails because pods could not be drained, you can force the update after it fails to terminate the old
+node whether or not any pods are
+running on the node.
+
+---
+
+###### \`instance_types\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_types\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsinstancetypes\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
+- *Default:* t3.medium will be used according to the cloudformation document.
+
+The instance types to use for your node group.
+
+> - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes
+
+---
+
+###### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionslabels\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The Kubernetes labels to be applied to the nodes in the node group when they are created.
+
+---
+
+###### \`launch_template_spec\`<sup>Optional</sup> <span data-heading-title=\\"\`launch_template_spec\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionslaunchtemplatespec\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
+- *Default:* no launch template
+
+Launch template specification used for the nodegroup.
+
+> - https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
+
+---
+
+###### \`max_size\`<sup>Optional</sup> <span data-heading-title=\\"\`max_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsmaxsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* desiredSize
+
+The maximum number of worker nodes that the managed node group can scale out to.
+
+Managed node groups can support up to 100 nodes by default.
+
+---
+
+###### \`min_size\`<sup>Optional</sup> <span data-heading-title=\\"\`min_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsminsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 1
+
+The minimum number of worker nodes that the managed node group can scale in to.
+
+This number must be greater than zero.
+
+---
+
+###### \`nodegroup_name\`<sup>Optional</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsnodegroupname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* resource ID
+
+Name of the Nodegroup.
+
+---
+
+###### \`node_role\`<sup>Optional</sup> <span data-heading-title=\\"\`node_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsnoderole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* None. Auto-generated if not specified.
+
+The IAM role to associate with your node group.
+
+The Amazon EKS worker node kubelet daemon
+makes calls to AWS APIs on your behalf. Worker nodes receive permissions for these API calls through
+an IAM instance profile and associated policies. Before you can launch worker nodes and register them
+into a cluster, you must create an IAM role for those worker nodes to use when they are launched.
+
+---
+
+###### \`release_version\`<sup>Optional</sup> <span data-heading-title=\\"\`release_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsreleaseversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
+
+The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, \`1.14.7-YYYYMMDD\`).
+
+---
+
+###### \`remote_access\`<sup>Optional</sup> <span data-heading-title=\\"\`remote_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsremoteaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
+- *Default:* disabled
+
+The remote access (SSH) configuration to use with your node group.
+
+Disabled by default, however, if you
+specify an Amazon EC2 SSH key but do not specify a source security group when you create a managed node group,
+then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+---
+
+###### \`subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionssubnets\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* private subnets
+
+The subnets to use for the Auto Scaling group that is created for your node group.
+
+By specifying the
+SubnetSelection, the selected subnets will automatically apply required tags i.e.
+\`kubernetes.io/cluster/CLUSTER_NAME\` with a value of \`shared\`, where \`CLUSTER_NAME\` is replaced with
+the name of your cluster.
+
+---
+
+###### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionstags\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The metadata to apply to the node group to assist with categorization and organization.
+
+Each tag consists of
+a key and an optional value, both of which you define. Node group tags do not propagate to any other resources
+associated with the node group, such as the Amazon EC2 instances or subnets.
+
+---
+
+##### \`add_service_account\` <span data-heading-title=\\"\`add_service_account\`\\" data-heading-id=\\"awscdkawseksclusteraddserviceaccount\\"></span>
+
+\`\`\`python
+def add_service_account(id: str, 
+                        name: str = None, 
+                        namespace: str = None)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+###### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountoptionsname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+###### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+##### \`connect_auto_scaling_group_capacity\` <span data-heading-title=\\"\`connect_auto_scaling_group_capacity\`\\" data-heading-id=\\"awscdkawseksclusterconnectautoscalinggroupcapacity\\"></span>
+
+\`\`\`python
+def connect_auto_scaling_group_capacity(auto_scaling_group: AutoScalingGroup, 
+                                        bootstrap_enabled: bool = None, 
+                                        bootstrap_options: BootstrapOptions = None, 
+                                        machine_image_type: MachineImageType = None, 
+                                        map_role: bool = None, 
+                                        spot_interrupt_handler: bool = None)
+\`\`\`
+
+###### \`auto_scaling_group\`<sup>Required</sup> <span data-heading-title=\\"\`auto_scaling_group\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterautoscalinggroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.AutoScalingGroup\`](#aws_cdk.aws_autoscaling.AutoScalingGroup)
+
+[disable-awslint:ref-via-interface].
+
+---
+
+###### \`bootstrap_enabled\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_enabled\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsbootstrapenabled\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Configures the EC2 user-data script for instances in this autoscaling group to bootstrap the node (invoke \`/etc/eks/bootstrap.sh\`) and associate it with the EKS cluster.
+
+If you wish to provide a custom user data script, set this to \`false\` and
+manually invoke \`autoscalingGroup.addUserData()\`.
+
+---
+
+###### \`bootstrap_options\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_options\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsbootstrapoptions\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
+- *Default:* default options
+
+Allows options for node bootstrapping through EC2 user data.
+
+---
+
+###### \`machine_image_type\`<sup>Optional</sup> <span data-heading-title=\\"\`machine_image_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsmachineimagetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
+- *Default:* MachineImageType.AMAZON_LINUX_2
+
+Allow options to specify different machine image type.
+
+---
+
+###### \`map_role\`<sup>Optional</sup> <span data-heading-title=\\"\`map_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsmaprole\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true if the cluster has kubectl enabled (which is the default).
+
+Will automatically update the aws-auth ConfigMap to map the IAM instance role to RBAC.
+
+This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
+
+---
+
+###### \`spot_interrupt_handler\`<sup>Optional</sup> <span data-heading-title=\\"\`spot_interrupt_handler\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsspotinterrupthandler\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Installs the AWS spot instance interrupt handler on the cluster if it's not already added.
+
+Only relevant if \`spotPrice\` is configured on the auto-scaling group.
+
+---
+
+##### \`get_service_load_balancer_address\` <span data-heading-title=\\"\`get_service_load_balancer_address\`\\" data-heading-id=\\"awscdkawseksclustergetserviceloadbalanceraddress\\"></span>
+
+\`\`\`python
+def get_service_load_balancer_address(service_name: str, 
+                                      namespace: str = None, 
+                                      timeout: Duration = None)
+\`\`\`
+
+###### \`service_name\`<sup>Required</sup> <span data-heading-title=\\"\`service_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterservicename\\"></span>
+
+- *Type:* \`str\`
+
+The name of the service.
+
+---
+
+###### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceloadbalanceraddressoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* 'default'
+
+The namespace the service belongs to.
+
+---
+
+###### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceloadbalanceraddressoptionstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Timeout for waiting on the load balancer address.
+
+---
+
+#### Static Functions <span data-heading-title=\\"Static Functions\\" data-heading-id=\\"static-functions\\"></span>
+
+##### \`from_cluster_attributes\` <span data-heading-title=\\"\`from_cluster_attributes\`\\" data-heading-id=\\"awscdkawseksclusterfromclusterattributes\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.Cluster.from_cluster_attributes(scope: Construct, 
+                                        id: str, 
+                                        cluster_name: str, 
+                                        cluster_certificate_authority_data: str = None, 
+                                        cluster_encryption_config_key_arn: str = None, 
+                                        cluster_endpoint: str = None, 
+                                        cluster_security_group_id: str = None, 
+                                        kubectl_environment: typing.Mapping[str] = None, 
+                                        kubectl_layer: ILayerVersion = None, 
+                                        kubectl_memory: Size = None, 
+                                        kubectl_private_subnet_ids: typing.List[str] = None, 
+                                        kubectl_role_arn: str = None, 
+                                        kubectl_security_group_id: str = None, 
+                                        open_id_connect_provider: IOpenIdConnectProvider = None, 
+                                        prune: bool = None, 
+                                        security_group_ids: typing.List[str] = None, 
+                                        vpc: IVpc = None)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+the construct scope, in most cases 'this'.
+
+---
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterid\\"></span>
+
+- *Type:* \`str\`
+
+the id or name to import as.
+
+---
+
+###### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclustername\\"></span>
+
+- *Type:* \`str\`
+
+The physical name of the Cluster.
+
+---
+
+###### \`cluster_certificate_authority_data\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_certificate_authority_data\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclustercertificateauthoritydata\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
+throw an error
+
+The certificate-authority-data for your cluster.
+
+---
+
+###### \`cluster_encryption_config_key_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_encryption_config_key_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclusterencryptionconfigkeyarn\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
+throw an error
+
+Amazon Resource Name (ARN) or alias of the customer master key (CMK).
+
+---
+
+###### \`cluster_endpoint\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_endpoint\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclusterendpoint\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
+
+The API Server endpoint URL.
+
+---
+
+###### \`cluster_security_group_id\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_security_group_id\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclustersecuritygroupid\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
+error
+
+The cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+###### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* no additional variables
+
+Environment variables to use when running \`kubectl\` against this cluster.
+
+---
+
+###### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+- *Default:* a layer bundled with this module.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+This layer
+is used by the kubectl handler to apply manifests and install helm charts.
+
+The handler expects the layer to include the following executables:
+
+    helm/helm
+    kubectl/kubectl
+    awscli/aws
+
+---
+
+###### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+###### \`kubectl_private_subnet_ids\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_private_subnet_ids\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlprivatesubnetids\\"></span>
+
+- *Type:* typing.List[\`str\`]
+- *Default:* k8s endpoint is expected to be accessible publicly
+
+Subnets to host the \`kubectl\` compute resources.
+
+If not specified, the k8s
+endpoint is expected to be accessible publicly.
+
+---
+
+###### \`kubectl_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlrolearn\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified, it not be possible to issue \`kubectl\` commands
+against an imported cluster.
+
+An IAM role with cluster administrator and \\"system:masters\\" permissions.
+
+---
+
+###### \`kubectl_security_group_id\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_security_group_id\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlsecuritygroupid\\"></span>
+
+- *Type:* \`str\`
+- *Default:* k8s endpoint is expected to be accessible publicly
+
+A security group to use for \`kubectl\` execution.
+
+If not specified, the k8s
+endpoint is expected to be accessible publicly.
+
+---
+
+###### \`open_id_connect_provider\`<sup>Optional</sup> <span data-heading-title=\\"\`open_id_connect_provider\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesopenidconnectprovider\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
+- *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
+
+An Open ID Connect provider for this cluster that can be used to configure service accounts.
+
+You can either import an existing provider using \`iam.OpenIdConnectProvider.fromProviderArn\`,
+or create a new provider using \`new eks.OpenIdConnectProvider\`
+
+---
+
+###### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+###### \`security_group_ids\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group_ids\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributessecuritygroupids\\"></span>
+
+- *Type:* typing.List[\`str\`]
+- *Default:* if not specified, no additional security groups will be
+considered in \`cluster.connections\`.
+
+Additional security groups associated with this cluster.
+
+---
+
+###### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* if not specified \`cluster.vpc\` will throw an error
+
+The VPC in which this Cluster was created.
+
+---
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`admin_role\`<sup>Required</sup> <span data-heading-title=\\"\`admin_role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusteradminrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.Role\`](#aws_cdk.aws_iam.Role)
+
+An IAM role with administrative permissions to create or update the cluster.
+
+This role also has \`systems:master\` permissions.
+
+---
+
+##### \`aws_auth\`<sup>Required</sup> <span data-heading-title=\\"\`aws_auth\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterawsauth\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.AwsAuth\`](#aws_cdk.aws_eks.AwsAuth)
+
+Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
+
+---
+
+##### \`cluster_arn\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclusterarn\\"></span>
+
+- *Type:* \`str\`
+
+The AWS generated ARN for the Cluster resource.
+
+---
+
+##### \`cluster_certificate_authority_data\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_certificate_authority_data\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclustercertificateauthoritydata\\"></span>
+
+- *Type:* \`str\`
+
+The certificate-authority-data for your cluster.
+
+---
+
+##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_encryption_config_key_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclusterencryptionconfigkeyarn\\"></span>
+
+- *Type:* \`str\`
+
+Amazon Resource Name (ARN) or alias of the customer master key (CMK).
+
+---
+
+##### \`cluster_endpoint\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_endpoint\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclusterendpoint\\"></span>
+
+- *Type:* \`str\`
+
+The endpoint URL for the Cluster.
+
+This is the URL inside the kubeconfig file to use with kubectl
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclustername\\"></span>
+
+- *Type:* \`str\`
+
+The Name of the created EKS Cluster.
+
+---
+
+##### \`cluster_open_id_connect_issuer\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_open_id_connect_issuer\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclusteropenidconnectissuer\\"></span>
+
+- *Type:* \`str\`
+
+If this cluster is kubectl-enabled, returns the OpenID Connect issuer.
+
+This is because the values is only be retrieved by the API and not exposed
+by CloudFormation. If this cluster is not kubectl-enabled (i.e. uses the
+stock \`CfnCluster\`), this is \`undefined\`.
+
+---
+
+##### \`cluster_open_id_connect_issuer_url\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_open_id_connect_issuer_url\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclusteropenidconnectissuerurl\\"></span>
+
+- *Type:* \`str\`
+
+If this cluster is kubectl-enabled, returns the OpenID Connect issuer url.
+
+This is because the values is only be retrieved by the API and not exposed
+by CloudFormation. If this cluster is not kubectl-enabled (i.e. uses the
+stock \`CfnCluster\`), this is \`undefined\`.
+
+---
+
+##### \`cluster_security_group\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_security_group\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclustersecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+
+The cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`cluster_security_group_id\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_security_group_id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterclustersecuritygroupid\\"></span>
+
+- *Type:* \`str\`
+
+The id of the cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`connections\`<sup>Required</sup> <span data-heading-title=\\"\`connections\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterconnections\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.Connections\`](#aws_cdk.aws_ec2.Connections)
+
+Manages connection rules (Security Group Rules) for the cluster.
+
+---
+
+##### \`open_id_connect_provider\`<sup>Required</sup> <span data-heading-title=\\"\`open_id_connect_provider\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusteropenidconnectprovider\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
+
+An \`OpenIdConnectProvider\` resource associated with this cluster, and which can be used to link this cluster to AWS IAM.
+
+A provider will only be defined if this property is accessed (lazy initialization).
+
+---
+
+##### \`prune\`<sup>Required</sup> <span data-heading-title=\\"\`prune\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterprune\\"></span>
+
+- *Type:* \`bool\`
+
+Determines if Kubernetes resources can be pruned automatically.
+
+---
+
+##### \`role\`<sup>Required</sup> <span data-heading-title=\\"\`role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+IAM role assumed by the EKS Control Plane.
+
+---
+
+##### \`vpc\`<sup>Required</sup> <span data-heading-title=\\"\`vpc\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclustervpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+
+The VPC in which this Cluster was created.
+
+---
+
+##### \`default_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`default_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterdefaultcapacity\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.AutoScalingGroup\`](#aws_cdk.aws_autoscaling.AutoScalingGroup)
+
+The auto scaling group that hosts the default capacity for this cluster.
+
+This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
+\`defaultCapacityType\` is \`EC2\` but default capacity is set to 0.
+
+---
+
+##### \`default_nodegroup\`<sup>Optional</sup> <span data-heading-title=\\"\`default_nodegroup\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterdefaultnodegroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.Nodegroup\`](#aws_cdk.aws_eks.Nodegroup)
+
+The node group that hosts the default capacity for this cluster.
+
+This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
+\`defaultCapacityType\` is \`NODEGROUP\` but default capacity is set to 0.
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterkubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+
+Custom environment variables when running \`kubectl\` against this cluster.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterkubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+
+The AWS Lambda layer that contains \`kubectl\`, \`helm\` and the AWS CLI.
+
+If
+undefined, a SAR app that contains this layer will be used.
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterkubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+
+The amount of memory allocated to the kubectl provider's lambda function.
+
+---
+
+##### \`kubectl_private_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_private_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterkubectlprivatesubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.ISubnet\`](#aws_cdk.aws_ec2.ISubnet)]
+- *Default:* If not specified, the k8s endpoint is expected to be accessible
+publicly.
+
+Subnets to host the \`kubectl\` compute resources.
+
+---
+
+##### \`kubectl_role\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterkubectlrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+An IAM role that can perform kubectl operations against this cluster.
+
+The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
+
+---
+
+##### \`kubectl_security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterkubectlsecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+- *Default:* If not specified, the k8s endpoint is expected to be accessible
+publicly.
+
+A security group to use for \`kubectl\` execution.
+
+---
+
+
+### FargateCluster <span data-heading-title=\\"FargateCluster\\" data-heading-id=\\"awscdkawseksfargatecluster\\"></span>
+
+Defines an EKS cluster that runs entirely on AWS Fargate.
+
+The cluster is created with a default Fargate Profile that matches the
+\\"default\\" and \\"kube-system\\" namespaces. You can add additional profiles using
+\`addFargateProfile\`.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawseksfargateclusterinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.FargateCluster(scope: Construct, 
+                       id: str, 
+                       version: KubernetesVersion, 
+                       cluster_name: str = None, 
+                       output_cluster_name: bool = None, 
+                       output_config_command: bool = None, 
+                       role: IRole = None, 
+                       security_group: ISecurityGroup = None, 
+                       vpc: IVpc = None, 
+                       vpc_subnets: typing.List[SubnetSelection] = None, 
+                       cluster_handler_environment: typing.Mapping[str] = None, 
+                       core_dns_compute_type: CoreDnsComputeType = None, 
+                       endpoint_access: EndpointAccess = None, 
+                       kubectl_environment: typing.Mapping[str] = None, 
+                       kubectl_layer: ILayerVersion = None, 
+                       kubectl_memory: Size = None, 
+                       masters_role: IRole = None, 
+                       output_masters_role_arn: bool = None, 
+                       place_cluster_handler_in_vpc: bool = None, 
+                       prune: bool = None, 
+                       secrets_encryption_key: IKey = None, 
+                       default_profile: FargateProfileOptions = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsversion\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsclustername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`output_cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`output_cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsoutputclustername\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`output_config_command\`<sup>Optional</sup> <span data-heading-title=\\"\`output_config_command\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsoutputconfigcommand\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <span data-heading-title=\\"\`role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropssecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsvpcsubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`cluster_handler_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_handler_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsclusterhandlerenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`core_dns_compute_type\`<sup>Optional</sup> <span data-heading-title=\\"\`core_dns_compute_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropscorednscomputetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpoint_access\`<sup>Optional</sup> <span data-heading-title=\\"\`endpoint_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsendpointaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropskubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropskubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropskubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`masters_role\`<sup>Optional</sup> <span data-heading-title=\\"\`masters_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsmastersrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`output_masters_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`output_masters_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsoutputmastersrolearn\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`place_cluster_handler_in_vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsplaceclusterhandlerinvpc\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secrets_encryption_key\`<sup>Optional</sup> <span data-heading-title=\\"\`secrets_encryption_key\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropssecretsencryptionkey\\"></span>
+
+- *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`default_profile\`<sup>Optional</sup> <span data-heading-title=\\"\`default_profile\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsdefaultprofile\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.FargateProfileOptions\`](#aws_cdk.aws_eks.FargateProfileOptions)
+- *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
+  selectors will be created if this is left undefined.
+
+Fargate Profile to create along with the cluster.
+
+---
+
+
+
+
+
+### FargateProfile <span data-heading-title=\\"FargateProfile\\" data-heading-id=\\"awscdkawseksfargateprofile\\"></span>
+
+- *Implements:* [\`aws_cdk.ITaggable\`](#aws_cdk.ITaggable)
+
+Fargate profiles allows an administrator to declare which pods run on Fargate.
+
+This declaration is done through the profile’s selectors. Each
+profile can have up to five selectors that contain a namespace and optional
+labels. You must define a namespace for every selector. The label field
+consists of multiple optional key-value pairs. Pods that match a selector (by
+matching a namespace for the selector and all of the labels specified in the
+selector) are scheduled on Fargate. If a namespace selector is defined
+without any labels, Amazon EKS will attempt to schedule all pods that run in
+that namespace onto Fargate using the profile. If a to-be-scheduled pod
+matches any of the selectors in the Fargate profile, then that pod is
+scheduled on Fargate.
+
+If a pod matches multiple Fargate profiles, Amazon EKS picks one of the
+matches at random. In this case, you can specify which profile a pod should
+use by adding the following Kubernetes label to the pod specification:
+eks.amazonaws.com/fargate-profile: profile_name. However, the pod must still
+match a selector in that profile in order to be scheduled onto Fargate.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawseksfargateprofileinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.FargateProfile(scope: Construct, 
+                       id: str, 
+                       selectors: typing.List[Selector], 
+                       fargate_profile_name: str = None, 
+                       pod_execution_role: IRole = None, 
+                       subnet_selection: SubnetSelection = None, 
+                       vpc: IVpc = None, 
+                       cluster: Cluster)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilescope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`selectors\`<sup>Required</sup> <span data-heading-title=\\"\`selectors\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropsselectors\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
+
+The selectors to match for pods to use this Fargate profile.
+
+Each selector
+must have an associated namespace. Optionally, you can also specify labels
+for a namespace.
+
+At least one selector is required and you may specify up to five selectors.
+
+---
+
+##### \`fargate_profile_name\`<sup>Optional</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropsfargateprofilename\\"></span>
+
+- *Type:* \`str\`
+- *Default:* generated
+
+The name of the Fargate profile.
+
+---
+
+##### \`pod_execution_role\`<sup>Optional</sup> <span data-heading-title=\\"\`pod_execution_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropspodexecutionrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role will be automatically created
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+> https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html
+
+---
+
+##### \`subnet_selection\`<sup>Optional</sup> <span data-heading-title=\\"\`subnet_selection\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropssubnetselection\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* all private subnets of the VPC are selected.
+
+Select which subnets to launch your pods into.
+
+At this time, pods running
+on Fargate are not assigned public IP addresses, so only private subnets
+(with no direct route to an Internet Gateway) are allowed.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* all private subnets used by theEKS cluster
+
+The VPC from which to select subnets to launch your pods into.
+
+By default, all private subnets are selected. You can customize this using
+\`subnetSelection\`.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
+
+The EKS cluster to apply the Fargate profile to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`fargate_profile_arn\`<sup>Required</sup> <span data-heading-title=\\"\`fargate_profile_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilefargateprofilearn\\"></span>
+
+- *Type:* \`str\`
+
+The full Amazon Resource Name (ARN) of the Fargate profile.
+
+---
+
+##### \`fargate_profile_name\`<sup>Required</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilefargateprofilename\\"></span>
+
+- *Type:* \`str\`
+
+The name of the Fargate profile.
+
+---
+
+##### \`pod_execution_role\`<sup>Required</sup> <span data-heading-title=\\"\`pod_execution_role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepodexecutionrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+---
+
+##### \`tags\`<sup>Required</sup> <span data-heading-title=\\"\`tags\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofiletags\\"></span>
+
+- *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
+
+Resource tags.
+
+---
+
+
+### HelmChart <span data-heading-title=\\"HelmChart\\" data-heading-id=\\"awscdkawsekshelmchart\\"></span>
+
+Represents a helm chart within the Kubernetes system.
+
+Applies/deletes the resources using \`kubectl\` in sync with the resource.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekshelmchartinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.HelmChart(scope: Construct, 
+                  id: str, 
+                  chart: str, 
+                  create_namespace: bool = None, 
+                  namespace: str = None, 
+                  release: str = None, 
+                  repository: str = None, 
+                  timeout: Duration = None, 
+                  values: typing.Mapping[typing.Any] = None, 
+                  version: str = None, 
+                  wait: bool = None, 
+                  cluster: ICluster)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`chart\`<sup>Required</sup> <span data-heading-title=\\"\`chart\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropschart\\"></span>
+
+- *Type:* \`str\`
+
+The name of the chart.
+
+---
+
+##### \`create_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`create_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropscreatenamespace\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+##### \`release\`<sup>Optional</sup> <span data-heading-title=\\"\`release\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsrelease\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+##### \`repository\`<sup>Optional</sup> <span data-heading-title=\\"\`repository\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsrepository\\"></span>
+
+- *Type:* \`str\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+##### \`values\`<sup>Optional</sup> <span data-heading-title=\\"\`values\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsvalues\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+##### \`wait\`<sup>Optional</sup> <span data-heading-title=\\"\`wait\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropswait\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+
+
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`RESOURCE_TYPE\` <span data-heading-title=\\"\`RESOURCE_TYPE\`\\" data-heading-id=\\"awscdkawsekshelmchartresourcetype\\"></span>
+
+- *Type:* \`str\`
+
+The CloudFormation resource type.
+
+---
+
+### KubernetesManifest <span data-heading-title=\\"KubernetesManifest\\" data-heading-id=\\"awscdkawsekskubernetesmanifest\\"></span>
+
+Represents a manifest within the Kubernetes system.
+
+Alternatively, you can use \`cluster.addManifest(resource[, resource, ...])\`
+to define resources on this cluster.
+
+Applies/deletes the manifest using \`kubectl\`.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekskubernetesmanifestinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesManifest(scope: Construct, 
+                           id: str, 
+                           prune: bool = None, 
+                           skip_validation: bool = None, 
+                           cluster: ICluster, 
+                           manifest: typing.List[typing.Mapping[typing.Any]], 
+                           overwrite: bool = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* based on the prune option of the cluster, which is \`true\` unless
+otherwise specified.
+
+When a resource is removed from a Kubernetes manifest, it no longer appears in the manifest, and there is no way to know that this resource needs to be deleted.
+
+To address this, \`kubectl apply\` has a \`--prune\` option which will
+query the cluster for all resources with a specific label and will remove
+all the labeld resources that are not part of the applied manifest. If this
+option is disabled and a resource is removed, it will become \\"orphaned\\" and
+will not be deleted from the cluster.
+
+When this option is enabled (default), the construct will inject a label to
+all Kubernetes resources included in this manifest which will be used to
+prune resources when the manifest changes via \`kubectl apply --prune\`.
+
+The label name will be \`aws.cdk.eks/prune-<ADDR>\` where \`<ADDR>\` is the
+42-char unique address of this construct in the construct tree. Value is
+empty.
+
+> https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+---
+
+##### \`skip_validation\`<sup>Optional</sup> <span data-heading-title=\\"\`skip_validation\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsskipvalidation\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+A flag to signify if the manifest validation should be skipped.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The EKS cluster to apply this manifest to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`manifest\`<sup>Required</sup> <span data-heading-title=\\"\`manifest\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsmanifest\\"></span>
+
+- *Type:* typing.List[typing.Mapping[\`typing.Any\`]]
+
+The manifest to apply.
+
+Consists of any number of child resources.
+
+When the resources are created/updated, this manifest will be applied to the
+cluster through \`kubectl apply\` and when the resources or the stack is
+deleted, the resources in the manifest will be deleted through \`kubectl delete\`.
+
+---
+
+##### \`overwrite\`<sup>Optional</sup> <span data-heading-title=\\"\`overwrite\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsoverwrite\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Overwrite any existing resources.
+
+If this is set, we will use \`kubectl apply\` instead of \`kubectl create\`
+when the resource is created. Otherwise, if there is already a resource
+in the cluster with the same name, the operation will fail.
+
+---
+
+
+
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`RESOURCE_TYPE\` <span data-heading-title=\\"\`RESOURCE_TYPE\`\\" data-heading-id=\\"awscdkawsekskubernetesmanifestresourcetype\\"></span>
+
+- *Type:* \`str\`
+
+The CloudFormation reosurce type.
+
+---
+
+### KubernetesObjectValue <span data-heading-title=\\"KubernetesObjectValue\\" data-heading-id=\\"awscdkawsekskubernetesobjectvalue\\"></span>
+
+Represents a value of a specific object deployed in the cluster.
+
+Use this to fetch any information available by the \`kubectl get\` command.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekskubernetesobjectvalueinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesObjectValue(scope: Construct, 
+                              id: str, 
+                              cluster: ICluster, 
+                              json_path: str, 
+                              object_name: str, 
+                              object_type: str, 
+                              object_namespace: str = None, 
+                              timeout: Duration = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluescope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvalueid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The EKS cluster to fetch attributes from.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`json_path\`<sup>Required</sup> <span data-heading-title=\\"\`json_path\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsjsonpath\\"></span>
+
+- *Type:* \`str\`
+
+JSONPath to the specific value.
+
+> https://kubernetes.io/docs/reference/kubectl/jsonpath/
+
+---
+
+##### \`object_name\`<sup>Required</sup> <span data-heading-title=\\"\`object_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsobjectname\\"></span>
+
+- *Type:* \`str\`
+
+The name of the object to query.
+
+---
+
+##### \`object_type\`<sup>Required</sup> <span data-heading-title=\\"\`object_type\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsobjecttype\\"></span>
+
+- *Type:* \`str\`
+
+The object type to query.
+
+(e.g 'service', 'pod'...)
+
+---
+
+##### \`object_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`object_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsobjectnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* 'default'
+
+The namespace the object belongs to.
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Timeout for waiting on a value.
+
+---
+
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`value\`<sup>Required</sup> <span data-heading-title=\\"\`value\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluevalue\\"></span>
+
+- *Type:* \`str\`
+
+The value as a string token.
+
+---
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`RESOURCE_TYPE\` <span data-heading-title=\\"\`RESOURCE_TYPE\`\\" data-heading-id=\\"awscdkawsekskubernetesobjectvalueresourcetype\\"></span>
+
+- *Type:* \`str\`
+
+The CloudFormation reosurce type.
+
+---
+
+### KubernetesPatch <span data-heading-title=\\"KubernetesPatch\\" data-heading-id=\\"awscdkawsekskubernetespatch\\"></span>
+
+A CloudFormation resource which applies/restores a JSON patch into a Kubernetes resource.
+
+> https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekskubernetespatchinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesPatch(scope: Construct, 
+                        id: str, 
+                        apply_patch: typing.Mapping[typing.Any], 
+                        cluster: ICluster, 
+                        resource_name: str, 
+                        restore_patch: typing.Mapping[typing.Any], 
+                        patch_type: PatchType = None, 
+                        resource_namespace: str = None)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`apply_patch\`<sup>Required</sup> <span data-heading-title=\\"\`apply_patch\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsapplypatch\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+
+The JSON object to pass to \`kubectl patch\` when the resource is created/updated.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The cluster to apply the patch to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`resource_name\`<sup>Required</sup> <span data-heading-title=\\"\`resource_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsresourcename\\"></span>
+
+- *Type:* \`str\`
+
+The full name of the resource to patch (e.g. \`deployment/coredns\`).
+
+---
+
+##### \`restore_patch\`<sup>Required</sup> <span data-heading-title=\\"\`restore_patch\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsrestorepatch\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+
+The JSON object to pass to \`kubectl patch\` when the resource is removed.
+
+---
+
+##### \`patch_type\`<sup>Optional</sup> <span data-heading-title=\\"\`patch_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropspatchtype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.PatchType\`](#aws_cdk.aws_eks.PatchType)
+- *Default:* PatchType.STRATEGIC
+
+The patch type to pass to \`kubectl patch\`.
+
+The default type used by \`kubectl patch\` is \\"strategic\\".
+
+---
+
+##### \`resource_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`resource_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsresourcenamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* \\"default\\"
+
+The kubernetes API namespace.
+
+---
+
+
+
+
+
+### Nodegroup <span data-heading-title=\\"Nodegroup\\" data-heading-id=\\"awscdkawseksnodegroup\\"></span>
+
+- *Implements:* [\`aws_cdk.aws_eks.INodegroup\`](#aws_cdk.aws_eks.INodegroup)
+
+The Nodegroup resource class.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawseksnodegroupinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.Nodegroup(scope: Construct, 
+                  id: str, 
+                  ami_type: NodegroupAmiType = None, 
+                  capacity_type: CapacityType = None, 
+                  desired_size: typing.Union[int, float] = None, 
+                  disk_size: typing.Union[int, float] = None, 
+                  force_update: bool = None, 
+                  instance_types: typing.List[InstanceType] = None, 
+                  labels: typing.Mapping[str] = None, 
+                  launch_template_spec: LaunchTemplateSpec = None, 
+                  max_size: typing.Union[int, float] = None, 
+                  min_size: typing.Union[int, float] = None, 
+                  nodegroup_name: str = None, 
+                  node_role: IRole = None, 
+                  release_version: str = None, 
+                  remote_access: NodegroupRemoteAccess = None, 
+                  subnets: SubnetSelection = None, 
+                  tags: typing.Mapping[str] = None, 
+                  cluster: ICluster)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`ami_type\`<sup>Optional</sup> <span data-heading-title=\\"\`ami_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsamitype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
+- *Default:* auto-determined from the instanceTypes property.
+
+The AMI type for your node group.
+
+---
+
+##### \`capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropscapacitytype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
+- *Default:* ON_DEMAND
+
+The capacity type of the nodegroup.
+
+---
+
+##### \`desired_size\`<sup>Optional</sup> <span data-heading-title=\\"\`desired_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsdesiredsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 2
+
+The current number of worker nodes that the managed node group should maintain.
+
+If not specified,
+the nodewgroup will initially create \`minSize\` instances.
+
+---
+
+##### \`disk_size\`<sup>Optional</sup> <span data-heading-title=\\"\`disk_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsdisksize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 20
+
+The root device disk size (in GiB) for your node group instances.
+
+---
+
+##### \`force_update\`<sup>Optional</sup> <span data-heading-title=\\"\`force_update\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsforceupdate\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.
+
+If an update fails because pods could not be drained, you can force the update after it fails to terminate the old
+node whether or not any pods are
+running on the node.
+
+---
+
+##### \`instance_types\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_types\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsinstancetypes\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
+- *Default:* t3.medium will be used according to the cloudformation document.
+
+The instance types to use for your node group.
+
+> - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes
+
+---
+
+##### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropslabels\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The Kubernetes labels to be applied to the nodes in the node group when they are created.
+
+---
+
+##### \`launch_template_spec\`<sup>Optional</sup> <span data-heading-title=\\"\`launch_template_spec\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropslaunchtemplatespec\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
+- *Default:* no launch template
+
+Launch template specification used for the nodegroup.
+
+> - https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
+
+---
+
+##### \`max_size\`<sup>Optional</sup> <span data-heading-title=\\"\`max_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsmaxsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* desiredSize
+
+The maximum number of worker nodes that the managed node group can scale out to.
+
+Managed node groups can support up to 100 nodes by default.
+
+---
+
+##### \`min_size\`<sup>Optional</sup> <span data-heading-title=\\"\`min_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsminsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 1
+
+The minimum number of worker nodes that the managed node group can scale in to.
+
+This number must be greater than zero.
+
+---
+
+##### \`nodegroup_name\`<sup>Optional</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsnodegroupname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* resource ID
+
+Name of the Nodegroup.
+
+---
+
+##### \`node_role\`<sup>Optional</sup> <span data-heading-title=\\"\`node_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsnoderole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* None. Auto-generated if not specified.
+
+The IAM role to associate with your node group.
+
+The Amazon EKS worker node kubelet daemon
+makes calls to AWS APIs on your behalf. Worker nodes receive permissions for these API calls through
+an IAM instance profile and associated policies. Before you can launch worker nodes and register them
+into a cluster, you must create an IAM role for those worker nodes to use when they are launched.
+
+---
+
+##### \`release_version\`<sup>Optional</sup> <span data-heading-title=\\"\`release_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsreleaseversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
+
+The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, \`1.14.7-YYYYMMDD\`).
+
+---
+
+##### \`remote_access\`<sup>Optional</sup> <span data-heading-title=\\"\`remote_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsremoteaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
+- *Default:* disabled
+
+The remote access (SSH) configuration to use with your node group.
+
+Disabled by default, however, if you
+specify an Amazon EC2 SSH key but do not specify a source security group when you create a managed node group,
+then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropssubnets\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* private subnets
+
+The subnets to use for the Auto Scaling group that is created for your node group.
+
+By specifying the
+SubnetSelection, the selected subnets will automatically apply required tags i.e.
+\`kubernetes.io/cluster/CLUSTER_NAME\` with a value of \`shared\`, where \`CLUSTER_NAME\` is replaced with
+the name of your cluster.
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropstags\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The metadata to apply to the node group to assist with categorization and organization.
+
+Each tag consists of
+a key and an optional value, both of which you define. Node group tags do not propagate to any other resources
+associated with the node group, such as the Amazon EC2 instances or subnets.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+Cluster resource.
+
+---
+
+
+#### Static Functions <span data-heading-title=\\"Static Functions\\" data-heading-id=\\"static-functions\\"></span>
+
+##### \`from_nodegroup_name\` <span data-heading-title=\\"\`from_nodegroup_name\`\\" data-heading-id=\\"awscdkawseksnodegroupfromnodegroupname\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.Nodegroup.from_nodegroup_name(scope: Construct, 
+                                      id: str, 
+                                      nodegroup_name: str)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+###### \`nodegroup_name\`<sup>Required</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupnodegroupname\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupcluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+the Amazon EKS cluster resource.
+
+---
+
+##### \`nodegroup_arn\`<sup>Required</sup> <span data-heading-title=\\"\`nodegroup_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupnodegrouparn\\"></span>
+
+- *Type:* \`str\`
+
+ARN of the nodegroup.
+
+---
+
+##### \`nodegroup_name\`<sup>Required</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupnodegroupname\\"></span>
+
+- *Type:* \`str\`
+
+Nodegroup name.
+
+---
+
+##### \`role\`<sup>Required</sup> <span data-heading-title=\\"\`role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegrouprole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+IAM role of the instance profile for the nodegroup.
+
+---
+
+
+### OpenIdConnectProvider <span data-heading-title=\\"OpenIdConnectProvider\\" data-heading-id=\\"awscdkawseksopenidconnectprovider\\"></span>
+
+IAM OIDC identity providers are entities in IAM that describe an external identity provider (IdP) service that supports the OpenID Connect (OIDC) standard, such as Google or Salesforce.
+
+You use an IAM OIDC identity provider
+when you want to establish trust between an OIDC-compatible IdP and your AWS
+account.
+
+This implementation has default values for thumbprints and clientIds props
+that will be compatible with the eks cluster
+
+> https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawseksopenidconnectproviderinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.OpenIdConnectProvider(scope: Construct, 
+                              id: str, 
+                              url: str)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksopenidconnectproviderscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+The definition scope.
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksopenidconnectproviderid\\"></span>
+
+- *Type:* \`str\`
+
+Construct ID.
+
+---
+
+##### \`url\`<sup>Required</sup> <span data-heading-title=\\"\`url\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksopenidconnectproviderpropsurl\\"></span>
+
+- *Type:* \`str\`
+
+The URL of the identity provider.
+
+The URL must begin with https:// and
+should correspond to the iss claim in the provider's OpenID Connect ID
+tokens. Per the OIDC standard, path components are allowed but query
+parameters are not. Typically the URL consists of only a hostname, like
+https://server.example.org or https://example.com.
+
+You can find your OIDC Issuer URL by:
+aws eks describe-cluster --name %cluster_name% --query \\"cluster.identity.oidc.issuer\\" --output text
+
+---
+
+
+
+
+
+### ServiceAccount <span data-heading-title=\\"ServiceAccount\\" data-heading-id=\\"awscdkawseksserviceaccount\\"></span>
+
+- *Implements:* [\`aws_cdk.aws_iam.IPrincipal\`](#aws_cdk.aws_iam.IPrincipal)
+
+Service Account.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawseksserviceaccountinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.ServiceAccount(scope: Construct, 
+                       id: str, 
+                       name: str = None, 
+                       namespace: str = None, 
+                       cluster: ICluster)
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountscope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountid\\"></span>
+
+- *Type:* \`str\`
+
+---
+
+##### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountpropsname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountpropsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The cluster to apply the patch to.
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`add_to_principal_policy\` <span data-heading-title=\\"\`add_to_principal_policy\`\\" data-heading-id=\\"awscdkawseksserviceaccountaddtoprincipalpolicy\\"></span>
+
+\`\`\`python
+def add_to_principal_policy(statement: PolicyStatement)
+\`\`\`
+
+###### \`statement\`<sup>Required</sup> <span data-heading-title=\\"\`statement\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountstatement\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
+
+---
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`assume_role_action\`<sup>Required</sup> <span data-heading-title=\\"\`assume_role_action\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountassumeroleaction\\"></span>
+
+- *Type:* \`str\`
+
+When this Principal is used in an AssumeRole policy, the action to use.
+
+---
+
+##### \`grant_principal\`<sup>Required</sup> <span data-heading-title=\\"\`grant_principal\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountgrantprincipal\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IPrincipal\`](#aws_cdk.aws_iam.IPrincipal)
+
+The principal to grant permissions to.
+
+---
+
+##### \`policy_fragment\`<sup>Required</sup> <span data-heading-title=\\"\`policy_fragment\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountpolicyfragment\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.PrincipalPolicyFragment\`](#aws_cdk.aws_iam.PrincipalPolicyFragment)
+
+Return the policy fragment that identifies this principal in a Policy.
+
+---
+
+##### \`role\`<sup>Required</sup> <span data-heading-title=\\"\`role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+The role which is linked to the service account.
+
+---
+
+##### \`service_account_name\`<sup>Required</sup> <span data-heading-title=\\"\`service_account_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountserviceaccountname\\"></span>
+
+- *Type:* \`str\`
+
+The name of the service account.
+
+---
+
+##### \`service_account_namespace\`<sup>Required</sup> <span data-heading-title=\\"\`service_account_namespace\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountserviceaccountnamespace\\"></span>
+
+- *Type:* \`str\`
+
+The namespace where the service account is located in.
+
+---
+
+
+## Structs <span data-heading-title=\\"Structs\\" data-heading-id=\\"structs\\"></span>
+
+### AutoScalingGroupCapacityOptions <span data-heading-title=\\"AutoScalingGroupCapacityOptions\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptions\\"></span>
+
+Options for adding worker nodes.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.AutoScalingGroupCapacityOptions(allow_all_outbound: bool = None, 
+                                        associate_public_ip_address: bool = None, 
+                                        auto_scaling_group_name: str = None, 
+                                        block_devices: typing.List[BlockDevice] = None, 
+                                        cooldown: Duration = None, 
+                                        desired_capacity: typing.Union[int, float] = None, 
+                                        group_metrics: typing.List[GroupMetrics] = None, 
+                                        health_check: HealthCheck = None, 
+                                        ignore_unmodified_size_properties: bool = None, 
+                                        instance_monitoring: Monitoring = None, 
+                                        key_name: str = None, 
+                                        max_capacity: typing.Union[int, float] = None, 
+                                        max_instance_lifetime: Duration = None, 
+                                        min_capacity: typing.Union[int, float] = None, 
+                                        new_instances_protected_from_scale_in: bool = None, 
+                                        notifications: typing.List[NotificationConfiguration] = None, 
+                                        signals: Signals = None, 
+                                        spot_price: str = None, 
+                                        update_policy: UpdatePolicy = None, 
+                                        vpc_subnets: SubnetSelection = None, 
+                                        instance_type: InstanceType, 
+                                        bootstrap_enabled: bool = None, 
+                                        bootstrap_options: BootstrapOptions = None, 
+                                        machine_image_type: MachineImageType = None, 
+                                        map_role: bool = None, 
+                                        spot_interrupt_handler: bool = None)
+\`\`\`
+
+##### \`allow_all_outbound\`<sup>Optional</sup> <span data-heading-title=\\"\`allow_all_outbound\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsallowalloutbound\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Whether the instances can initiate connections to anywhere by default.
+
+---
+
+##### \`associate_public_ip_address\`<sup>Optional</sup> <span data-heading-title=\\"\`associate_public_ip_address\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsassociatepublicipaddress\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* Use subnet setting.
+
+Whether instances in the Auto Scaling Group should have public IP addresses associated with them.
+
+---
+
+##### \`auto_scaling_group_name\`<sup>Optional</sup> <span data-heading-title=\\"\`auto_scaling_group_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsautoscalinggroupname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Auto generated by CloudFormation
+
+The name of the Auto Scaling group.
+
+This name must be unique per Region per account.
+
+---
+
+##### \`block_devices\`<sup>Optional</sup> <span data-heading-title=\\"\`block_devices\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsblockdevices\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_autoscaling.BlockDevice\`](#aws_cdk.aws_autoscaling.BlockDevice)]
+- *Default:* Uses the block device mapping of the AMI
+
+Specifies how block devices are exposed to the instance. You can specify virtual devices and EBS volumes.
+
+Each instance that is launched has an associated root device volume,
+either an Amazon EBS volume or an instance store volume.
+You can use block device mappings to specify additional EBS volumes or
+instance store volumes to attach to an instance when it is launched.
+
+> https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
+
+---
+
+##### \`cooldown\`<sup>Optional</sup> <span data-heading-title=\\"\`cooldown\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionscooldown\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Default scaling cooldown for this AutoScalingGroup.
+
+---
+
+##### \`desired_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`desired_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsdesiredcapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* minCapacity, and leave unchanged during deployment
+
+Initial amount of instances in the fleet.
+
+If this is set to a number, every deployment will reset the amount of
+instances to this number. It is recommended to leave this value blank.
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-desiredcapacity
+
+---
+
+##### \`group_metrics\`<sup>Optional</sup> <span data-heading-title=\\"\`group_metrics\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsgroupmetrics\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_autoscaling.GroupMetrics\`](#aws_cdk.aws_autoscaling.GroupMetrics)]
+- *Default:* no group metrics will be reported
+
+Enable monitoring for group metrics, these metrics describe the group rather than any of its instances.
+
+To report all group metrics use \`GroupMetrics.all()\`
+Group metrics are reported in a granularity of 1 minute at no additional charge.
+
+---
+
+##### \`health_check\`<sup>Optional</sup> <span data-heading-title=\\"\`health_check\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionshealthcheck\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.HealthCheck\`](#aws_cdk.aws_autoscaling.HealthCheck)
+- *Default:* HealthCheck.ec2 with no grace period
+
+Configuration for health checks.
+
+---
+
+##### \`ignore_unmodified_size_properties\`<sup>Optional</sup> <span data-heading-title=\\"\`ignore_unmodified_size_properties\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsignoreunmodifiedsizeproperties\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+If the ASG has scheduled actions, don't reset unchanged group sizes.
+
+Only used if the ASG has scheduled actions (which may scale your ASG up
+or down regardless of cdk deployments). If true, the size of the group
+will only be reset if it has been changed in the CDK app. If false, the
+sizes will always be changed back to what they were in the CDK app
+on deployment.
+
+---
+
+##### \`instance_monitoring\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_monitoring\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsinstancemonitoring\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.Monitoring\`](#aws_cdk.aws_autoscaling.Monitoring)
+- *Default:* Monitoring.DETAILED
+
+Controls whether instances in this group are launched with detailed or basic monitoring.
+
+When detailed monitoring is enabled, Amazon CloudWatch generates metrics every minute and your account
+is charged a fee. When you disable detailed monitoring, CloudWatch generates metrics every 5 minutes.
+
+> https://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-monitoring.html#enable-as-instance-metrics
+
+---
+
+##### \`key_name\`<sup>Optional</sup> <span data-heading-title=\\"\`key_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionskeyname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* No SSH access will be possible.
+
+Name of SSH keypair to grant access to instances.
+
+---
+
+##### \`max_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`max_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmaxcapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* desiredCapacity
+
+Maximum number of instances in the fleet.
+
+---
+
+##### \`max_instance_lifetime\`<sup>Optional</sup> <span data-heading-title=\\"\`max_instance_lifetime\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmaxinstancelifetime\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* none
+
+The maximum amount of time that an instance can be in service.
+
+The maximum duration applies
+to all current and future instances in the group. As an instance approaches its maximum duration,
+it is terminated and replaced, and cannot be used again.
+
+You must specify a value of at least 604,800 seconds (7 days). To clear a previously set value,
+leave this property undefined.
+
+> https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html
+
+---
+
+##### \`min_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`min_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmincapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 1
+
+Minimum number of instances in the fleet.
+
+---
+
+##### \`new_instances_protected_from_scale_in\`<sup>Optional</sup> <span data-heading-title=\\"\`new_instances_protected_from_scale_in\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsnewinstancesprotectedfromscalein\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Whether newly-launched instances are protected from termination by Amazon EC2 Auto Scaling when scaling in.
+
+By default, Auto Scaling can terminate an instance at any time after launch
+when scaling in an Auto Scaling Group, subject to the group's termination
+policy. However, you may wish to protect newly-launched instances from
+being scaled in if they are going to run critical applications that should
+not be prematurely terminated.
+
+This flag must be enabled if the Auto Scaling Group will be associated with
+an ECS Capacity Provider with managed termination protection.
+
+---
+
+##### \`notifications\`<sup>Optional</sup> <span data-heading-title=\\"\`notifications\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsnotifications\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_autoscaling.NotificationConfiguration\`](#aws_cdk.aws_autoscaling.NotificationConfiguration)]
+- *Default:* No fleet change notifications will be sent.
+
+Configure autoscaling group to send notifications about fleet changes to an SNS topic(s).
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-notificationconfigurations
+
+---
+
+##### \`signals\`<sup>Optional</sup> <span data-heading-title=\\"\`signals\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionssignals\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.Signals\`](#aws_cdk.aws_autoscaling.Signals)
+- *Default:* Do not wait for signals
+
+Configure waiting for signals during deployment.
+
+Use this to pause the CloudFormation deployment to wait for the instances
+in the AutoScalingGroup to report successful startup during
+creation and updates. The UserData script needs to invoke \`cfn-signal\`
+with a success or failure code after it is done setting up the instance.
+
+Without waiting for signals, the CloudFormation deployment will proceed as
+soon as the AutoScalingGroup has been created or updated but before the
+instances in the group have been started.
+
+For example, to have instances wait for an Elastic Load Balancing health check before
+they signal success, add a health-check verification by using the
+cfn-init helper script. For an example, see the verify_instance_health
+command in the Auto Scaling rolling updates sample template:
+
+https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/AutoScaling/AutoScalingRollingUpdates.yaml
+
+---
+
+##### \`spot_price\`<sup>Optional</sup> <span data-heading-title=\\"\`spot_price\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsspotprice\\"></span>
+
+- *Type:* \`str\`
+- *Default:* none
+
+The maximum hourly price (in USD) to be paid for any Spot Instance launched to fulfill the request.
+
+Spot Instances are
+launched when the price you specify exceeds the current Spot market price.
+
+---
+
+##### \`update_policy\`<sup>Optional</sup> <span data-heading-title=\\"\`update_policy\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsupdatepolicy\\"></span>
+
+- *Type:* [\`aws_cdk.aws_autoscaling.UpdatePolicy\`](#aws_cdk.aws_autoscaling.UpdatePolicy)
+- *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
+
+What to do when an AutoScalingGroup's instance configuration is changed.
+
+This is applied when any of the settings on the ASG are changed that
+affect how the instances should be created (VPC, instance type, startup
+scripts, etc.). It indicates how the existing instances should be
+replaced with new instances matching the new config. By default, nothing
+is done and only new instances are launched with the new config.
+
+---
+
+##### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsvpcsubnets\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* All Private subnets.
+
+Where to place instances within the VPC.
+
+---
+
+##### \`instance_type\`<sup>Required</sup> <span data-heading-title=\\"\`instance_type\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsinstancetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
+
+Instance type of the instances to start.
+
+---
+
+##### \`bootstrap_enabled\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_enabled\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsbootstrapenabled\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Configures the EC2 user-data script for instances in this autoscaling group to bootstrap the node (invoke \`/etc/eks/bootstrap.sh\`) and associate it with the EKS cluster.
+
+If you wish to provide a custom user data script, set this to \`false\` and
+manually invoke \`autoscalingGroup.addUserData()\`.
+
+---
+
+##### \`bootstrap_options\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_options\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsbootstrapoptions\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
+- *Default:* none
+
+EKS node bootstrapping options.
+
+---
+
+##### \`machine_image_type\`<sup>Optional</sup> <span data-heading-title=\\"\`machine_image_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmachineimagetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
+- *Default:* MachineImageType.AMAZON_LINUX_2
+
+Machine image type.
+
+---
+
+##### \`map_role\`<sup>Optional</sup> <span data-heading-title=\\"\`map_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsmaprole\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true if the cluster has kubectl enabled (which is the default).
+
+Will automatically update the aws-auth ConfigMap to map the IAM instance role to RBAC.
+
+This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
+
+---
+
+##### \`spot_interrupt_handler\`<sup>Optional</sup> <span data-heading-title=\\"\`spot_interrupt_handler\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupcapacityoptionsspotinterrupthandler\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Installs the AWS spot instance interrupt handler on the cluster if it's not already added.
+
+Only relevant if \`spotPrice\` is used.
+
+---
+
+### AutoScalingGroupOptions <span data-heading-title=\\"AutoScalingGroupOptions\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptions\\"></span>
+
+Options for adding an AutoScalingGroup as capacity.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.AutoScalingGroupOptions(bootstrap_enabled: bool = None, 
+                                bootstrap_options: BootstrapOptions = None, 
+                                machine_image_type: MachineImageType = None, 
+                                map_role: bool = None, 
+                                spot_interrupt_handler: bool = None)
+\`\`\`
+
+##### \`bootstrap_enabled\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_enabled\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsbootstrapenabled\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Configures the EC2 user-data script for instances in this autoscaling group to bootstrap the node (invoke \`/etc/eks/bootstrap.sh\`) and associate it with the EKS cluster.
+
+If you wish to provide a custom user data script, set this to \`false\` and
+manually invoke \`autoscalingGroup.addUserData()\`.
+
+---
+
+##### \`bootstrap_options\`<sup>Optional</sup> <span data-heading-title=\\"\`bootstrap_options\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsbootstrapoptions\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
+- *Default:* default options
+
+Allows options for node bootstrapping through EC2 user data.
+
+---
+
+##### \`machine_image_type\`<sup>Optional</sup> <span data-heading-title=\\"\`machine_image_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsmachineimagetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
+- *Default:* MachineImageType.AMAZON_LINUX_2
+
+Allow options to specify different machine image type.
+
+---
+
+##### \`map_role\`<sup>Optional</sup> <span data-heading-title=\\"\`map_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsmaprole\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true if the cluster has kubectl enabled (which is the default).
+
+Will automatically update the aws-auth ConfigMap to map the IAM instance role to RBAC.
+
+This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
+
+---
+
+##### \`spot_interrupt_handler\`<sup>Optional</sup> <span data-heading-title=\\"\`spot_interrupt_handler\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksautoscalinggroupoptionsspotinterrupthandler\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Installs the AWS spot instance interrupt handler on the cluster if it's not already added.
+
+Only relevant if \`spotPrice\` is configured on the auto-scaling group.
+
+---
+
+### AwsAuthMapping <span data-heading-title=\\"AwsAuthMapping\\" data-heading-id=\\"awscdkawseksawsauthmapping\\"></span>
+
+AwsAuth mapping.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.AwsAuthMapping(groups: typing.List[str], 
+                       username: str = None)
+\`\`\`
+
+##### \`groups\`<sup>Required</sup> <span data-heading-title=\\"\`groups\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthmappinggroups\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+A list of groups within Kubernetes to which the role is mapped.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`username\`<sup>Optional</sup> <span data-heading-title=\\"\`username\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksawsauthmappingusername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* By default, the user name is the ARN of the IAM role.
+
+The user name within Kubernetes to map to the IAM role.
+
+---
+
+### AwsAuthProps <span data-heading-title=\\"AwsAuthProps\\" data-heading-id=\\"awscdkawseksawsauthprops\\"></span>
+
+Configuration props for the AwsAuth construct.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.AwsAuthProps(cluster: Cluster)
+\`\`\`
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksawsauthpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+### BootstrapOptions <span data-heading-title=\\"BootstrapOptions\\" data-heading-id=\\"awscdkawseksbootstrapoptions\\"></span>
+
+EKS node bootstrapping options.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.BootstrapOptions(additional_args: str = None, 
+                         aws_api_retry_attempts: typing.Union[int, float] = None, 
+                         dns_cluster_ip: str = None, 
+                         docker_config_json: str = None, 
+                         enable_docker_bridge: bool = None, 
+                         kubelet_extra_args: str = None, 
+                         use_max_pods: bool = None)
+\`\`\`
+
+##### \`additional_args\`<sup>Optional</sup> <span data-heading-title=\\"\`additional_args\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksbootstrapoptionsadditionalargs\\"></span>
+
+- *Type:* \`str\`
+- *Default:* none
+
+Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` command.
+
+> https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh
+
+---
+
+##### \`aws_api_retry_attempts\`<sup>Optional</sup> <span data-heading-title=\\"\`aws_api_retry_attempts\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksbootstrapoptionsawsapiretryattempts\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 3
+
+Number of retry attempts for AWS API call (DescribeCluster).
+
+---
+
+##### \`dns_cluster_ip\`<sup>Optional</sup> <span data-heading-title=\\"\`dns_cluster_ip\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksbootstrapoptionsdnsclusterip\\"></span>
+
+- *Type:* \`str\`
+- *Default:* 10.100.0.10 or 172.20.0.10 based on the IP
+address of the primary interface.
+
+Overrides the IP address to use for DNS queries within the cluster.
+
+---
+
+##### \`docker_config_json\`<sup>Optional</sup> <span data-heading-title=\\"\`docker_config_json\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksbootstrapoptionsdockerconfigjson\\"></span>
+
+- *Type:* \`str\`
+- *Default:* none
+
+The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custom config differing from the default one in the EKS AMI.
+
+---
+
+##### \`enable_docker_bridge\`<sup>Optional</sup> <span data-heading-title=\\"\`enable_docker_bridge\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksbootstrapoptionsenabledockerbridge\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Restores the docker default bridge network.
+
+---
+
+##### \`kubelet_extra_args\`<sup>Optional</sup> <span data-heading-title=\\"\`kubelet_extra_args\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksbootstrapoptionskubeletextraargs\\"></span>
+
+- *Type:* \`str\`
+- *Default:* none
+
+Extra arguments to add to the kubelet.
+
+Useful for adding labels or taints.
+
+---
+
+##### \`use_max_pods\`<sup>Optional</sup> <span data-heading-title=\\"\`use_max_pods\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksbootstrapoptionsusemaxpods\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Sets \`--max-pods\` for the kubelet based on the capacity of the EC2 instance.
+
+---
+
+### CfnAddonProps <span data-heading-title=\\"CfnAddonProps\\" data-heading-id=\\"awscdkawsekscfnaddonprops\\"></span>
+
+Properties for defining a \`AWS::EKS::Addon\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnAddonProps(addon_name: str, 
+                      cluster_name: str, 
+                      addon_version: str = None, 
+                      resolve_conflicts: str = None, 
+                      service_account_role_arn: str = None, 
+                      tags: typing.List[CfnTag] = None)
+\`\`\`
+
+##### \`addon_name\`<sup>Required</sup> <span data-heading-title=\\"\`addon_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsaddonname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.AddonName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname)
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername)
+
+---
+
+##### \`addon_version\`<sup>Optional</sup> <span data-heading-title=\\"\`addon_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsaddonversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.AddonVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion)
+
+---
+
+##### \`resolve_conflicts\`<sup>Optional</sup> <span data-heading-title=\\"\`resolve_conflicts\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsresolveconflicts\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ResolveConflicts\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts)
+
+---
+
+##### \`service_account_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`service_account_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropsserviceaccountrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Addon.ServiceAccountRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnaddonpropstags\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
+
+\`AWS::EKS::Addon.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags)
+
+---
+
+### CfnClusterProps <span data-heading-title=\\"CfnClusterProps\\" data-heading-id=\\"awscdkawsekscfnclusterprops\\"></span>
+
+Properties for defining a \`AWS::EKS::Cluster\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnClusterProps(resources_vpc_config: typing.Union[ResourcesVpcConfigProperty, IResolvable], 
+                        role_arn: str, 
+                        encryption_config: typing.Union[IResolvable, typing.List[typing.Union[EncryptionConfigProperty, IResolvable]]] = None, 
+                        kubernetes_network_config: typing.Union[KubernetesNetworkConfigProperty, IResolvable] = None, 
+                        name: str = None, 
+                        version: str = None)
+\`\`\`
+
+##### \`resources_vpc_config\`<sup>Required</sup> <span data-heading-title=\\"\`resources_vpc_config\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsresourcesvpcconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Cluster.ResourcesVpcConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig)
+
+---
+
+##### \`role_arn\`<sup>Required</sup> <span data-heading-title=\\"\`role_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.RoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn)
+
+---
+
+##### \`encryption_config\`<sup>Optional</sup> <span data-heading-title=\\"\`encryption_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsencryptionconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::Cluster.EncryptionConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig)
+
+---
+
+##### \`kubernetes_network_config\`<sup>Optional</sup> <span data-heading-title=\\"\`kubernetes_network_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropskubernetesnetworkconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig)
+
+---
+
+##### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterpropsversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Cluster.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version)
+
+---
+
+### CfnFargateProfileProps <span data-heading-title=\\"CfnFargateProfileProps\\" data-heading-id=\\"awscdkawsekscfnfargateprofileprops\\"></span>
+
+Properties for defining a \`AWS::EKS::FargateProfile\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnFargateProfileProps(cluster_name: str, 
+                               pod_execution_role_arn: str, 
+                               selectors: typing.Union[IResolvable, typing.List[typing.Union[SelectorProperty, IResolvable]]], 
+                               fargate_profile_name: str = None, 
+                               subnets: typing.List[str] = None, 
+                               tags: typing.List[CfnTag] = None)
+\`\`\`
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropsclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername)
+
+---
+
+##### \`pod_execution_role_arn\`<sup>Required</sup> <span data-heading-title=\\"\`pod_execution_role_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropspodexecutionrolearn\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.PodExecutionRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn)
+
+---
+
+##### \`selectors\`<sup>Required</sup> <span data-heading-title=\\"\`selectors\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropsselectors\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::FargateProfile.Selectors\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors)
+
+---
+
+##### \`fargate_profile_name\`<sup>Optional</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropsfargateprofilename\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::FargateProfile.FargateProfileName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropssubnets\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::FargateProfile.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilepropstags\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
+
+\`AWS::EKS::FargateProfile.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags)
+
+---
+
+### CfnNodegroupProps <span data-heading-title=\\"CfnNodegroupProps\\" data-heading-id=\\"awscdkawsekscfnnodegroupprops\\"></span>
+
+Properties for defining a \`AWS::EKS::Nodegroup\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnNodegroupProps(cluster_name: str, 
+                          node_role: str, 
+                          subnets: typing.List[str], 
+                          ami_type: str = None, 
+                          capacity_type: str = None, 
+                          disk_size: typing.Union[int, float] = None, 
+                          force_update_enabled: typing.Union[bool, IResolvable] = None, 
+                          instance_types: typing.List[str] = None, 
+                          labels: typing.Any = None, 
+                          launch_template: typing.Union[LaunchTemplateSpecificationProperty, IResolvable] = None, 
+                          nodegroup_name: str = None, 
+                          release_version: str = None, 
+                          remote_access: typing.Union[RemoteAccessProperty, IResolvable] = None, 
+                          scaling_config: typing.Union[ScalingConfigProperty, IResolvable] = None, 
+                          tags: typing.Any = None, 
+                          taints: typing.Union[IResolvable, typing.List[typing.Union[TaintProperty, IResolvable]]] = None, 
+                          version: str = None)
+\`\`\`
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsclustername\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername)
+
+---
+
+##### \`node_role\`<sup>Required</sup> <span data-heading-title=\\"\`node_role\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsnoderole\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.NodeRole\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole)
+
+---
+
+##### \`subnets\`<sup>Required</sup> <span data-heading-title=\\"\`subnets\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropssubnets\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::Nodegroup.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets)
+
+---
+
+##### \`ami_type\`<sup>Optional</sup> <span data-heading-title=\\"\`ami_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsamitype\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.AmiType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype)
+
+---
+
+##### \`capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropscapacitytype\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.CapacityType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype)
+
+---
+
+##### \`disk_size\`<sup>Optional</sup> <span data-heading-title=\\"\`disk_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsdisksize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+
+\`AWS::EKS::Nodegroup.DiskSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize)
+
+---
+
+##### \`force_update_enabled\`<sup>Optional</sup> <span data-heading-title=\\"\`force_update_enabled\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsforceupdateenabled\\"></span>
+
+- *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled)
+
+---
+
+##### \`instance_types\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_types\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsinstancetypes\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`AWS::EKS::Nodegroup.InstanceTypes\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes)
+
+---
+
+##### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropslabels\\"></span>
+
+- *Type:* \`typing.Any\`
+
+\`AWS::EKS::Nodegroup.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels)
+
+---
+
+##### \`launch_template\`<sup>Optional</sup> <span data-heading-title=\\"\`launch_template\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropslaunchtemplate\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.LaunchTemplate\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate)
+
+---
+
+##### \`nodegroup_name\`<sup>Optional</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsnodegroupname\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.NodegroupName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname)
+
+---
+
+##### \`release_version\`<sup>Optional</sup> <span data-heading-title=\\"\`release_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsreleaseversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.ReleaseVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion)
+
+---
+
+##### \`remote_access\`<sup>Optional</sup> <span data-heading-title=\\"\`remote_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsremoteaccess\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.RemoteAccess\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess)
+
+---
+
+##### \`scaling_config\`<sup>Optional</sup> <span data-heading-title=\\"\`scaling_config\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsscalingconfig\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`AWS::EKS::Nodegroup.ScalingConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropstags\\"></span>
+
+- *Type:* \`typing.Any\`
+
+\`AWS::EKS::Nodegroup.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags)
+
+---
+
+##### \`taints\`<sup>Optional</sup> <span data-heading-title=\\"\`taints\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropstaints\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`AWS::EKS::Nodegroup.Taints\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints)
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouppropsversion\\"></span>
+
+- *Type:* \`str\`
+
+\`AWS::EKS::Nodegroup.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version)
+
+---
+
+### ClusterAttributes <span data-heading-title=\\"ClusterAttributes\\" data-heading-id=\\"awscdkawseksclusterattributes\\"></span>
+
+Attributes for EKS clusters.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.ClusterAttributes(cluster_name: str, 
+                          cluster_certificate_authority_data: str = None, 
+                          cluster_encryption_config_key_arn: str = None, 
+                          cluster_endpoint: str = None, 
+                          cluster_security_group_id: str = None, 
+                          kubectl_environment: typing.Mapping[str] = None, 
+                          kubectl_layer: ILayerVersion = None, 
+                          kubectl_memory: Size = None, 
+                          kubectl_private_subnet_ids: typing.List[str] = None, 
+                          kubectl_role_arn: str = None, 
+                          kubectl_security_group_id: str = None, 
+                          open_id_connect_provider: IOpenIdConnectProvider = None, 
+                          prune: bool = None, 
+                          security_group_ids: typing.List[str] = None, 
+                          vpc: IVpc = None)
+\`\`\`
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclustername\\"></span>
+
+- *Type:* \`str\`
+
+The physical name of the Cluster.
+
+---
+
+##### \`cluster_certificate_authority_data\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_certificate_authority_data\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclustercertificateauthoritydata\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
+throw an error
+
+The certificate-authority-data for your cluster.
+
+---
+
+##### \`cluster_encryption_config_key_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_encryption_config_key_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclusterencryptionconfigkeyarn\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
+throw an error
+
+Amazon Resource Name (ARN) or alias of the customer master key (CMK).
+
+---
+
+##### \`cluster_endpoint\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_endpoint\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclusterendpoint\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
+
+The API Server endpoint URL.
+
+---
+
+##### \`cluster_security_group_id\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_security_group_id\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesclustersecuritygroupid\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
+error
+
+The cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* no additional variables
+
+Environment variables to use when running \`kubectl\` against this cluster.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+- *Default:* a layer bundled with this module.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+This layer
+is used by the kubectl handler to apply manifests and install helm charts.
+
+The handler expects the layer to include the following executables:
+
+    helm/helm
+    kubectl/kubectl
+    awscli/aws
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`kubectl_private_subnet_ids\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_private_subnet_ids\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlprivatesubnetids\\"></span>
+
+- *Type:* typing.List[\`str\`]
+- *Default:* k8s endpoint is expected to be accessible publicly
+
+Subnets to host the \`kubectl\` compute resources.
+
+If not specified, the k8s
+endpoint is expected to be accessible publicly.
+
+---
+
+##### \`kubectl_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlrolearn\\"></span>
+
+- *Type:* \`str\`
+- *Default:* if not specified, it not be possible to issue \`kubectl\` commands
+against an imported cluster.
+
+An IAM role with cluster administrator and \\"system:masters\\" permissions.
+
+---
+
+##### \`kubectl_security_group_id\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_security_group_id\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributeskubectlsecuritygroupid\\"></span>
+
+- *Type:* \`str\`
+- *Default:* k8s endpoint is expected to be accessible publicly
+
+A security group to use for \`kubectl\` execution.
+
+If not specified, the k8s
+endpoint is expected to be accessible publicly.
+
+---
+
+##### \`open_id_connect_provider\`<sup>Optional</sup> <span data-heading-title=\\"\`open_id_connect_provider\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesopenidconnectprovider\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
+- *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
+
+An Open ID Connect provider for this cluster that can be used to configure service accounts.
+
+You can either import an existing provider using \`iam.OpenIdConnectProvider.fromProviderArn\`,
+or create a new provider using \`new eks.OpenIdConnectProvider\`
+
+---
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`security_group_ids\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group_ids\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributessecuritygroupids\\"></span>
+
+- *Type:* typing.List[\`str\`]
+- *Default:* if not specified, no additional security groups will be
+considered in \`cluster.connections\`.
+
+Additional security groups associated with this cluster.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterattributesvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* if not specified \`cluster.vpc\` will throw an error
+
+The VPC in which this Cluster was created.
+
+---
+
+### ClusterOptions <span data-heading-title=\\"ClusterOptions\\" data-heading-id=\\"awscdkawseksclusteroptions\\"></span>
+
+Options for EKS clusters.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.ClusterOptions(version: KubernetesVersion, 
+                       cluster_name: str = None, 
+                       output_cluster_name: bool = None, 
+                       output_config_command: bool = None, 
+                       role: IRole = None, 
+                       security_group: ISecurityGroup = None, 
+                       vpc: IVpc = None, 
+                       vpc_subnets: typing.List[SubnetSelection] = None, 
+                       cluster_handler_environment: typing.Mapping[str] = None, 
+                       core_dns_compute_type: CoreDnsComputeType = None, 
+                       endpoint_access: EndpointAccess = None, 
+                       kubectl_environment: typing.Mapping[str] = None, 
+                       kubectl_layer: ILayerVersion = None, 
+                       kubectl_memory: Size = None, 
+                       masters_role: IRole = None, 
+                       output_masters_role_arn: bool = None, 
+                       place_cluster_handler_in_vpc: bool = None, 
+                       prune: bool = None, 
+                       secrets_encryption_key: IKey = None)
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsversion\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsclustername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`output_cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`output_cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsoutputclustername\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`output_config_command\`<sup>Optional</sup> <span data-heading-title=\\"\`output_config_command\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsoutputconfigcommand\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <span data-heading-title=\\"\`role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionssecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsvpcsubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`cluster_handler_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_handler_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsclusterhandlerenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`core_dns_compute_type\`<sup>Optional</sup> <span data-heading-title=\\"\`core_dns_compute_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionscorednscomputetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpoint_access\`<sup>Optional</sup> <span data-heading-title=\\"\`endpoint_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsendpointaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionskubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionskubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionskubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`masters_role\`<sup>Optional</sup> <span data-heading-title=\\"\`masters_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsmastersrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`output_masters_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`output_masters_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsoutputmastersrolearn\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`place_cluster_handler_in_vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsplaceclusterhandlerinvpc\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secrets_encryption_key\`<sup>Optional</sup> <span data-heading-title=\\"\`secrets_encryption_key\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusteroptionssecretsencryptionkey\\"></span>
+
+- *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+### ClusterProps <span data-heading-title=\\"ClusterProps\\" data-heading-id=\\"awscdkawseksclusterprops\\"></span>
+
+Common configuration props for EKS clusters.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.ClusterProps(version: KubernetesVersion, 
+                     cluster_name: str = None, 
+                     output_cluster_name: bool = None, 
+                     output_config_command: bool = None, 
+                     role: IRole = None, 
+                     security_group: ISecurityGroup = None, 
+                     vpc: IVpc = None, 
+                     vpc_subnets: typing.List[SubnetSelection] = None, 
+                     cluster_handler_environment: typing.Mapping[str] = None, 
+                     core_dns_compute_type: CoreDnsComputeType = None, 
+                     endpoint_access: EndpointAccess = None, 
+                     kubectl_environment: typing.Mapping[str] = None, 
+                     kubectl_layer: ILayerVersion = None, 
+                     kubectl_memory: Size = None, 
+                     masters_role: IRole = None, 
+                     output_masters_role_arn: bool = None, 
+                     place_cluster_handler_in_vpc: bool = None, 
+                     prune: bool = None, 
+                     secrets_encryption_key: IKey = None, 
+                     default_capacity: typing.Union[int, float] = None, 
+                     default_capacity_instance: InstanceType = None, 
+                     default_capacity_type: DefaultCapacityType = None)
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsversion\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsclustername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`output_cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`output_cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsoutputclustername\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`output_config_command\`<sup>Optional</sup> <span data-heading-title=\\"\`output_config_command\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsoutputconfigcommand\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <span data-heading-title=\\"\`role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropssecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsvpcsubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`cluster_handler_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_handler_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsclusterhandlerenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`core_dns_compute_type\`<sup>Optional</sup> <span data-heading-title=\\"\`core_dns_compute_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropscorednscomputetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpoint_access\`<sup>Optional</sup> <span data-heading-title=\\"\`endpoint_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsendpointaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropskubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropskubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropskubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`masters_role\`<sup>Optional</sup> <span data-heading-title=\\"\`masters_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsmastersrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`output_masters_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`output_masters_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsoutputmastersrolearn\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`place_cluster_handler_in_vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsplaceclusterhandlerinvpc\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secrets_encryption_key\`<sup>Optional</sup> <span data-heading-title=\\"\`secrets_encryption_key\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropssecretsencryptionkey\\"></span>
+
+- *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`default_capacity\`<sup>Optional</sup> <span data-heading-title=\\"\`default_capacity\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsdefaultcapacity\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 2
+
+Number of instances to allocate as an initial capacity for this cluster.
+
+Instance type can be configured through \`defaultCapacityInstanceType\`,
+which defaults to \`m5.large\`.
+
+Use \`cluster.addAutoScalingGroupCapacity\` to add additional customized capacity. Set this
+to \`0\` is you wish to avoid the initial capacity allocation.
+
+---
+
+##### \`default_capacity_instance\`<sup>Optional</sup> <span data-heading-title=\\"\`default_capacity_instance\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsdefaultcapacityinstance\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
+- *Default:* m5.large
+
+The instance type to use for the default capacity.
+
+This will only be taken
+into account if \`defaultCapacity\` is > 0.
+
+---
+
+##### \`default_capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`default_capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksclusterpropsdefaultcapacitytype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.DefaultCapacityType\`](#aws_cdk.aws_eks.DefaultCapacityType)
+- *Default:* NODEGROUP
+
+The default capacity type for the cluster.
+
+---
+
+### CommonClusterOptions <span data-heading-title=\\"CommonClusterOptions\\" data-heading-id=\\"awscdkawsekscommonclusteroptions\\"></span>
+
+Options for configuring an EKS cluster.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CommonClusterOptions(version: KubernetesVersion, 
+                             cluster_name: str = None, 
+                             output_cluster_name: bool = None, 
+                             output_config_command: bool = None, 
+                             role: IRole = None, 
+                             security_group: ISecurityGroup = None, 
+                             vpc: IVpc = None, 
+                             vpc_subnets: typing.List[SubnetSelection] = None)
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionsversion\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionsclustername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`output_cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`output_cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionsoutputclustername\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`output_config_command\`<sup>Optional</sup> <span data-heading-title=\\"\`output_config_command\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionsoutputconfigcommand\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <span data-heading-title=\\"\`role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionsrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionssecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscommonclusteroptionsvpcsubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+### EksOptimizedImageProps <span data-heading-title=\\"EksOptimizedImageProps\\" data-heading-id=\\"awscdkawsekseksoptimizedimageprops\\"></span>
+
+Properties for EksOptimizedImage.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.EksOptimizedImageProps(cpu_arch: CpuArch = None, 
+                               kubernetes_version: str = None, 
+                               node_type: NodeType = None)
+\`\`\`
+
+##### \`cpu_arch\`<sup>Optional</sup> <span data-heading-title=\\"\`cpu_arch\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekseksoptimizedimagepropscpuarch\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CpuArch\`](#aws_cdk.aws_eks.CpuArch)
+- *Default:* CpuArch.X86_64
+
+What cpu architecture to retrieve the image for (arm64 or x86_64).
+
+---
+
+##### \`kubernetes_version\`<sup>Optional</sup> <span data-heading-title=\\"\`kubernetes_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekseksoptimizedimagepropskubernetesversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* The latest version
+
+The Kubernetes version to use.
+
+---
+
+##### \`node_type\`<sup>Optional</sup> <span data-heading-title=\\"\`node_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekseksoptimizedimagepropsnodetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodeType\`](#aws_cdk.aws_eks.NodeType)
+- *Default:* NodeType.STANDARD
+
+What instance type to retrieve the image for (standard or GPU-optimized).
+
+---
+
+### EncryptionConfigProperty <span data-heading-title=\\"EncryptionConfigProperty\\" data-heading-id=\\"awscdkawsekscfnclusterencryptionconfigproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnCluster.EncryptionConfigProperty(provider: typing.Union[ProviderProperty, IResolvable] = None, 
+                                            resources: typing.List[str] = None)
+\`\`\`
+
+##### \`provider\`<sup>Optional</sup> <span data-heading-title=\\"\`provider\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterencryptionconfigpropertyprovider\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ProviderProperty\`](#aws_cdk.aws_eks.CfnCluster.ProviderProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
+
+\`CfnCluster.EncryptionConfigProperty.Provider\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-provider](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-provider)
+
+---
+
+##### \`resources\`<sup>Optional</sup> <span data-heading-title=\\"\`resources\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterencryptionconfigpropertyresources\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`CfnCluster.EncryptionConfigProperty.Resources\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-resources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-resources)
+
+---
+
+### FargateClusterProps <span data-heading-title=\\"FargateClusterProps\\" data-heading-id=\\"awscdkawseksfargateclusterprops\\"></span>
+
+Configuration props for EKS Fargate.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.FargateClusterProps(version: KubernetesVersion, 
+                            cluster_name: str = None, 
+                            output_cluster_name: bool = None, 
+                            output_config_command: bool = None, 
+                            role: IRole = None, 
+                            security_group: ISecurityGroup = None, 
+                            vpc: IVpc = None, 
+                            vpc_subnets: typing.List[SubnetSelection] = None, 
+                            cluster_handler_environment: typing.Mapping[str] = None, 
+                            core_dns_compute_type: CoreDnsComputeType = None, 
+                            endpoint_access: EndpointAccess = None, 
+                            kubectl_environment: typing.Mapping[str] = None, 
+                            kubectl_layer: ILayerVersion = None, 
+                            kubectl_memory: Size = None, 
+                            masters_role: IRole = None, 
+                            output_masters_role_arn: bool = None, 
+                            place_cluster_handler_in_vpc: bool = None, 
+                            prune: bool = None, 
+                            secrets_encryption_key: IKey = None, 
+                            default_profile: FargateProfileOptions = None)
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsversion\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsclustername\\"></span>
+
+- *Type:* \`str\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`output_cluster_name\`<sup>Optional</sup> <span data-heading-title=\\"\`output_cluster_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsoutputclustername\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`output_config_command\`<sup>Optional</sup> <span data-heading-title=\\"\`output_config_command\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsoutputconfigcommand\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <span data-heading-title=\\"\`role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropssecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpc_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsvpcsubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`cluster_handler_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`cluster_handler_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsclusterhandlerenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`core_dns_compute_type\`<sup>Optional</sup> <span data-heading-title=\\"\`core_dns_compute_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropscorednscomputetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpoint_access\`<sup>Optional</sup> <span data-heading-title=\\"\`endpoint_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsendpointaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropskubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropskubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropskubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`masters_role\`<sup>Optional</sup> <span data-heading-title=\\"\`masters_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsmastersrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`output_masters_role_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`output_masters_role_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsoutputmastersrolearn\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`place_cluster_handler_in_vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsplaceclusterhandlerinvpc\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secrets_encryption_key\`<sup>Optional</sup> <span data-heading-title=\\"\`secrets_encryption_key\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropssecretsencryptionkey\\"></span>
+
+- *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`default_profile\`<sup>Optional</sup> <span data-heading-title=\\"\`default_profile\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateclusterpropsdefaultprofile\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.FargateProfileOptions\`](#aws_cdk.aws_eks.FargateProfileOptions)
+- *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
+  selectors will be created if this is left undefined.
+
+Fargate Profile to create along with the cluster.
+
+---
+
+### FargateProfileOptions <span data-heading-title=\\"FargateProfileOptions\\" data-heading-id=\\"awscdkawseksfargateprofileoptions\\"></span>
+
+Options for defining EKS Fargate Profiles.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.FargateProfileOptions(selectors: typing.List[Selector], 
+                              fargate_profile_name: str = None, 
+                              pod_execution_role: IRole = None, 
+                              subnet_selection: SubnetSelection = None, 
+                              vpc: IVpc = None)
+\`\`\`
+
+##### \`selectors\`<sup>Required</sup> <span data-heading-title=\\"\`selectors\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionsselectors\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
+
+The selectors to match for pods to use this Fargate profile.
+
+Each selector
+must have an associated namespace. Optionally, you can also specify labels
+for a namespace.
+
+At least one selector is required and you may specify up to five selectors.
+
+---
+
+##### \`fargate_profile_name\`<sup>Optional</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionsfargateprofilename\\"></span>
+
+- *Type:* \`str\`
+- *Default:* generated
+
+The name of the Fargate profile.
+
+---
+
+##### \`pod_execution_role\`<sup>Optional</sup> <span data-heading-title=\\"\`pod_execution_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionspodexecutionrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role will be automatically created
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+> https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html
+
+---
+
+##### \`subnet_selection\`<sup>Optional</sup> <span data-heading-title=\\"\`subnet_selection\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionssubnetselection\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* all private subnets of the VPC are selected.
+
+Select which subnets to launch your pods into.
+
+At this time, pods running
+on Fargate are not assigned public IP addresses, so only private subnets
+(with no direct route to an Internet Gateway) are allowed.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofileoptionsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* all private subnets used by theEKS cluster
+
+The VPC from which to select subnets to launch your pods into.
+
+By default, all private subnets are selected. You can customize this using
+\`subnetSelection\`.
+
+---
+
+### FargateProfileProps <span data-heading-title=\\"FargateProfileProps\\" data-heading-id=\\"awscdkawseksfargateprofileprops\\"></span>
+
+Configuration props for EKS Fargate Profiles.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.FargateProfileProps(selectors: typing.List[Selector], 
+                            fargate_profile_name: str = None, 
+                            pod_execution_role: IRole = None, 
+                            subnet_selection: SubnetSelection = None, 
+                            vpc: IVpc = None, 
+                            cluster: Cluster)
+\`\`\`
+
+##### \`selectors\`<sup>Required</sup> <span data-heading-title=\\"\`selectors\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropsselectors\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
+
+The selectors to match for pods to use this Fargate profile.
+
+Each selector
+must have an associated namespace. Optionally, you can also specify labels
+for a namespace.
+
+At least one selector is required and you may specify up to five selectors.
+
+---
+
+##### \`fargate_profile_name\`<sup>Optional</sup> <span data-heading-title=\\"\`fargate_profile_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropsfargateprofilename\\"></span>
+
+- *Type:* \`str\`
+- *Default:* generated
+
+The name of the Fargate profile.
+
+---
+
+##### \`pod_execution_role\`<sup>Optional</sup> <span data-heading-title=\\"\`pod_execution_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropspodexecutionrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* a role will be automatically created
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+> https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html
+
+---
+
+##### \`subnet_selection\`<sup>Optional</sup> <span data-heading-title=\\"\`subnet_selection\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropssubnetselection\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* all private subnets of the VPC are selected.
+
+Select which subnets to launch your pods into.
+
+At this time, pods running
+on Fargate are not assigned public IP addresses, so only private subnets
+(with no direct route to an Internet Gateway) are allowed.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <span data-heading-title=\\"\`vpc\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropsvpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+- *Default:* all private subnets used by theEKS cluster
+
+The VPC from which to select subnets to launch your pods into.
+
+By default, all private subnets are selected. You can customize this using
+\`subnetSelection\`.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksfargateprofilepropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
+
+The EKS cluster to apply the Fargate profile to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+### HelmChartOptions <span data-heading-title=\\"HelmChartOptions\\" data-heading-id=\\"awscdkawsekshelmchartoptions\\"></span>
+
+Helm Chart options.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.HelmChartOptions(chart: str, 
+                         create_namespace: bool = None, 
+                         namespace: str = None, 
+                         release: str = None, 
+                         repository: str = None, 
+                         timeout: Duration = None, 
+                         values: typing.Mapping[typing.Any] = None, 
+                         version: str = None, 
+                         wait: bool = None)
+\`\`\`
+
+##### \`chart\`<sup>Required</sup> <span data-heading-title=\\"\`chart\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionschart\\"></span>
+
+- *Type:* \`str\`
+
+The name of the chart.
+
+---
+
+##### \`create_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`create_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionscreatenamespace\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+##### \`release\`<sup>Optional</sup> <span data-heading-title=\\"\`release\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsrelease\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+##### \`repository\`<sup>Optional</sup> <span data-heading-title=\\"\`repository\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsrepository\\"></span>
+
+- *Type:* \`str\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+##### \`values\`<sup>Optional</sup> <span data-heading-title=\\"\`values\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsvalues\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+##### \`wait\`<sup>Optional</sup> <span data-heading-title=\\"\`wait\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionswait\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+### HelmChartProps <span data-heading-title=\\"HelmChartProps\\" data-heading-id=\\"awscdkawsekshelmchartprops\\"></span>
+
+Helm Chart properties.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.HelmChartProps(chart: str, 
+                       create_namespace: bool = None, 
+                       namespace: str = None, 
+                       release: str = None, 
+                       repository: str = None, 
+                       timeout: Duration = None, 
+                       values: typing.Mapping[typing.Any] = None, 
+                       version: str = None, 
+                       wait: bool = None, 
+                       cluster: ICluster)
+\`\`\`
+
+##### \`chart\`<sup>Required</sup> <span data-heading-title=\\"\`chart\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropschart\\"></span>
+
+- *Type:* \`str\`
+
+The name of the chart.
+
+---
+
+##### \`create_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`create_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropscreatenamespace\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+##### \`release\`<sup>Optional</sup> <span data-heading-title=\\"\`release\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsrelease\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+##### \`repository\`<sup>Optional</sup> <span data-heading-title=\\"\`repository\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsrepository\\"></span>
+
+- *Type:* \`str\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+##### \`values\`<sup>Optional</sup> <span data-heading-title=\\"\`values\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsvalues\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropsversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+##### \`wait\`<sup>Optional</sup> <span data-heading-title=\\"\`wait\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropswait\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+### KubernetesManifestOptions <span data-heading-title=\\"KubernetesManifestOptions\\" data-heading-id=\\"awscdkawsekskubernetesmanifestoptions\\"></span>
+
+Options for \`KubernetesManifest\`.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesManifestOptions(prune: bool = None, 
+                                  skip_validation: bool = None)
+\`\`\`
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestoptionsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* based on the prune option of the cluster, which is \`true\` unless
+otherwise specified.
+
+When a resource is removed from a Kubernetes manifest, it no longer appears in the manifest, and there is no way to know that this resource needs to be deleted.
+
+To address this, \`kubectl apply\` has a \`--prune\` option which will
+query the cluster for all resources with a specific label and will remove
+all the labeld resources that are not part of the applied manifest. If this
+option is disabled and a resource is removed, it will become \\"orphaned\\" and
+will not be deleted from the cluster.
+
+When this option is enabled (default), the construct will inject a label to
+all Kubernetes resources included in this manifest which will be used to
+prune resources when the manifest changes via \`kubectl apply --prune\`.
+
+The label name will be \`aws.cdk.eks/prune-<ADDR>\` where \`<ADDR>\` is the
+42-char unique address of this construct in the construct tree. Value is
+empty.
+
+> https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+---
+
+##### \`skip_validation\`<sup>Optional</sup> <span data-heading-title=\\"\`skip_validation\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestoptionsskipvalidation\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+A flag to signify if the manifest validation should be skipped.
+
+---
+
+### KubernetesManifestProps <span data-heading-title=\\"KubernetesManifestProps\\" data-heading-id=\\"awscdkawsekskubernetesmanifestprops\\"></span>
+
+Properties for KubernetesManifest.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesManifestProps(prune: bool = None, 
+                                skip_validation: bool = None, 
+                                cluster: ICluster, 
+                                manifest: typing.List[typing.Mapping[typing.Any]], 
+                                overwrite: bool = None)
+\`\`\`
+
+##### \`prune\`<sup>Optional</sup> <span data-heading-title=\\"\`prune\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsprune\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* based on the prune option of the cluster, which is \`true\` unless
+otherwise specified.
+
+When a resource is removed from a Kubernetes manifest, it no longer appears in the manifest, and there is no way to know that this resource needs to be deleted.
+
+To address this, \`kubectl apply\` has a \`--prune\` option which will
+query the cluster for all resources with a specific label and will remove
+all the labeld resources that are not part of the applied manifest. If this
+option is disabled and a resource is removed, it will become \\"orphaned\\" and
+will not be deleted from the cluster.
+
+When this option is enabled (default), the construct will inject a label to
+all Kubernetes resources included in this manifest which will be used to
+prune resources when the manifest changes via \`kubectl apply --prune\`.
+
+The label name will be \`aws.cdk.eks/prune-<ADDR>\` where \`<ADDR>\` is the
+42-char unique address of this construct in the construct tree. Value is
+empty.
+
+> https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+---
+
+##### \`skip_validation\`<sup>Optional</sup> <span data-heading-title=\\"\`skip_validation\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsskipvalidation\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+A flag to signify if the manifest validation should be skipped.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The EKS cluster to apply this manifest to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`manifest\`<sup>Required</sup> <span data-heading-title=\\"\`manifest\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsmanifest\\"></span>
+
+- *Type:* typing.List[typing.Mapping[\`typing.Any\`]]
+
+The manifest to apply.
+
+Consists of any number of child resources.
+
+When the resources are created/updated, this manifest will be applied to the
+cluster through \`kubectl apply\` and when the resources or the stack is
+deleted, the resources in the manifest will be deleted through \`kubectl delete\`.
+
+---
+
+##### \`overwrite\`<sup>Optional</sup> <span data-heading-title=\\"\`overwrite\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesmanifestpropsoverwrite\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* false
+
+Overwrite any existing resources.
+
+If this is set, we will use \`kubectl apply\` instead of \`kubectl create\`
+when the resource is created. Otherwise, if there is already a resource
+in the cluster with the same name, the operation will fail.
+
+---
+
+### KubernetesNetworkConfigProperty <span data-heading-title=\\"KubernetesNetworkConfigProperty\\" data-heading-id=\\"awscdkawsekscfnclusterkubernetesnetworkconfigproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnCluster.KubernetesNetworkConfigProperty(service_ipv4_cidr: str = None)
+\`\`\`
+
+##### \`service_ipv4_cidr\`<sup>Optional</sup> <span data-heading-title=\\"\`service_ipv4_cidr\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterkubernetesnetworkconfigpropertyserviceipv4cidr\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnCluster.KubernetesNetworkConfigProperty.ServiceIpv4Cidr\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html#cfn-eks-cluster-kubernetesnetworkconfig-serviceipv4cidr](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html#cfn-eks-cluster-kubernetesnetworkconfig-serviceipv4cidr)
+
+---
+
+### KubernetesObjectValueProps <span data-heading-title=\\"KubernetesObjectValueProps\\" data-heading-id=\\"awscdkawsekskubernetesobjectvalueprops\\"></span>
+
+Properties for KubernetesObjectValue.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesObjectValueProps(cluster: ICluster, 
+                                   json_path: str, 
+                                   object_name: str, 
+                                   object_type: str, 
+                                   object_namespace: str = None, 
+                                   timeout: Duration = None)
+\`\`\`
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The EKS cluster to fetch attributes from.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`json_path\`<sup>Required</sup> <span data-heading-title=\\"\`json_path\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsjsonpath\\"></span>
+
+- *Type:* \`str\`
+
+JSONPath to the specific value.
+
+> https://kubernetes.io/docs/reference/kubectl/jsonpath/
+
+---
+
+##### \`object_name\`<sup>Required</sup> <span data-heading-title=\\"\`object_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsobjectname\\"></span>
+
+- *Type:* \`str\`
+
+The name of the object to query.
+
+---
+
+##### \`object_type\`<sup>Required</sup> <span data-heading-title=\\"\`object_type\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsobjecttype\\"></span>
+
+- *Type:* \`str\`
+
+The object type to query.
+
+(e.g 'service', 'pod'...)
+
+---
+
+##### \`object_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`object_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropsobjectnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* 'default'
+
+The namespace the object belongs to.
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetesobjectvaluepropstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Timeout for waiting on a value.
+
+---
+
+### KubernetesPatchProps <span data-heading-title=\\"KubernetesPatchProps\\" data-heading-id=\\"awscdkawsekskubernetespatchprops\\"></span>
+
+Properties for KubernetesPatch.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesPatchProps(apply_patch: typing.Mapping[typing.Any], 
+                             cluster: ICluster, 
+                             resource_name: str, 
+                             restore_patch: typing.Mapping[typing.Any], 
+                             patch_type: PatchType = None, 
+                             resource_namespace: str = None)
+\`\`\`
+
+##### \`apply_patch\`<sup>Required</sup> <span data-heading-title=\\"\`apply_patch\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsapplypatch\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+
+The JSON object to pass to \`kubectl patch\` when the resource is created/updated.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The cluster to apply the patch to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`resource_name\`<sup>Required</sup> <span data-heading-title=\\"\`resource_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsresourcename\\"></span>
+
+- *Type:* \`str\`
+
+The full name of the resource to patch (e.g. \`deployment/coredns\`).
+
+---
+
+##### \`restore_patch\`<sup>Required</sup> <span data-heading-title=\\"\`restore_patch\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsrestorepatch\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+
+The JSON object to pass to \`kubectl patch\` when the resource is removed.
+
+---
+
+##### \`patch_type\`<sup>Optional</sup> <span data-heading-title=\\"\`patch_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropspatchtype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.PatchType\`](#aws_cdk.aws_eks.PatchType)
+- *Default:* PatchType.STRATEGIC
+
+The patch type to pass to \`kubectl patch\`.
+
+The default type used by \`kubectl patch\` is \\"strategic\\".
+
+---
+
+##### \`resource_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`resource_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekskubernetespatchpropsresourcenamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* \\"default\\"
+
+The kubernetes API namespace.
+
+---
+
+### LabelProperty <span data-heading-title=\\"LabelProperty\\" data-heading-id=\\"awscdkawsekscfnfargateprofilelabelproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnFargateProfile.LabelProperty(key: str, 
+                                        value: str)
+\`\`\`
+
+##### \`key\`<sup>Required</sup> <span data-heading-title=\\"\`key\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilelabelpropertykey\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnFargateProfile.LabelProperty.Key\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-key](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-key)
+
+---
+
+##### \`value\`<sup>Required</sup> <span data-heading-title=\\"\`value\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofilelabelpropertyvalue\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnFargateProfile.LabelProperty.Value\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-value](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-value)
+
+---
+
+### LaunchTemplateSpec <span data-heading-title=\\"LaunchTemplateSpec\\" data-heading-id=\\"awscdkawsekslaunchtemplatespec\\"></span>
+
+Launch template property specification.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.LaunchTemplateSpec(id: str, 
+                           version: str = None)
+\`\`\`
+
+##### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekslaunchtemplatespecid\\"></span>
+
+- *Type:* \`str\`
+
+The Launch template ID.
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekslaunchtemplatespecversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* the default version of the launch template
+
+The launch template version to be used (optional).
+
+---
+
+### LaunchTemplateSpecificationProperty <span data-heading-title=\\"LaunchTemplateSpecificationProperty\\" data-heading-id=\\"awscdkawsekscfnnodegrouplaunchtemplatespecificationproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty(id: str = None, 
+                                                         name: str = None, 
+                                                         version: str = None)
+\`\`\`
+
+##### \`id\`<sup>Optional</sup> <span data-heading-title=\\"\`id\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouplaunchtemplatespecificationpropertyid\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnNodegroup.LaunchTemplateSpecificationProperty.Id\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-id](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-id)
+
+---
+
+##### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouplaunchtemplatespecificationpropertyname\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnNodegroup.LaunchTemplateSpecificationProperty.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouplaunchtemplatespecificationpropertyversion\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnNodegroup.LaunchTemplateSpecificationProperty.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-version)
+
+---
+
+### NodegroupOptions <span data-heading-title=\\"NodegroupOptions\\" data-heading-id=\\"awscdkawseksnodegroupoptions\\"></span>
+
+The Nodegroup Options for addNodeGroup() method.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.NodegroupOptions(ami_type: NodegroupAmiType = None, 
+                         capacity_type: CapacityType = None, 
+                         desired_size: typing.Union[int, float] = None, 
+                         disk_size: typing.Union[int, float] = None, 
+                         force_update: bool = None, 
+                         instance_types: typing.List[InstanceType] = None, 
+                         labels: typing.Mapping[str] = None, 
+                         launch_template_spec: LaunchTemplateSpec = None, 
+                         max_size: typing.Union[int, float] = None, 
+                         min_size: typing.Union[int, float] = None, 
+                         nodegroup_name: str = None, 
+                         node_role: IRole = None, 
+                         release_version: str = None, 
+                         remote_access: NodegroupRemoteAccess = None, 
+                         subnets: SubnetSelection = None, 
+                         tags: typing.Mapping[str] = None)
+\`\`\`
+
+##### \`ami_type\`<sup>Optional</sup> <span data-heading-title=\\"\`ami_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsamitype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
+- *Default:* auto-determined from the instanceTypes property.
+
+The AMI type for your node group.
+
+---
+
+##### \`capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionscapacitytype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
+- *Default:* ON_DEMAND
+
+The capacity type of the nodegroup.
+
+---
+
+##### \`desired_size\`<sup>Optional</sup> <span data-heading-title=\\"\`desired_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsdesiredsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 2
+
+The current number of worker nodes that the managed node group should maintain.
+
+If not specified,
+the nodewgroup will initially create \`minSize\` instances.
+
+---
+
+##### \`disk_size\`<sup>Optional</sup> <span data-heading-title=\\"\`disk_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsdisksize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 20
+
+The root device disk size (in GiB) for your node group instances.
+
+---
+
+##### \`force_update\`<sup>Optional</sup> <span data-heading-title=\\"\`force_update\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsforceupdate\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.
+
+If an update fails because pods could not be drained, you can force the update after it fails to terminate the old
+node whether or not any pods are
+running on the node.
+
+---
+
+##### \`instance_types\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_types\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsinstancetypes\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
+- *Default:* t3.medium will be used according to the cloudformation document.
+
+The instance types to use for your node group.
+
+> - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes
+
+---
+
+##### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionslabels\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The Kubernetes labels to be applied to the nodes in the node group when they are created.
+
+---
+
+##### \`launch_template_spec\`<sup>Optional</sup> <span data-heading-title=\\"\`launch_template_spec\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionslaunchtemplatespec\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
+- *Default:* no launch template
+
+Launch template specification used for the nodegroup.
+
+> - https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
+
+---
+
+##### \`max_size\`<sup>Optional</sup> <span data-heading-title=\\"\`max_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsmaxsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* desiredSize
+
+The maximum number of worker nodes that the managed node group can scale out to.
+
+Managed node groups can support up to 100 nodes by default.
+
+---
+
+##### \`min_size\`<sup>Optional</sup> <span data-heading-title=\\"\`min_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsminsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 1
+
+The minimum number of worker nodes that the managed node group can scale in to.
+
+This number must be greater than zero.
+
+---
+
+##### \`nodegroup_name\`<sup>Optional</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsnodegroupname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* resource ID
+
+Name of the Nodegroup.
+
+---
+
+##### \`node_role\`<sup>Optional</sup> <span data-heading-title=\\"\`node_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsnoderole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* None. Auto-generated if not specified.
+
+The IAM role to associate with your node group.
+
+The Amazon EKS worker node kubelet daemon
+makes calls to AWS APIs on your behalf. Worker nodes receive permissions for these API calls through
+an IAM instance profile and associated policies. Before you can launch worker nodes and register them
+into a cluster, you must create an IAM role for those worker nodes to use when they are launched.
+
+---
+
+##### \`release_version\`<sup>Optional</sup> <span data-heading-title=\\"\`release_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsreleaseversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
+
+The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, \`1.14.7-YYYYMMDD\`).
+
+---
+
+##### \`remote_access\`<sup>Optional</sup> <span data-heading-title=\\"\`remote_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionsremoteaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
+- *Default:* disabled
+
+The remote access (SSH) configuration to use with your node group.
+
+Disabled by default, however, if you
+specify an Amazon EC2 SSH key but do not specify a source security group when you create a managed node group,
+then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionssubnets\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* private subnets
+
+The subnets to use for the Auto Scaling group that is created for your node group.
+
+By specifying the
+SubnetSelection, the selected subnets will automatically apply required tags i.e.
+\`kubernetes.io/cluster/CLUSTER_NAME\` with a value of \`shared\`, where \`CLUSTER_NAME\` is replaced with
+the name of your cluster.
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupoptionstags\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The metadata to apply to the node group to assist with categorization and organization.
+
+Each tag consists of
+a key and an optional value, both of which you define. Node group tags do not propagate to any other resources
+associated with the node group, such as the Amazon EC2 instances or subnets.
+
+---
+
+### NodegroupProps <span data-heading-title=\\"NodegroupProps\\" data-heading-id=\\"awscdkawseksnodegroupprops\\"></span>
+
+NodeGroup properties interface.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.NodegroupProps(ami_type: NodegroupAmiType = None, 
+                       capacity_type: CapacityType = None, 
+                       desired_size: typing.Union[int, float] = None, 
+                       disk_size: typing.Union[int, float] = None, 
+                       force_update: bool = None, 
+                       instance_types: typing.List[InstanceType] = None, 
+                       labels: typing.Mapping[str] = None, 
+                       launch_template_spec: LaunchTemplateSpec = None, 
+                       max_size: typing.Union[int, float] = None, 
+                       min_size: typing.Union[int, float] = None, 
+                       nodegroup_name: str = None, 
+                       node_role: IRole = None, 
+                       release_version: str = None, 
+                       remote_access: NodegroupRemoteAccess = None, 
+                       subnets: SubnetSelection = None, 
+                       tags: typing.Mapping[str] = None, 
+                       cluster: ICluster)
+\`\`\`
+
+##### \`ami_type\`<sup>Optional</sup> <span data-heading-title=\\"\`ami_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsamitype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
+- *Default:* auto-determined from the instanceTypes property.
+
+The AMI type for your node group.
+
+---
+
+##### \`capacity_type\`<sup>Optional</sup> <span data-heading-title=\\"\`capacity_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropscapacitytype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
+- *Default:* ON_DEMAND
+
+The capacity type of the nodegroup.
+
+---
+
+##### \`desired_size\`<sup>Optional</sup> <span data-heading-title=\\"\`desired_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsdesiredsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 2
+
+The current number of worker nodes that the managed node group should maintain.
+
+If not specified,
+the nodewgroup will initially create \`minSize\` instances.
+
+---
+
+##### \`disk_size\`<sup>Optional</sup> <span data-heading-title=\\"\`disk_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsdisksize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 20
+
+The root device disk size (in GiB) for your node group instances.
+
+---
+
+##### \`force_update\`<sup>Optional</sup> <span data-heading-title=\\"\`force_update\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsforceupdate\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.
+
+If an update fails because pods could not be drained, you can force the update after it fails to terminate the old
+node whether or not any pods are
+running on the node.
+
+---
+
+##### \`instance_types\`<sup>Optional</sup> <span data-heading-title=\\"\`instance_types\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsinstancetypes\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
+- *Default:* t3.medium will be used according to the cloudformation document.
+
+The instance types to use for your node group.
+
+> - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes
+
+---
+
+##### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropslabels\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The Kubernetes labels to be applied to the nodes in the node group when they are created.
+
+---
+
+##### \`launch_template_spec\`<sup>Optional</sup> <span data-heading-title=\\"\`launch_template_spec\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropslaunchtemplatespec\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
+- *Default:* no launch template
+
+Launch template specification used for the nodegroup.
+
+> - https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
+
+---
+
+##### \`max_size\`<sup>Optional</sup> <span data-heading-title=\\"\`max_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsmaxsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* desiredSize
+
+The maximum number of worker nodes that the managed node group can scale out to.
+
+Managed node groups can support up to 100 nodes by default.
+
+---
+
+##### \`min_size\`<sup>Optional</sup> <span data-heading-title=\\"\`min_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsminsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+- *Default:* 1
+
+The minimum number of worker nodes that the managed node group can scale in to.
+
+This number must be greater than zero.
+
+---
+
+##### \`nodegroup_name\`<sup>Optional</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsnodegroupname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* resource ID
+
+Name of the Nodegroup.
+
+---
+
+##### \`node_role\`<sup>Optional</sup> <span data-heading-title=\\"\`node_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsnoderole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+- *Default:* None. Auto-generated if not specified.
+
+The IAM role to associate with your node group.
+
+The Amazon EKS worker node kubelet daemon
+makes calls to AWS APIs on your behalf. Worker nodes receive permissions for these API calls through
+an IAM instance profile and associated policies. Before you can launch worker nodes and register them
+into a cluster, you must create an IAM role for those worker nodes to use when they are launched.
+
+---
+
+##### \`release_version\`<sup>Optional</sup> <span data-heading-title=\\"\`release_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsreleaseversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
+
+The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, \`1.14.7-YYYYMMDD\`).
+
+---
+
+##### \`remote_access\`<sup>Optional</sup> <span data-heading-title=\\"\`remote_access\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropsremoteaccess\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
+- *Default:* disabled
+
+The remote access (SSH) configuration to use with your node group.
+
+Disabled by default, however, if you
+specify an Amazon EC2 SSH key but do not specify a source security group when you create a managed node group,
+then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropssubnets\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
+- *Default:* private subnets
+
+The subnets to use for the Auto Scaling group that is created for your node group.
+
+By specifying the
+SubnetSelection, the selected subnets will automatically apply required tags i.e.
+\`kubernetes.io/cluster/CLUSTER_NAME\` with a value of \`shared\`, where \`CLUSTER_NAME\` is replaced with
+the name of your cluster.
+
+---
+
+##### \`tags\`<sup>Optional</sup> <span data-heading-title=\\"\`tags\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropstags\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* None
+
+The metadata to apply to the node group to assist with categorization and organization.
+
+Each tag consists of
+a key and an optional value, both of which you define. Node group tags do not propagate to any other resources
+associated with the node group, such as the Amazon EC2 instances or subnets.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegrouppropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+Cluster resource.
+
+---
+
+### NodegroupRemoteAccess <span data-heading-title=\\"NodegroupRemoteAccess\\" data-heading-id=\\"awscdkawseksnodegroupremoteaccess\\"></span>
+
+The remote access (SSH) configuration to use with your node group.
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.NodegroupRemoteAccess(ssh_key_name: str, 
+                              source_security_groups: typing.List[ISecurityGroup] = None)
+\`\`\`
+
+##### \`ssh_key_name\`<sup>Required</sup> <span data-heading-title=\\"\`ssh_key_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksnodegroupremoteaccesssshkeyname\\"></span>
+
+- *Type:* \`str\`
+
+The Amazon EC2 SSH key that provides access for SSH communication with the worker nodes in the managed node group.
+
+---
+
+##### \`source_security_groups\`<sup>Optional</sup> <span data-heading-title=\\"\`source_security_groups\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksnodegroupremoteaccesssourcesecuritygroups\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)]
+- *Default:* port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+The security groups that are allowed SSH access (port 22) to the worker nodes.
+
+If you specify an Amazon EC2 SSH
+key but do not specify a source security group when you create a managed node group, then port 22 on the worker
+nodes is opened to the internet (0.0.0.0/0).
+
+---
+
+### OpenIdConnectProviderProps <span data-heading-title=\\"OpenIdConnectProviderProps\\" data-heading-id=\\"awscdkawseksopenidconnectproviderprops\\"></span>
+
+Initialization properties for \`OpenIdConnectProvider\`.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.OpenIdConnectProviderProps(url: str)
+\`\`\`
+
+##### \`url\`<sup>Required</sup> <span data-heading-title=\\"\`url\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksopenidconnectproviderpropsurl\\"></span>
+
+- *Type:* \`str\`
+
+The URL of the identity provider.
+
+The URL must begin with https:// and
+should correspond to the iss claim in the provider's OpenID Connect ID
+tokens. Per the OIDC standard, path components are allowed but query
+parameters are not. Typically the URL consists of only a hostname, like
+https://server.example.org or https://example.com.
+
+You can find your OIDC Issuer URL by:
+aws eks describe-cluster --name %cluster_name% --query \\"cluster.identity.oidc.issuer\\" --output text
+
+---
+
+### ProviderProperty <span data-heading-title=\\"ProviderProperty\\" data-heading-id=\\"awscdkawsekscfnclusterproviderproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnCluster.ProviderProperty(key_arn: str = None)
+\`\`\`
+
+##### \`key_arn\`<sup>Optional</sup> <span data-heading-title=\\"\`key_arn\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterproviderpropertykeyarn\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnCluster.ProviderProperty.KeyArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html#cfn-eks-cluster-provider-keyarn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html#cfn-eks-cluster-provider-keyarn)
+
+---
+
+### RemoteAccessProperty <span data-heading-title=\\"RemoteAccessProperty\\" data-heading-id=\\"awscdkawsekscfnnodegroupremoteaccessproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnNodegroup.RemoteAccessProperty(ec2_ssh_key: str, 
+                                          source_security_groups: typing.List[str] = None)
+\`\`\`
+
+##### \`ec2_ssh_key\`<sup>Required</sup> <span data-heading-title=\\"\`ec2_ssh_key\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupremoteaccesspropertyec2sshkey\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnNodegroup.RemoteAccessProperty.Ec2SshKey\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-ec2sshkey](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-ec2sshkey)
+
+---
+
+##### \`source_security_groups\`<sup>Optional</sup> <span data-heading-title=\\"\`source_security_groups\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupremoteaccesspropertysourcesecuritygroups\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`CfnNodegroup.RemoteAccessProperty.SourceSecurityGroups\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-sourcesecuritygroups](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-sourcesecuritygroups)
+
+---
+
+### ResourcesVpcConfigProperty <span data-heading-title=\\"ResourcesVpcConfigProperty\\" data-heading-id=\\"awscdkawsekscfnclusterresourcesvpcconfigproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnCluster.ResourcesVpcConfigProperty(subnet_ids: typing.List[str], 
+                                              security_group_ids: typing.List[str] = None)
+\`\`\`
+
+##### \`subnet_ids\`<sup>Required</sup> <span data-heading-title=\\"\`subnet_ids\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterresourcesvpcconfigpropertysubnetids\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`CfnCluster.ResourcesVpcConfigProperty.SubnetIds\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-subnetids](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-subnetids)
+
+---
+
+##### \`security_group_ids\`<sup>Optional</sup> <span data-heading-title=\\"\`security_group_ids\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnclusterresourcesvpcconfigpropertysecuritygroupids\\"></span>
+
+- *Type:* typing.List[\`str\`]
+
+\`CfnCluster.ResourcesVpcConfigProperty.SecurityGroupIds\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-securitygroupids](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-securitygroupids)
+
+---
+
+### ScalingConfigProperty <span data-heading-title=\\"ScalingConfigProperty\\" data-heading-id=\\"awscdkawsekscfnnodegroupscalingconfigproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnNodegroup.ScalingConfigProperty(desired_size: typing.Union[int, float] = None, 
+                                           max_size: typing.Union[int, float] = None, 
+                                           min_size: typing.Union[int, float] = None)
+\`\`\`
+
+##### \`desired_size\`<sup>Optional</sup> <span data-heading-title=\\"\`desired_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupscalingconfigpropertydesiredsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+
+\`CfnNodegroup.ScalingConfigProperty.DesiredSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-desiredsize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-desiredsize)
+
+---
+
+##### \`max_size\`<sup>Optional</sup> <span data-heading-title=\\"\`max_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupscalingconfigpropertymaxsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+
+\`CfnNodegroup.ScalingConfigProperty.MaxSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-maxsize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-maxsize)
+
+---
+
+##### \`min_size\`<sup>Optional</sup> <span data-heading-title=\\"\`min_size\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegroupscalingconfigpropertyminsize\\"></span>
+
+- *Type:* \`typing.Union[int, float]\`
+
+\`CfnNodegroup.ScalingConfigProperty.MinSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-minsize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-minsize)
+
+---
+
+### Selector <span data-heading-title=\\"Selector\\" data-heading-id=\\"awscdkawseksselector\\"></span>
+
+Fargate profile selector.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.Selector(namespace: str, 
+                 labels: typing.Mapping[str] = None)
+\`\`\`
+
+##### \`namespace\`<sup>Required</sup> <span data-heading-title=\\"\`namespace\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksselectornamespace\\"></span>
+
+- *Type:* \`str\`
+
+The Kubernetes namespace that the selector should match.
+
+You must specify a namespace for a selector. The selector only matches pods
+that are created in this namespace, but you can create multiple selectors
+to target multiple namespaces.
+
+---
+
+##### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksselectorlabels\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+- *Default:* all pods within the namespace will be selected.
+
+The Kubernetes labels that the selector should match.
+
+A pod must contain
+all of the labels that are specified in the selector for it to be
+considered a match.
+
+---
+
+### SelectorProperty <span data-heading-title=\\"SelectorProperty\\" data-heading-id=\\"awscdkawsekscfnfargateprofileselectorproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnFargateProfile.SelectorProperty(namespace: str, 
+                                           labels: typing.Union[IResolvable, typing.List[typing.Union[LabelProperty, IResolvable]]] = None)
+\`\`\`
+
+##### \`namespace\`<sup>Required</sup> <span data-heading-title=\\"\`namespace\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofileselectorpropertynamespace\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnFargateProfile.SelectorProperty.Namespace\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-namespace](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-namespace)
+
+---
+
+##### \`labels\`<sup>Optional</sup> <span data-heading-title=\\"\`labels\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnfargateprofileselectorpropertylabels\\"></span>
+
+- *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.LabelProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.LabelProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
+
+\`CfnFargateProfile.SelectorProperty.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-labels)
+
+---
+
+### ServiceAccountOptions <span data-heading-title=\\"ServiceAccountOptions\\" data-heading-id=\\"awscdkawseksserviceaccountoptions\\"></span>
+
+Options for \`ServiceAccount\`.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.ServiceAccountOptions(name: str = None, 
+                              namespace: str = None)
+\`\`\`
+
+##### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountoptionsname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+### ServiceAccountProps <span data-heading-title=\\"ServiceAccountProps\\" data-heading-id=\\"awscdkawseksserviceaccountprops\\"></span>
+
+Properties for defining service accounts.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.ServiceAccountProps(name: str = None, 
+                            namespace: str = None, 
+                            cluster: ICluster)
+\`\`\`
+
+##### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountpropsname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountpropsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <span data-heading-title=\\"\`cluster\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountpropscluster\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+The cluster to apply the patch to.
+
+---
+
+### ServiceLoadBalancerAddressOptions <span data-heading-title=\\"ServiceLoadBalancerAddressOptions\\" data-heading-id=\\"awscdkawseksserviceloadbalanceraddressoptions\\"></span>
+
+Options for fetching a ServiceLoadBalancerAddress.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.ServiceLoadBalancerAddressOptions(namespace: str = None, 
+                                          timeout: Duration = None)
+\`\`\`
+
+##### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceloadbalanceraddressoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* 'default'
+
+The namespace the service belongs to.
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceloadbalanceraddressoptionstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Timeout for waiting on the load balancer address.
+
+---
+
+### TaintProperty <span data-heading-title=\\"TaintProperty\\" data-heading-id=\\"awscdkawsekscfnnodegrouptaintproperty\\"></span>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html)
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"object-objectinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.CfnNodegroup.TaintProperty(effect: str = None, 
+                                   key: str = None, 
+                                   value: str = None)
+\`\`\`
+
+##### \`effect\`<sup>Optional</sup> <span data-heading-title=\\"\`effect\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouptaintpropertyeffect\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnNodegroup.TaintProperty.Effect\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-effect](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-effect)
+
+---
+
+##### \`key\`<sup>Optional</sup> <span data-heading-title=\\"\`key\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouptaintpropertykey\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnNodegroup.TaintProperty.Key\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-key](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-key)
+
+---
+
+##### \`value\`<sup>Optional</sup> <span data-heading-title=\\"\`value\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekscfnnodegrouptaintpropertyvalue\\"></span>
+
+- *Type:* \`str\`
+
+\`CfnNodegroup.TaintProperty.Value\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-value](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-value)
+
+---
+
+## Classes <span data-heading-title=\\"Classes\\" data-heading-id=\\"classes\\"></span>
+
+### EksOptimizedImage <span data-heading-title=\\"EksOptimizedImage\\" data-heading-id=\\"awscdkawsekseksoptimizedimage\\"></span>
+
+- *Implements:* [\`aws_cdk.aws_ec2.IMachineImage\`](#aws_cdk.aws_ec2.IMachineImage)
+
+Construct an Amazon Linux 2 image from the latest EKS Optimized AMI published in SSM.
+
+#### Initializer <span data-heading-title=\\"Initializer\\" data-heading-id=\\"awscdkawsekseksoptimizedimageinitializer\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.EksOptimizedImage(cpu_arch: CpuArch = None, 
+                          kubernetes_version: str = None, 
+                          node_type: NodeType = None)
+\`\`\`
+
+##### \`cpu_arch\`<sup>Optional</sup> <span data-heading-title=\\"\`cpu_arch\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekseksoptimizedimagepropscpuarch\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.CpuArch\`](#aws_cdk.aws_eks.CpuArch)
+- *Default:* CpuArch.X86_64
+
+What cpu architecture to retrieve the image for (arm64 or x86_64).
+
+---
+
+##### \`kubernetes_version\`<sup>Optional</sup> <span data-heading-title=\\"\`kubernetes_version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekseksoptimizedimagepropskubernetesversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* The latest version
+
+The Kubernetes version to use.
+
+---
+
+##### \`node_type\`<sup>Optional</sup> <span data-heading-title=\\"\`node_type\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekseksoptimizedimagepropsnodetype\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.NodeType\`](#aws_cdk.aws_eks.NodeType)
+- *Default:* NodeType.STANDARD
+
+What instance type to retrieve the image for (standard or GPU-optimized).
+
+---
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`get_image\` <span data-heading-title=\\"\`get_image\`\\" data-heading-id=\\"awscdkawsekseksoptimizedimagegetimage\\"></span>
+
+\`\`\`python
+def get_image(scope: Construct)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <span data-heading-title=\\"\`scope\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekseksoptimizedimagescope\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+---
+
+
+
+
+### EndpointAccess <span data-heading-title=\\"EndpointAccess\\" data-heading-id=\\"awscdkawseksendpointaccess\\"></span>
+
+Endpoint access characteristics.
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`only_from\` <span data-heading-title=\\"\`only_from\`\\" data-heading-id=\\"awscdkawseksendpointaccessonlyfrom\\"></span>
+
+\`\`\`python
+def only_from(cidr: str)
+\`\`\`
+
+###### \`cidr\`<sup>Required</sup> <span data-heading-title=\\"\`cidr\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksendpointaccesscidr\\"></span>
+
+- *Type:* \`str\`
+
+CIDR blocks.
+
+---
+
+
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`PRIVATE\` <span data-heading-title=\\"\`PRIVATE\`\\" data-heading-id=\\"awscdkawseksendpointaccessprivate\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+
+The cluster endpoint is only accessible through your VPC.
+
+Worker node traffic to the endpoint will stay within your VPC.
+
+---
+
+##### \`PUBLIC\` <span data-heading-title=\\"\`PUBLIC\`\\" data-heading-id=\\"awscdkawseksendpointaccesspublic\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+
+The cluster endpoint is accessible from outside of your VPC.
+
+Worker node traffic will leave your VPC to connect to the endpoint.
+
+By default, the endpoint is exposed to all adresses. You can optionally limit the CIDR blocks that can access the public endpoint using the \`PUBLIC.onlyFrom\` method.
+If you limit access to specific CIDR blocks, you must ensure that the CIDR blocks that you
+specify include the addresses that worker nodes and Fargate pods (if you use them)
+access the public endpoint from.
+
+---
+
+##### \`PUBLIC_AND_PRIVATE\` <span data-heading-title=\\"\`PUBLIC_AND_PRIVATE\`\\" data-heading-id=\\"awscdkawseksendpointaccesspublicandprivate\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
+
+The cluster endpoint is accessible from outside of your VPC.
+
+Worker node traffic to the endpoint will stay within your VPC.
+
+By default, the endpoint is exposed to all adresses. You can optionally limit the CIDR blocks that can access the public endpoint using the \`PUBLIC_AND_PRIVATE.onlyFrom\` method.
+If you limit access to specific CIDR blocks, you must ensure that the CIDR blocks that you
+specify include the addresses that worker nodes and Fargate pods (if you use them)
+access the public endpoint from.
+
+---
+
+### KubernetesVersion <span data-heading-title=\\"KubernetesVersion\\" data-heading-id=\\"awscdkawsekskubernetesversion\\"></span>
+
+Kubernetes cluster version.
+
+
+#### Static Functions <span data-heading-title=\\"Static Functions\\" data-heading-id=\\"static-functions\\"></span>
+
+##### \`of\` <span data-heading-title=\\"\`of\`\\" data-heading-id=\\"awscdkawsekskubernetesversionof\\"></span>
+
+\`\`\`python
+from aws_cdk import aws_eks
+
+aws_eks.KubernetesVersion.of(version: str)
+\`\`\`
+
+###### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesversionversion\\"></span>
+
+- *Type:* \`str\`
+
+custom version number.
+
+---
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`version\`<sup>Required</sup> <span data-heading-title=\\"\`version\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekskubernetesversionversion\\"></span>
+
+- *Type:* \`str\`
+
+cluster version number.
+
+---
+
+#### Constants <span data-heading-title=\\"Constants\\" data-heading-id=\\"constants\\"></span>
+
+##### \`V1_14\` <span data-heading-title=\\"\`V1_14\`\\" data-heading-id=\\"awscdkawsekskubernetesversionv114\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+Kubernetes version 1.14.
+
+---
+
+##### \`V1_15\` <span data-heading-title=\\"\`V1_15\`\\" data-heading-id=\\"awscdkawsekskubernetesversionv115\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+Kubernetes version 1.15.
+
+---
+
+##### \`V1_16\` <span data-heading-title=\\"\`V1_16\`\\" data-heading-id=\\"awscdkawsekskubernetesversionv116\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+Kubernetes version 1.16.
+
+---
+
+##### \`V1_17\` <span data-heading-title=\\"\`V1_17\`\\" data-heading-id=\\"awscdkawsekskubernetesversionv117\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+Kubernetes version 1.17.
+
+---
+
+##### \`V1_18\` <span data-heading-title=\\"\`V1_18\`\\" data-heading-id=\\"awscdkawsekskubernetesversionv118\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+Kubernetes version 1.18.
+
+---
+
+##### \`V1_19\` <span data-heading-title=\\"\`V1_19\`\\" data-heading-id=\\"awscdkawsekskubernetesversionv119\\"></span>
+
+- *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
+
+Kubernetes version 1.19.
+
+---
+
+## Protocols <span data-heading-title=\\"Protocols\\" data-heading-id=\\"protocols\\"></span>
+
+### ICluster <span data-heading-title=\\"ICluster\\" data-heading-id=\\"awscdkawseksicluster\\"></span>
+
+- *Extends:* [\`aws_cdk.IResource\`](#aws_cdk.IResource), [\`aws_cdk.aws_ec2.IConnectable\`](#aws_cdk.aws_ec2.IConnectable)
+
+- *Implemented By:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster), [\`aws_cdk.aws_eks.FargateCluster\`](#aws_cdk.aws_eks.FargateCluster), [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
+
+An EKS cluster.
+
+#### Methods <span data-heading-title=\\"Methods\\" data-heading-id=\\"methods\\"></span>
+
+##### \`add_cdk8s_chart\` <span data-heading-title=\\"\`add_cdk8s_chart\`\\" data-heading-id=\\"awscdkawseksiclusteraddcdk8schart\\"></span>
+
+\`\`\`python
+def add_cdk8s_chart(id: str, 
+                    chart: Construct)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterid\\"></span>
+
+- *Type:* \`str\`
+
+logical id of this chart.
+
+---
+
+###### \`chart\`<sup>Required</sup> <span data-heading-title=\\"\`chart\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterchart\\"></span>
+
+- *Type:* [\`constructs.Construct\`](#constructs.Construct)
+
+the cdk8s chart.
+
+---
+
+##### \`add_helm_chart\` <span data-heading-title=\\"\`add_helm_chart\`\\" data-heading-id=\\"awscdkawseksiclusteraddhelmchart\\"></span>
+
+\`\`\`python
+def add_helm_chart(id: str, 
+                   chart: str, 
+                   create_namespace: bool = None, 
+                   namespace: str = None, 
+                   release: str = None, 
+                   repository: str = None, 
+                   timeout: Duration = None, 
+                   values: typing.Mapping[typing.Any] = None, 
+                   version: str = None, 
+                   wait: bool = None)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterid\\"></span>
+
+- *Type:* \`str\`
+
+logical id of this chart.
+
+---
+
+###### \`chart\`<sup>Required</sup> <span data-heading-title=\\"\`chart\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionschart\\"></span>
+
+- *Type:* \`str\`
+
+The name of the chart.
+
+---
+
+###### \`create_namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`create_namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionscreatenamespace\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+###### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+###### \`release\`<sup>Optional</sup> <span data-heading-title=\\"\`release\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsrelease\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+###### \`repository\`<sup>Optional</sup> <span data-heading-title=\\"\`repository\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsrepository\\"></span>
+
+- *Type:* \`str\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+###### \`timeout\`<sup>Optional</sup> <span data-heading-title=\\"\`timeout\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionstimeout\\"></span>
+
+- *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+###### \`values\`<sup>Optional</sup> <span data-heading-title=\\"\`values\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsvalues\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+###### \`version\`<sup>Optional</sup> <span data-heading-title=\\"\`version\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionsversion\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+###### \`wait\`<sup>Optional</sup> <span data-heading-title=\\"\`wait\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawsekshelmchartoptionswait\\"></span>
+
+- *Type:* \`bool\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+##### \`add_manifest\` <span data-heading-title=\\"\`add_manifest\`\\" data-heading-id=\\"awscdkawseksiclusteraddmanifest\\"></span>
+
+\`\`\`python
+def add_manifest(id: str, 
+                 manifest: typing.Mapping[typing.Any])
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterid\\"></span>
+
+- *Type:* \`str\`
+
+logical id of this manifest.
+
+---
+
+###### \`manifest\`<sup>Required</sup> <span data-heading-title=\\"\`manifest\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclustermanifest\\"></span>
+
+- *Type:* typing.Mapping[\`typing.Any\`]
+
+a list of Kubernetes resource specifications.
+
+---
+
+##### \`add_service_account\` <span data-heading-title=\\"\`add_service_account\`\\" data-heading-id=\\"awscdkawseksiclusteraddserviceaccount\\"></span>
+
+\`\`\`python
+def add_service_account(id: str, 
+                        name: str = None, 
+                        namespace: str = None)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <span data-heading-title=\\"\`id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterid\\"></span>
+
+- *Type:* \`str\`
+
+logical id of service account.
+
+---
+
+###### \`name\`<sup>Optional</sup> <span data-heading-title=\\"\`name\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountoptionsname\\"></span>
+
+- *Type:* \`str\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+###### \`namespace\`<sup>Optional</sup> <span data-heading-title=\\"\`namespace\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksserviceaccountoptionsnamespace\\"></span>
+
+- *Type:* \`str\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`node\`<sup>Required</sup> <span data-heading-title=\\"\`node\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusternode\\"></span>
+
+- *Type:* [\`constructs.Node\`](#constructs.Node)
+
+The tree node.
+
+---
+
+##### \`env\`<sup>Required</sup> <span data-heading-title=\\"\`env\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterenv\\"></span>
+
+- *Type:* [\`aws_cdk.ResourceEnvironment\`](#aws_cdk.ResourceEnvironment)
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <span data-heading-title=\\"\`stack\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterstack\\"></span>
+
+- *Type:* [\`aws_cdk.Stack\`](#aws_cdk.Stack)
+
+The stack in which this resource is defined.
+
+---
+
+##### \`connections\`<sup>Required</sup> <span data-heading-title=\\"\`connections\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterconnections\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.Connections\`](#aws_cdk.aws_ec2.Connections)
+
+---
+
+##### \`cluster_arn\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterclusterarn\\"></span>
+
+- *Type:* \`str\`
+
+The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
+
+---
+
+##### \`cluster_certificate_authority_data\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_certificate_authority_data\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterclustercertificateauthoritydata\\"></span>
+
+- *Type:* \`str\`
+
+The certificate-authority-data for your cluster.
+
+---
+
+##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_encryption_config_key_arn\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterclusterencryptionconfigkeyarn\\"></span>
+
+- *Type:* \`str\`
+
+Amazon Resource Name (ARN) or alias of the customer master key (CMK).
+
+---
+
+##### \`cluster_endpoint\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_endpoint\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterclusterendpoint\\"></span>
+
+- *Type:* \`str\`
+
+The API Server endpoint URL.
+
+---
+
+##### \`cluster_name\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterclustername\\"></span>
+
+- *Type:* \`str\`
+
+The physical name of the Cluster.
+
+---
+
+##### \`cluster_security_group\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_security_group\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterclustersecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+
+The cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`cluster_security_group_id\`<sup>Required</sup> <span data-heading-title=\\"\`cluster_security_group_id\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterclustersecuritygroupid\\"></span>
+
+- *Type:* \`str\`
+
+The id of the cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`open_id_connect_provider\`<sup>Required</sup> <span data-heading-title=\\"\`open_id_connect_provider\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusteropenidconnectprovider\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
+
+The Open ID Connect Provider of the cluster used to configure Service Accounts.
+
+---
+
+##### \`prune\`<sup>Required</sup> <span data-heading-title=\\"\`prune\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclusterprune\\"></span>
+
+- *Type:* \`bool\`
+
+Indicates whether Kubernetes resources can be automatically pruned.
+
+When
+this is enabled (default), prune labels will be allocated and injected to
+each resource. These labels will then be used when issuing the \`kubectl
+apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`vpc\`<sup>Required</sup> <span data-heading-title=\\"\`vpc\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksiclustervpc\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
+
+The VPC in which this Cluster was created.
+
+---
+
+##### \`kubectl_environment\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_environment\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksiclusterkubectlenvironment\\"></span>
+
+- *Type:* typing.Mapping[\`str\`]
+
+Custom environment variables when running \`kubectl\` against this cluster.
+
+---
+
+##### \`kubectl_layer\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_layer\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksiclusterkubectllayer\\"></span>
+
+- *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
+
+An AWS Lambda layer that includes \`kubectl\`, \`helm\` and the \`aws\` CLI.
+
+If not defined, a default layer will be used.
+
+---
+
+##### \`kubectl_memory\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_memory\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksiclusterkubectlmemory\\"></span>
+
+- *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`kubectl_private_subnets\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_private_subnets\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksiclusterkubectlprivatesubnets\\"></span>
+
+- *Type:* typing.List[[\`aws_cdk.aws_ec2.ISubnet\`](#aws_cdk.aws_ec2.ISubnet)]
+
+Subnets to host the \`kubectl\` compute resources.
+
+If this is undefined, the k8s endpoint is expected to be accessible
+publicly.
+
+---
+
+##### \`kubectl_role\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_role\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksiclusterkubectlrole\\"></span>
+
+- *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
+
+An IAM role that can perform kubectl operations against this cluster.
+
+The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
+
+---
+
+##### \`kubectl_security_group\`<sup>Optional</sup> <span data-heading-title=\\"\`kubectl_security_group\`<sup>Optional</sup>\\" data-heading-id=\\"awscdkawseksiclusterkubectlsecuritygroup\\"></span>
+
+- *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
+
+A security group to use for \`kubectl\` execution.
+
+If this is undefined, the k8s endpoint is expected to be accessible
+publicly.
+
+---
+
+### INodegroup <span data-heading-title=\\"INodegroup\\" data-heading-id=\\"awscdkawseksinodegroup\\"></span>
+
+- *Extends:* [\`aws_cdk.IResource\`](#aws_cdk.IResource)
+
+- *Implemented By:* [\`aws_cdk.aws_eks.Nodegroup\`](#aws_cdk.aws_eks.Nodegroup), [\`aws_cdk.aws_eks.INodegroup\`](#aws_cdk.aws_eks.INodegroup)
+
+NodeGroup interface.
+
+
+#### Properties <span data-heading-title=\\"Properties\\" data-heading-id=\\"properties\\"></span>
+
+##### \`node\`<sup>Required</sup> <span data-heading-title=\\"\`node\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksinodegroupnode\\"></span>
+
+- *Type:* [\`constructs.Node\`](#constructs.Node)
+
+The tree node.
+
+---
+
+##### \`env\`<sup>Required</sup> <span data-heading-title=\\"\`env\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksinodegroupenv\\"></span>
+
+- *Type:* [\`aws_cdk.ResourceEnvironment\`](#aws_cdk.ResourceEnvironment)
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <span data-heading-title=\\"\`stack\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksinodegroupstack\\"></span>
+
+- *Type:* [\`aws_cdk.Stack\`](#aws_cdk.Stack)
+
+The stack in which this resource is defined.
+
+---
+
+##### \`nodegroup_name\`<sup>Required</sup> <span data-heading-title=\\"\`nodegroup_name\`<sup>Required</sup>\\" data-heading-id=\\"awscdkawseksinodegroupnodegroupname\\"></span>
+
+- *Type:* \`str\`
+
+Name of the nodegroup.
+
+---
+
+## Enums <span data-heading-title=\\"Enums\\" data-heading-id=\\"enums\\"></span>
+
+### CapacityType <span data-heading-title=\\"CapacityType\\" data-heading-id=\\"capacitytype\\"></span>
+
+Capacity type of the managed node group.
+
+#### \`SPOT\` <span data-heading-title=\\"\`SPOT\`\\" data-heading-id=\\"awscdkawsekscapacitytypespot\\"></span>
+
+spot instances.
+
+---
+
+
+#### \`ON_DEMAND\` <span data-heading-title=\\"\`ON_DEMAND\`\\" data-heading-id=\\"awscdkawsekscapacitytypeondemand\\"></span>
+
+on-demand instances.
+
+---
+
+
+### CoreDnsComputeType <span data-heading-title=\\"CoreDnsComputeType\\" data-heading-id=\\"corednscomputetype\\"></span>
+
+The type of compute resources to use for CoreDNS.
+
+#### \`EC2\` <span data-heading-title=\\"\`EC2\`\\" data-heading-id=\\"awscdkawsekscorednscomputetypeec2\\"></span>
+
+Deploy CoreDNS on EC2 instances.
+
+---
+
+
+#### \`FARGATE\` <span data-heading-title=\\"\`FARGATE\`\\" data-heading-id=\\"awscdkawsekscorednscomputetypefargate\\"></span>
+
+Deploy CoreDNS on Fargate-managed instances.
+
+---
+
+
+### CpuArch <span data-heading-title=\\"CpuArch\\" data-heading-id=\\"cpuarch\\"></span>
+
+CPU architecture.
+
+#### \`ARM_64\` <span data-heading-title=\\"\`ARM_64\`\\" data-heading-id=\\"awscdkawsekscpuarcharm64\\"></span>
+
+arm64 CPU type.
+
+---
+
+
+#### \`X86_64\` <span data-heading-title=\\"\`X86_64\`\\" data-heading-id=\\"awscdkawsekscpuarchx8664\\"></span>
+
+x86_64 CPU type.
+
+---
+
+
+### DefaultCapacityType <span data-heading-title=\\"DefaultCapacityType\\" data-heading-id=\\"defaultcapacitytype\\"></span>
+
+The default capacity type for the cluster.
+
+#### \`NODEGROUP\` <span data-heading-title=\\"\`NODEGROUP\`\\" data-heading-id=\\"awscdkawseksdefaultcapacitytypenodegroup\\"></span>
+
+managed node group.
+
+---
+
+
+#### \`EC2\` <span data-heading-title=\\"\`EC2\`\\" data-heading-id=\\"awscdkawseksdefaultcapacitytypeec2\\"></span>
+
+EC2 autoscaling group.
+
+---
+
+
+### MachineImageType <span data-heading-title=\\"MachineImageType\\" data-heading-id=\\"machineimagetype\\"></span>
+
+The machine image type.
+
+#### \`AMAZON_LINUX_2\` <span data-heading-title=\\"\`AMAZON_LINUX_2\`\\" data-heading-id=\\"awscdkawseksmachineimagetypeamazonlinux2\\"></span>
+
+Amazon EKS-optimized Linux AMI.
+
+---
+
+
+#### \`BOTTLEROCKET\` <span data-heading-title=\\"\`BOTTLEROCKET\`\\" data-heading-id=\\"awscdkawseksmachineimagetypebottlerocket\\"></span>
+
+Bottlerocket AMI.
+
+---
+
+
+### NodegroupAmiType <span data-heading-title=\\"NodegroupAmiType\\" data-heading-id=\\"nodegroupamitype\\"></span>
+
+The AMI type for your node group.
+
+GPU instance types should use the \`AL2_x86_64_GPU\` AMI type, which uses the
+Amazon EKS-optimized Linux AMI with GPU support. Non-GPU instances should use the \`AL2_x86_64\` AMI type, which
+uses the Amazon EKS-optimized Linux AMI.
+
+#### \`AL2_X86_64\` <span data-heading-title=\\"\`AL2_X86_64\`\\" data-heading-id=\\"awscdkawseksnodegroupamitypeal2x8664\\"></span>
+
+Amazon Linux 2 (x86-64).
+
+---
+
+
+#### \`AL2_X86_64_GPU\` <span data-heading-title=\\"\`AL2_X86_64_GPU\`\\" data-heading-id=\\"awscdkawseksnodegroupamitypeal2x8664gpu\\"></span>
+
+Amazon Linux 2 with GPU support.
+
+---
+
+
+#### \`AL2_ARM_64\` <span data-heading-title=\\"\`AL2_ARM_64\`\\" data-heading-id=\\"awscdkawseksnodegroupamitypeal2arm64\\"></span>
+
+Amazon Linux 2 (ARM-64).
+
+---
+
+
+### NodeType <span data-heading-title=\\"NodeType\\" data-heading-id=\\"nodetype\\"></span>
+
+Whether the worker nodes should support GPU or just standard instances.
+
+#### \`STANDARD\` <span data-heading-title=\\"\`STANDARD\`\\" data-heading-id=\\"awscdkawseksnodetypestandard\\"></span>
+
+Standard instances.
+
+---
+
+
+#### \`GPU\` <span data-heading-title=\\"\`GPU\`\\" data-heading-id=\\"awscdkawseksnodetypegpu\\"></span>
+
+GPU instances.
+
+---
+
+
+#### \`INFERENTIA\` <span data-heading-title=\\"\`INFERENTIA\`\\" data-heading-id=\\"awscdkawseksnodetypeinferentia\\"></span>
+
+Inferentia instances.
+
+---
+
+
+### PatchType <span data-heading-title=\\"PatchType\\" data-heading-id=\\"patchtype\\"></span>
+
+Values for \`kubectl patch\` --type argument.
+
+#### \`JSON\` <span data-heading-title=\\"\`JSON\`\\" data-heading-id=\\"awscdkawsekspatchtypejson\\"></span>
+
+JSON Patch, RFC 6902.
+
+---
+
+
+#### \`MERGE\` <span data-heading-title=\\"\`MERGE\`\\" data-heading-id=\\"awscdkawsekspatchtypemerge\\"></span>
+
+JSON Merge patch.
+
+---
+
+
+#### \`STRATEGIC\` <span data-heading-title=\\"\`STRATEGIC\`\\" data-heading-id=\\"awscdkawsekspatchtypestrategic\\"></span>
+
+Strategic merge patch.
 
 ---
 

--- a/src/api/docgen/view/api-reference.ts
+++ b/src/api/docgen/view/api-reference.ts
@@ -21,9 +21,13 @@ export class ApiReference {
     assembly: reflect.Assembly,
     submodule?: reflect.Submodule
   ) {
-    const classes = this.filterSubmodule(assembly.classes, submodule);
-    const interfaces = this.filterSubmodule(assembly.interfaces, submodule);
-    const enums = this.filterSubmodule(assembly.enums, submodule);
+    const classes = this.sortByName(
+      submodule ? submodule.classes : assembly.classes
+    );
+    const interfaces = this.sortByName(
+      submodule ? submodule.interfaces : assembly.interfaces
+    );
+    const enums = this.sortByName(submodule ? submodule.enums : assembly.enums);
 
     this.constructs = new Constructs(transpile, classes);
     this.classes = new Classes(transpile, classes);
@@ -45,14 +49,7 @@ export class ApiReference {
     return md;
   }
 
-  private filterSubmodule<Type extends reflect.Type>(
-    arr: readonly Type[],
-    submodule?: reflect.Submodule
-  ): Type[] {
-    return arr
-      .filter((e) =>
-        submodule ? !!e.namespace?.startsWith(submodule.name) : true
-      )
-      .sort((s1, s2) => s1.name.localeCompare(s2.name));
+  private sortByName<Type extends reflect.Type>(arr: readonly Type[]): Type[] {
+    return [...arr].sort((s1, s2) => s1.name.localeCompare(s2.name));
   }
 }

--- a/src/api/docgen/view/class.test.ts
+++ b/src/api/docgen/view/class.test.ts
@@ -5,7 +5,7 @@ import { Class } from "./class";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const klass = new Class(transpile, assembly.classes[0]);
     expect(klass.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/documentation.test.ts
+++ b/src/api/docgen/view/documentation.test.ts
@@ -2,12 +2,24 @@ import * as reflect from "jsii-reflect";
 import { Documentation } from "./documentation";
 
 const assembly: reflect.Assembly = (global as any).assembly;
+const assemblyWithSubmodules: reflect.Assembly = (global as any)
+  .assemblyWithSubmodules;
 
 describe("python", () => {
-  test("snapshot", () => {
+  test("snapshot - root module", () => {
     const docs = new Documentation({
       language: "python",
       assembly: assembly,
+      readme: true,
+    });
+    expect(docs.render().render()).toMatchSnapshot();
+  });
+
+  test("snapshot - submodules", () => {
+    const docs = new Documentation({
+      language: "python",
+      assembly: assemblyWithSubmodules,
+      submoduleName: "aws_eks",
       readme: true,
     });
     expect(docs.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/documentation.ts
+++ b/src/api/docgen/view/documentation.ts
@@ -58,7 +58,7 @@ export class Documentation {
 
     switch (options.language) {
       case "python":
-        this.transpile = new PythonTranspile(this.assembly.system);
+        this.transpile = new PythonTranspile();
         break;
       default:
         throw new Error(

--- a/src/api/docgen/view/enum.test.ts
+++ b/src/api/docgen/view/enum.test.ts
@@ -5,7 +5,7 @@ import { Enum } from "./enum";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const enu = new Enum(transpile, assembly.enums[0]);
     expect(enu.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/initializer.test.ts
+++ b/src/api/docgen/view/initializer.test.ts
@@ -5,7 +5,7 @@ import { Initializer } from "./initializer";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const initializer = new Initializer(transpile, findInitializer());
     expect(initializer.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/instance-method.test.ts
+++ b/src/api/docgen/view/instance-method.test.ts
@@ -5,7 +5,7 @@ import { InstanceMethod } from "./instance-method";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
     expect(instanceMethod.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/interface.test.ts
+++ b/src/api/docgen/view/interface.test.ts
@@ -5,7 +5,7 @@ import { Interface } from "./interface";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const klass = new Interface(transpile, findInterface());
     expect(klass.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/parameter.test.ts
+++ b/src/api/docgen/view/parameter.test.ts
@@ -5,7 +5,7 @@ import { Parameter } from "./parameter";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const parameter = new Parameter(transpile, findParameter());
     expect(parameter.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/property.test.ts
+++ b/src/api/docgen/view/property.test.ts
@@ -5,7 +5,7 @@ import { Property } from "./property";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const parameter = new Property(
       transpile,

--- a/src/api/docgen/view/static-function.test.ts
+++ b/src/api/docgen/view/static-function.test.ts
@@ -5,7 +5,7 @@ import { StaticFunction } from "./static-function";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction());
     expect(staticFunction.render().render()).toMatchSnapshot();

--- a/src/api/docgen/view/struct.test.ts
+++ b/src/api/docgen/view/struct.test.ts
@@ -5,7 +5,7 @@ import { Struct } from "./struct";
 const assembly: reflect.Assembly = (global as any).assembly;
 
 describe("python", () => {
-  const transpile = new PythonTranspile(assembly.system);
+  const transpile = new PythonTranspile();
   test("snapshot", () => {
     const struct = new Struct(
       transpile,

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -9,21 +9,19 @@ import * as path from "path";
 import * as jsii from "@jsii/spec";
 import * as reflect from "jsii-reflect";
 
-// randomly selected...
-const ASSEMBLY_UNDER_TEST = "@aws-cdk/aws-ecr";
-
-function createAssembly(): reflect.Assembly {
+function createAssembly(name: string): reflect.Assembly {
   const ts = new reflect.TypeSystem();
 
   const packages = `${__dirname}/__fixtures__/assemblies`;
 
   collectAssebmlies(packages, ts);
 
-  return ts.findAssembly(ASSEMBLY_UNDER_TEST);
+  return ts.findAssembly(name);
 }
 
-// expose the type system under test gloablly
-(global as any).assembly = createAssembly();
+// expose the assemblies under test gloablly
+(global as any).assembly = createAssembly("@aws-cdk/aws-ecr");
+(global as any).assemblyWithSubmodules = createAssembly("aws-cdk-lib");
 
 function collectAssebmlies(p: string, ts: reflect.TypeSystem) {
   const stat = fs.statSync(p);


### PR DESCRIPTION
We mistakenly used `assembly.classes` for the submodule instead of `submodule.classes`, etc...

This is how it will look like after the fix:

```python
from aws_cdk import aws_eks

aws_eks.CfnCluster.ResourcesVpcConfigProperty(subnet_ids: typing.List[str], 
                                              security_group_ids: typing.List[str] = None)
```

Also includes some refactoring to handle module name transliteration in more generic way in preparation of typescript support.

Note: I added the assembly of `aws-cdk-lib` (28M) for tests. Its big but not too bad. GitHub's limit is 100MB