### PR TITLE
feat: package metadata in search results

### DIFF
--- a/src/views/SearchResults/components/Results.tsx
+++ b/src/views/SearchResults/components/Results.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, GridItem, SimpleGrid, Tag, Text } from "@chakra-ui/react";
+import { format } from "date-fns";
 import { FunctionComponent } from "react";
 import { Link } from "react-router-dom";
 import { Packages } from "../../../api/package/packages";
@@ -25,6 +26,14 @@ export const Results: FunctionComponent<ResultsProps> = ({ results }) => {
                 p={2}
               >
                 <Text>{pkg.name}</Text>
+                <Text>{pkg.version}</Text>
+                <Text>{pkg.metadata.description}</Text>
+                <Text>
+                  {`Published on ${format(
+                    new Date(pkg.metadata.date),
+                    "MMMM dd, yyyy"
+                  )} by ${pkg.metadata.author.name}`}
+                </Text>
                 <Box overflow="hidden">
                   {pkg.metadata.keywords.map((tag) => {
                     return (


### PR DESCRIPTION
No design whatsoever, just displaying the data.

![Screen Shot 2021-06-22 at 5 46 29 PM](https://user-images.githubusercontent.com/1428812/122946408-018a9280-d382-11eb-8f6d-0caac9dec50a.png)

Resolves https://github.com/cdklabs/construct-hub-webapp/issues/114
