### PR TITLE
feat: redirect to latest version

### DIFF
--- a/src/views/PackageLatest/PackageLatest.test.tsx
+++ b/src/views/PackageLatest/PackageLatest.test.tsx
@@ -1,0 +1,82 @@
+import { Packages } from "../../api/package/packages";
+import { buildRedirectUrl } from "./index";
+
+test("redirect to latest", () => {
+  const catalog: Packages = {
+    packages: [
+      {
+        author: {
+          name: "authorName",
+          url: "authorUrl",
+        },
+        description: "packageDescription",
+        keywords: [],
+        metadata: {
+          date: "publish date",
+        },
+        name: "my-package",
+        version: "1.109.0",
+      },
+    ],
+  };
+
+  const url = buildRedirectUrl(catalog, "my-package");
+  expect(url).toEqual("/packages/my-package/v/1.109.0");
+});
+
+test("throws if missing package", () => {
+  const catalog: Packages = {
+    packages: [
+      {
+        author: {
+          name: "authorName",
+          url: "authorUrl",
+        },
+        description: "packageDescription",
+        keywords: [],
+        metadata: {
+          date: "publish date",
+        },
+        name: "my-package",
+        version: "1.109.0",
+      },
+    ],
+  };
+
+  expect(() => buildRedirectUrl(catalog, "missing-package")).toThrow();
+});
+
+test("throws if multiple packages", () => {
+  const catalog: Packages = {
+    packages: [
+      {
+        author: {
+          name: "authorName",
+          url: "authorUrl",
+        },
+        description: "packageDescription",
+        keywords: [],
+        metadata: {
+          date: "publish date",
+        },
+        name: "my-package",
+        version: "1.109.0",
+      },
+      {
+        author: {
+          name: "authorName",
+          url: "authorUrl",
+        },
+        description: "packageDescription",
+        keywords: [],
+        metadata: {
+          date: "publish date",
+        },
+        name: "my-package",
+        version: "1.109.0",
+      },
+    ],
+  };
+
+  expect(() => buildRedirectUrl(catalog, "my-package")).toThrow();
+});

--- a/src/views/PackageLatest/index.tsx
+++ b/src/views/PackageLatest/index.tsx
@@ -1,4 +1,8 @@
+import { Center, Spinner } from "@chakra-ui/react";
 import { Redirect, useParams } from "react-router-dom";
+import { Packages } from "../../api/package/packages";
+import { getFullPackageName } from "../../api/package/util";
+import { useCatalog } from "../../contexts/Catalog";
 
 interface RouteParams {
   name: string;
@@ -7,11 +11,41 @@ interface RouteParams {
 
 export function PackageLatest() {
   const { name, scope }: RouteParams = useParams();
-  const version = "latest"; // read latest version from state here
+  const catalog = useCatalog();
 
+  if (catalog.loading || !catalog.data) {
+    return (
+      <Center minH="200px">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
+
+  return <Redirect to={buildRedirectUrl(catalog.data, name, scope)} />;
+}
+
+export function buildRedirectUrl(
+  catalog: Packages,
+  name: string,
+  scope?: string
+) {
   const prefix = "/packages/";
-  const packagePath = scope ? `${scope}/${name}` : `${name}`;
+  const packageName = getFullPackageName(name, scope);
+  const version = findPackage(catalog, packageName).version;
   const suffix = `/v/${version}`;
+  return `${prefix}${packageName}${suffix}`;
+}
 
-  return <Redirect to={`${prefix}${packagePath}${suffix}`} />;
+function findPackage(catalog: Packages, pkg: string) {
+  const packages = catalog.packages.filter((p) => p.name === pkg);
+
+  if (packages.length === 0) {
+    throw new Error(`Package ${pkg} does not exist in catalog`);
+  }
+
+  if (packages.length > 1) {
+    throw new Error(`Multiple packages found for ${pkg} in catalog`);
+  }
+
+  return packages[0];
 }


### PR DESCRIPTION
For example: Redirects `packages/@aws-cdk/aws-eks` --> `packages/@aws-cdk/aws-eks/v/1.109.0`

As far as testing goes, there is a simple unit test to validate the url construction. I tried doing a full react rendering test but that seems a bit tricky since we need to mock a few hooks/context. @gabewomble maybe you can have a look?

In any case I think its ok for now.

Resolves https://github.com/cdklabs/construct-hub-webapp/issues/120
