### PR TITLE
chore: fix mapped keys for <GettingStartedDropdown />

### DIFF
--- a/src/components/GettingStartedDropdown/GettingStartedDropdown.tsx
+++ b/src/components/GettingStartedDropdown/GettingStartedDropdown.tsx
@@ -8,11 +8,11 @@ import {
   MenuItem,
   MenuList,
 } from "@chakra-ui/react";
-import { Fragment } from "react";
+import { Fragment, FunctionComponent } from "react";
 import { GETTING_STARTED } from "../../constants/links";
 import { ExternalLink } from "../ExternalLink";
 
-export const GettingStartedDropdown = (): JSX.Element => {
+export const GettingStartedDropdown: FunctionComponent = () => {
   return (
     <Menu colorScheme="blue.800">
       <MenuButton

--- a/src/components/GettingStartedDropdown/GettingStartedDropdown.tsx
+++ b/src/components/GettingStartedDropdown/GettingStartedDropdown.tsx
@@ -8,6 +8,7 @@ import {
   MenuItem,
   MenuList,
 } from "@chakra-ui/react";
+import { Fragment } from "react";
 import { GETTING_STARTED } from "../../constants/links";
 import { ExternalLink } from "../ExternalLink";
 
@@ -28,8 +29,8 @@ export const GettingStartedDropdown = (): JSX.Element => {
         {GETTING_STARTED.map((item, idx) => {
           if ("links" in item) {
             return (
-              <>
-                <MenuGroup key={item.display} title={item.display}>
+              <Fragment key={item.display}>
+                <MenuGroup title={item.display}>
                   {item.links.map((link) => (
                     <MenuItem key={link.display}>
                       <ExternalLink href={link.url}>
@@ -39,7 +40,7 @@ export const GettingStartedDropdown = (): JSX.Element => {
                   ))}
                 </MenuGroup>
                 {idx !== GETTING_STARTED.length - 1 && <MenuDivider />}
-              </>
+              </Fragment>
             );
           }
           return (


### PR DESCRIPTION
This is a silly and harmless bug (which logs an error in console) from the GettingStartedDropdown. Mapped items need a key at the root jsx element, even if the element is a fragment 🙂 