### PR TITLE
fix: broken fetching of assemblies and metadata

### DIFF
--- a/src/api/package/assemblies.ts
+++ b/src/api/package/assemblies.ts
@@ -64,7 +64,7 @@ async function fetchAssembly(
     version = version.substring(1, version.length);
   }
 
-  const assemblyPath = `${getAssetsPath(name, version, scope)}/${
+  const assemblyPath = `${getAssetsPath(name, version, scope)}${
     consts.ASSEMBLY_SUFFIX
   }`;
   const response = await fetch(assemblyPath);

--- a/src/api/package/metadata.ts
+++ b/src/api/package/metadata.ts
@@ -16,7 +16,7 @@ export async function fetchMetadata(
     sanitizedVersion = sanitizedVersion.substring(1, sanitizedVersion.length);
   }
 
-  const metadataPath = `${getAssetsPath(name, version, scope)}/${
+  const metadataPath = `${getAssetsPath(name, version, scope)}${
     consts.METADATA_SUFFIX
   }`;
   const response = await fetch(metadataPath);


### PR DESCRIPTION
There is an extra `/` that breaks the request.