### PR TITLE
feat: enable typescript lang selection

### DIFF
--- a/src/api/docgen/view/documentation.test.ts
+++ b/src/api/docgen/view/documentation.test.ts
@@ -29,7 +29,7 @@ describe("python", () => {
 describe("typescript", () => {
   test("snapshot - single module", () => {
     const docs = new Documentation({
-      language: "typescript",
+      language: "ts",
       assembly: assembly,
       readme: true,
     });
@@ -38,7 +38,7 @@ describe("typescript", () => {
 
   test("snapshot - submodules", () => {
     const docs = new Documentation({
-      language: "typescript",
+      language: "ts",
       assembly: assemblyWithSubmodules,
       submoduleName: "aws_eks",
       readme: true,

--- a/src/api/docgen/view/documentation.ts
+++ b/src/api/docgen/view/documentation.ts
@@ -61,7 +61,7 @@ export class Documentation {
       case "python":
         this.transpile = new PythonTranspile();
         break;
-      case "typescript":
+      case "ts":
         this.transpile = new TypeScriptTranspile();
         break;
       default:

--- a/src/components/LanguageSelection/index.tsx
+++ b/src/components/LanguageSelection/index.tsx
@@ -2,6 +2,7 @@ import { Button, Flex, Text } from "@chakra-ui/react";
 import type { Assembly } from "jsii-reflect";
 import {
   Language,
+  Languages,
   LANGUAGES,
   TEMP_SUPPORTED_LANGUAGES,
 } from "../../constants/languages";
@@ -16,7 +17,12 @@ export interface LanguageSelectionProps {
 
 export function LanguageSelection({ assembly }: LanguageSelectionProps) {
   const [language, setLanguage] = useLanguage({ updateUrl: true });
-  const targets = Object.keys(assembly?.spec?.targets ?? {}) as Language[];
+  const targets = [
+    ...Object.keys(assembly?.spec?.targets ?? {}),
+    // typescript is the source language and hence always supported.
+    // (it doesn't appear in spec.targets)
+    Languages.TypeScript,
+  ] as Language[];
 
   return (
     <Card align="center" as={Flex} justify="space-between" px={4} py={0}>

--- a/src/constants/languages.ts
+++ b/src/constants/languages.ts
@@ -18,4 +18,7 @@ export const LANGUAGES: Language[] = [
   Languages.DotNet,
 ];
 
-export const TEMP_SUPPORTED_LANGUAGES: Language[] = [Languages.Python];
+export const TEMP_SUPPORTED_LANGUAGES: Language[] = [
+  Languages.Python,
+  Languages.TypeScript,
+];

--- a/src/hooks/useLanguage/useLanguage.test.ts
+++ b/src/hooks/useLanguage/useLanguage.test.ts
@@ -49,7 +49,7 @@ describe("useLanguage", () => {
     });
     const { result } = testRender();
 
-    expect(result.current[0]).toEqual("python"); // The default language
+    expect(result.current[0]).toEqual("ts"); // The default language
   });
 
   it("checks localStorage for valid language if no url param value", () => {
@@ -63,13 +63,13 @@ describe("useLanguage", () => {
     getItem.mockReturnValueOnce("ruby");
     const { result } = testRender();
 
-    expect(result.current[0]).toEqual("python");
+    expect(result.current[0]).toEqual("ts");
   });
 
   it("falls back to default lang if not localStorage or url param", () => {
     getItem.mockReturnValueOnce(null);
     const { result } = testRender();
 
-    expect(result.current[0]).toEqual("python");
+    expect(result.current[0]).toEqual("ts");
   });
 });

--- a/src/hooks/useLanguage/useLanguage.ts
+++ b/src/hooks/useLanguage/useLanguage.ts
@@ -8,7 +8,7 @@ import {
 import { useQueryParams } from "../../hooks/useQueryParams";
 
 // Only supported language atm
-const defaultLang: Language = Languages.Python;
+const defaultLang: Language = Languages.TypeScript;
 
 const LOCAL_KEY = "preferred-language";
 const PARAM_KEY = "lang";


### PR DESCRIPTION
TypeScript support has been [added](https://github.com/cdklabs/construct-hub-webapp/pull/100) to the doc generation, this PR now adds typescript as a supported language in the language bar component. 

<img width="602" alt="Screen Shot 2021-06-17 at 4 25 03 PM" src="https://user-images.githubusercontent.com/1428812/122405287-978c7a80-cf88-11eb-914c-0f4c7cc3ad08.png">

Also switch the default language to TypeScript.