### PR TITLE
fix: package-doc rerender performance

### DIFF
--- a/src/components/PackageDocs/Body.tsx
+++ b/src/components/PackageDocs/Body.tsx
@@ -1,7 +1,7 @@
 import { LinkIcon } from "@chakra-ui/icons";
 import { Heading, As } from "@chakra-ui/react";
 import ChakraUIRenderer from "chakra-ui-markdown-renderer";
-import React from "react";
+import React, { useMemo } from "react";
 import ReactDOMServer from "react-dom/server";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
@@ -66,10 +66,16 @@ const components = ChakraUIRenderer({
   h6: Headings,
 });
 
+const rehypePlugins = [rehypeRaw];
+
 export function Body({ children }: { children: string }) {
-  return (
-    <ReactMarkdown components={components} rehypePlugins={[rehypeRaw]}>
-      {children}
-    </ReactMarkdown>
-  );
+  const body = useMemo(() => {
+    return (
+      <ReactMarkdown components={components} rehypePlugins={rehypePlugins}>
+        {children}
+      </ReactMarkdown>
+    );
+  }, [children]);
+
+  return body;
 }

--- a/src/components/PackageDocs/index.tsx
+++ b/src/components/PackageDocs/index.tsx
@@ -59,20 +59,20 @@ export function PackageDocs({
 
   const hasApiReference = !isDev || (isDev && q.get("apiRef") !== "false");
 
-  const doc = useMemo(
-    () =>
-      new Documentation({
-        apiReference: hasApiReference,
-        assembly: assembly,
-        language: language,
-        submoduleName: submodule,
-      }),
-    [hasApiReference, assembly, language, submodule]
-  );
+  const source = useMemo(() => {
+    const doc = new Documentation({
+      apiReference: hasApiReference,
+      assembly: assembly,
+      language: language,
+      submoduleName: submodule,
+    });
 
-  const md = doc.render();
-  const source = md.render();
+    const md = doc.render();
+    return md.render();
+  }, [hasApiReference, assembly, language, submodule]);
+
   const [navItems, setNavItems] = useState<PackageNavItem[]>([]);
+
   useEffect(() => {
     const tree = [
       ...document.querySelectorAll(

--- a/src/components/PackageDocs/index.tsx
+++ b/src/components/PackageDocs/index.tsx
@@ -1,6 +1,6 @@
 import { Grid } from "@chakra-ui/react";
 import type { Assembly } from "jsii-reflect";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Documentation } from "../../api/docgen/view/documentation";
 import { useQueryParams } from "../../hooks/useQueryParams";
 import { Card } from "../Card";
@@ -59,12 +59,16 @@ export function PackageDocs({
 
   const hasApiReference = !isDev || (isDev && q.get("apiRef") !== "false");
 
-  const doc = new Documentation({
-    apiReference: hasApiReference,
-    assembly: assembly,
-    language: language,
-    submoduleName: submodule,
-  });
+  const doc = useMemo(
+    () =>
+      new Documentation({
+        apiReference: hasApiReference,
+        assembly: assembly,
+        language: language,
+        submoduleName: submodule,
+      }),
+    [hasApiReference, assembly, language, submodule]
+  );
 
   const md = doc.render();
   const source = md.render();

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,5 +1,8 @@
+import { useMemo } from "react";
 import { useLocation } from "react-router-dom";
 
 export function useQueryParams() {
-  return new URLSearchParams(useLocation().search);
+  const { search } = useLocation();
+
+  return useMemo(() => new URLSearchParams(search), [search]);
 }


### PR DESCRIPTION
Updates to the url language were re-rendering the page markdown even when the markdown source was unchanged, which was causing poor performance - especially on larger markdown files. This change memoizes the markdown generation, markdown rendering, and the `useQueryParams` hook to minimize unnecessary re-renders