### PR TITLE
feat: supported languages only

### DIFF
--- a/src/components/LanguageSelection/index.tsx
+++ b/src/components/LanguageSelection/index.tsx
@@ -1,6 +1,10 @@
 import { Button, Flex, Text } from "@chakra-ui/react";
 import type { Assembly } from "jsii-reflect";
-import { Language, LANGUAGES } from "../../constants/languages";
+import {
+  Language,
+  LANGUAGES,
+  TEMP_SUPPORTED_LANGUAGES,
+} from "../../constants/languages";
 import { useLanguage } from "../../hooks/useLanguage";
 import { Card } from "../Card";
 import { LanguageBar } from "../LanguageBar";
@@ -32,7 +36,9 @@ export function LanguageSelection({ assembly }: LanguageSelectionProps) {
           selectedLanguage={targets.includes(language) ? language : targets[0]}
           setSelectedLanguage={setLanguage}
           showDisabled
-          targetLanguages={targets}
+          targetLanguages={targets.filter((target) =>
+            TEMP_SUPPORTED_LANGUAGES.includes(target)
+          )}
         />
       </Flex>
       <Button colorScheme="blue" disabled size="lg">

--- a/src/constants/languages.ts
+++ b/src/constants/languages.ts
@@ -17,3 +17,5 @@ export const LANGUAGES: Language[] = [
   Languages.Go,
   Languages.DotNet,
 ];
+
+export const TEMP_SUPPORTED_LANGUAGES: Language[] = [Languages.Python];

--- a/src/hooks/useLanguage/useLanguage.test.ts
+++ b/src/hooks/useLanguage/useLanguage.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { useLocation as useLocationMock } from "react-router-dom";
+import * as languageConstants from "../../constants/languages";
 import { useLanguage } from "./useLanguage";
 
 jest.mock("react-router-dom", () => ({
@@ -22,6 +23,8 @@ describe("useLanguage", () => {
   const getItem = jest.spyOn(window.localStorage.__proto__, "getItem");
 
   beforeEach(() => {
+    // @ts-ignore
+    languageConstants.TEMP_SUPPORTED_LANGUAGES = languageConstants.LANGUAGES;
     useLocation.mockReturnValue(baseLocation);
   });
 
@@ -46,7 +49,7 @@ describe("useLanguage", () => {
     });
     const { result } = testRender();
 
-    expect(result.current[0]).toEqual("ts"); // The default language
+    expect(result.current[0]).toEqual("python"); // The default language
   });
 
   it("checks localStorage for valid language if no url param value", () => {
@@ -60,13 +63,13 @@ describe("useLanguage", () => {
     getItem.mockReturnValueOnce("ruby");
     const { result } = testRender();
 
-    expect(result.current[0]).toEqual("ts");
+    expect(result.current[0]).toEqual("python");
   });
 
   it("falls back to default lang if not localStorage or url param", () => {
     getItem.mockReturnValueOnce(null);
     const { result } = testRender();
 
-    expect(result.current[0]).toEqual("ts");
+    expect(result.current[0]).toEqual("python");
   });
 });

--- a/src/views/Package/index.tsx
+++ b/src/views/Package/index.tsx
@@ -5,6 +5,7 @@ import { createAssembly } from "../../api/package/assemblies";
 import { fetchMetadata } from "../../api/package/metadata";
 import { PackageDetails } from "../../components/PackageDetails";
 import { PackageDocs } from "../../components/PackageDocs";
+import { useLanguage } from "../../hooks/useLanguage";
 import { useQueryParams } from "../../hooks/useQueryParams";
 import { useRequest } from "../../hooks/useRequest";
 
@@ -19,6 +20,7 @@ export function Package() {
   const [requestAssembly, assemblyResponse] = useRequest(createAssembly);
   const [requestMetadata, metadataResponse] = useRequest(fetchMetadata);
   const q = useQueryParams();
+  const [language] = useLanguage();
 
   useEffect(() => {
     void requestAssembly(name, version, scope);
@@ -38,7 +40,7 @@ export function Package() {
       {assemblyResponse.data && !assemblyResponse.loading && (
         <PackageDocs
           assembly={assemblyResponse.data}
-          language={q.get("language") ?? "python"}
+          language={language}
           submodule={q.get("submodule") ?? ""}
         />
       )}


### PR DESCRIPTION
This work prevents languages that have not yet been implemented from being selected via language bar or query param to prevent doc generation from erroring. This also updates `useLanguage` to always subscribe to the language query param if it is present