### PR TITLE
feat: parallelize assembly requests

### DIFF
--- a/src/api/package/assemblies.ts
+++ b/src/api/package/assemblies.ts
@@ -31,14 +31,18 @@ async function fetchAssemblies(
       return;
     }
     assemblies[packageFqn] = assembly;
+    const promises: Promise<void>[] = [];
+
     for (const [d, v] of Object.entries(assembly.dependencies ?? {})) {
       const scopeAndName = d.split("/");
       if (scopeAndName.length > 1) {
-        await recurse(scopeAndName[1], v, scopeAndName[0]);
+        promises.push(recurse(scopeAndName[1], v, scopeAndName[0]));
       } else {
-        await recurse(scopeAndName[0], v, "");
+        promises.push(recurse(scopeAndName[0], v, ""));
       }
     }
+
+    await Promise.all(promises);
   }
 
   await recurse(name, version, scope);


### PR DESCRIPTION
Low hanging fruit regarding performance. Runs requests for assembly dependencies in parallel rather than sequentially