### PR TITLE
feat: dedupe assembly requests

### DIFF
--- a/src/api/package/assemblies.ts
+++ b/src/api/package/assemblies.ts
@@ -23,13 +23,17 @@ async function fetchAssemblies(
   scope?: string
 ): Promise<Assemblies> {
   const assemblies: Assemblies = {};
+  const requested = new Set();
 
   async function recurse(_name: string, _version: string, _scope?: string) {
-    const assembly = await fetchAssembly(_name, _version, _scope);
     const packageFqn = `${getFullPackageName(_name, _scope)}@${_version};`;
-    if (assemblies[packageFqn]) {
+
+    if (requested.has(packageFqn)) {
       return;
     }
+
+    requested.add(packageFqn);
+    const assembly = await fetchAssembly(_name, _version, _scope);
     assemblies[packageFqn] = assembly;
     const promises: Promise<void>[] = [];
 


### PR DESCRIPTION
More low hanging fruit! Thanks to @iliapolo for pointing this one out. Even though we are parallelizing requests for dependency assemblies, we weren't accounting for the scenario where two dependencies shared a dependency, thus creating redundant requests.

I logged a pretty simple counter to measure the difference here
`iterations` = `recurse` calls
`requestsMade` = `fetch` calls

Before:
![Screen Shot 2021-06-21 at 2 02 41 PM](https://user-images.githubusercontent.com/8749859/122814451-cf056a80-d299-11eb-88bb-3dae2540cae9.png)

After:
![Screen Shot 2021-06-21 at 2 02 19 PM](https://user-images.githubusercontent.com/8749859/122814489-e0e70d80-d299-11eb-8bfd-cb0ae79a1195.png)

