### PR TITLE
chore: setting up for mobile package nav

### DIFF
--- a/src/components/CatalogSearch/CatalogSearch.test.tsx
+++ b/src/components/CatalogSearch/CatalogSearch.test.tsx
@@ -1,7 +1,8 @@
 import { render, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { CatalogSearch, CatalogSearchProps, testIds } from "./CatalogSearch";
+import { CatalogSearch, CatalogSearchProps } from "./CatalogSearch";
+import { testIds } from "./constants";
 
 describe("<CatalogSearch />", () => {
   const onSubmit = jest.fn();

--- a/src/components/CatalogSearch/CatalogSearch.tsx
+++ b/src/components/CatalogSearch/CatalogSearch.tsx
@@ -1,98 +1,18 @@
-import { Button, Grid, Input } from "@chakra-ui/react";
-import type {
-  ChangeEventHandler,
-  FormEventHandler,
-  FunctionComponent,
-} from "react";
-import {
-  Language,
-  TEMP_SUPPORTED_LANGUAGES,
-  LANGUAGE_NAME_MAP,
-} from "../../constants/languages";
-import { createTestIds } from "../../util/createTestIds";
+import { Grid } from "@chakra-ui/react";
+import type { FormEventHandler, FunctionComponent } from "react";
 import { Form } from "../Form";
-import { Dropdown, DropdownProps } from "./Dropdown";
+import {
+  CatalogSearchInputs,
+  CatalogSearchInputsProps,
+} from "./CatalogSearchInputs";
+import { testIds } from "./constants";
 
-type LanguageItems = Partial<Record<Language, string>>;
-
-const languageOptions = Object.fromEntries(
-  Object.entries(LANGUAGE_NAME_MAP).filter(([key]) =>
-    TEMP_SUPPORTED_LANGUAGES.includes(key as Language)
-  )
-) as LanguageItems;
-
-const LanguageDropdown: FunctionComponent<DropdownProps<LanguageItems>> =
-  Dropdown;
-
-export const testIds = createTestIds("catalog-search", [
-  "form",
-  "input",
-  "languageDropdown",
-  "languageDropdownMenu",
-  "languageDropdownValue",
-  "languageItem",
-  "submit",
-] as const);
-
-export interface CatalogSearchProps {
-  /**
-   * Controls the query state value
-   */
-  query: string;
-  /**
-   * Controls the query state change event
-   */
-  onQueryChange: ChangeEventHandler<HTMLInputElement>;
-  /**
-   * Controls the language state value
-   */
-  language: Language | null;
-  /**
-   * Controls the language state change event
-   */
-  onLanguageChange: (language: Language | null) => void;
+export interface CatalogSearchProps extends CatalogSearchInputsProps {
   /**
    * Called when the catalog search form is submitted (via enter keypress or submit click)
    */
   onSubmit: FormEventHandler<HTMLFormElement>;
 }
-
-export const CatalogSearchInputs: FunctionComponent<
-  Omit<CatalogSearchProps, "onSubmit">
-> = ({ query, onQueryChange, language, onLanguageChange }) => (
-  <>
-    <Input
-      bg="white"
-      borderColor="blue.100"
-      boxShadow="base"
-      data-testid={testIds.input}
-      name="query"
-      onChange={onQueryChange}
-      placeholder="Search providers or modules..."
-      value={query}
-    />
-    <LanguageDropdown
-      items={languageOptions}
-      onSelect={onLanguageChange}
-      placeholder="Language..."
-      selected={language}
-      testIds={{
-        item: testIds.languageItem,
-        menu: testIds.languageDropdownMenu,
-        trigger: testIds.languageDropdown,
-        value: testIds.languageDropdownValue,
-      }}
-    />
-    <Button
-      boxShadow="base"
-      colorScheme="blue"
-      data-testid={testIds.submit}
-      type="submit"
-    >
-      Search
-    </Button>
-  </>
-);
 
 export const CatalogSearch: FunctionComponent<CatalogSearchProps> = ({
   onSubmit,

--- a/src/components/CatalogSearch/CatalogSearchInputs.tsx
+++ b/src/components/CatalogSearch/CatalogSearchInputs.tsx
@@ -1,0 +1,75 @@
+import { Button, Input } from "@chakra-ui/react";
+import type { ChangeEventHandler, FunctionComponent } from "react";
+import {
+  Language,
+  TEMP_SUPPORTED_LANGUAGES,
+  LANGUAGE_NAME_MAP,
+} from "../../constants/languages";
+import { testIds } from "./constants";
+import { Dropdown, DropdownProps } from "./Dropdown";
+
+type LanguageItems = Partial<Record<Language, string>>;
+
+const languageOptions = Object.fromEntries(
+  Object.entries(LANGUAGE_NAME_MAP).filter(([key]) =>
+    TEMP_SUPPORTED_LANGUAGES.includes(key as Language)
+  )
+) as LanguageItems;
+
+const LanguageDropdown: FunctionComponent<DropdownProps<LanguageItems>> =
+  Dropdown;
+
+export interface CatalogSearchInputsProps {
+  /**
+   * Controls the query state value
+   */
+  query: string;
+  /**
+   * Controls the query state change event
+   */
+  onQueryChange: ChangeEventHandler<HTMLInputElement>;
+  /**
+   * Controls the language state value
+   */
+  language: Language | null;
+  /**
+   * Controls the language state change event
+   */
+  onLanguageChange: (language: Language | null) => void;
+}
+
+export const CatalogSearchInputs: FunctionComponent<CatalogSearchInputsProps> =
+  ({ query, onQueryChange, language, onLanguageChange }) => (
+    <>
+      <Input
+        bg="white"
+        borderColor="blue.100"
+        boxShadow="base"
+        data-testid={testIds.input}
+        name="query"
+        onChange={onQueryChange}
+        placeholder="Search providers or modules..."
+        value={query}
+      />
+      <LanguageDropdown
+        items={languageOptions}
+        onSelect={onLanguageChange}
+        placeholder="Language..."
+        selected={language}
+        testIds={{
+          item: testIds.languageItem,
+          menu: testIds.languageDropdownMenu,
+          trigger: testIds.languageDropdown,
+          value: testIds.languageDropdownValue,
+        }}
+      />
+      <Button
+        boxShadow="base"
+        colorScheme="blue"
+        data-testid={testIds.submit}
+        type="submit"
+      >
+        Search
+      </Button>
+    </>
+  );

--- a/src/components/CatalogSearch/constants.ts
+++ b/src/components/CatalogSearch/constants.ts
@@ -1,0 +1,11 @@
+import { createTestIds } from "../../util/createTestIds";
+
+export const testIds = createTestIds("catalog-search", [
+  "form",
+  "input",
+  "languageDropdown",
+  "languageDropdownMenu",
+  "languageDropdownValue",
+  "languageItem",
+  "submit",
+] as const);

--- a/src/components/CatalogSearch/index.ts
+++ b/src/components/CatalogSearch/index.ts
@@ -1,1 +1,3 @@
 export * from "./CatalogSearch";
+export * from "./constants";
+export * from "./CatalogSearchInputs";

--- a/src/components/LanguageBar/LanguageBar.tsx
+++ b/src/components/LanguageBar/LanguageBar.tsx
@@ -45,7 +45,7 @@ export const LanguageBar: FunctionComponent<LanguageBarProps> = ({
             bg="white"
             border={isSelected ? "1px solid" : "none"}
             borderColor="blue.500"
-            borderRadius="md"
+            borderRadius="lg"
             boxShadow="base"
             cursor={isDisabled ? "not-allowed" : "pointer"}
             data-disabled={isDisabled}
@@ -58,7 +58,7 @@ export const LanguageBar: FunctionComponent<LanguageBarProps> = ({
             key={language}
             onClick={onClick}
             opacity={isDisabled ? "0.5" : 1}
-            p={2}
+            p={1}
             sx={{
               ":hover:not(:disabled)": {
                 bg: "gray.100",
@@ -68,8 +68,9 @@ export const LanguageBar: FunctionComponent<LanguageBarProps> = ({
           >
             <LangIcon
               aria-label={`${language}-icon`}
-              height="2rem"
-              width="2rem"
+              borderRadius="sm"
+              height={[4, 5, 6]}
+              width={[4, 5, 6]}
             />
           </Flex>
         );

--- a/src/views/Package/Package.tsx
+++ b/src/views/Package/Package.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from "@chakra-ui/react";
+import { Box, Flex, Stack } from "@chakra-ui/react";
 import { FunctionComponent, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { createAssembly } from "../../api/package/assemblies";
@@ -7,9 +7,9 @@ import { QUERY_PARAMS } from "../../constants/url";
 import { useLanguage } from "../../hooks/useLanguage";
 import { useQueryParams } from "../../hooks/useQueryParams";
 import { useRequest } from "../../hooks/useRequest";
-import { LanguageSelection } from "./components/LanguageSelection";
 import { PackageDetails } from "./components/PackageDetails";
 import { PackageDocs } from "./components/PackageDocs";
+import { UseConstruct } from "./components/UseConstruct";
 
 interface PathParams {
   name: string;
@@ -40,11 +40,14 @@ export const Package: FunctionComponent = () => {
           version={version}
         />
       </Box>
-      <Box px={4}>
-        {assemblyResponse.data && (
-          <LanguageSelection assembly={assemblyResponse.data} />
-        )}
-      </Box>
+      {assemblyResponse.data && (
+        <Flex justify="end" px={4}>
+          <UseConstruct
+            packageName={assemblyResponse.data.name}
+            version={assemblyResponse.data.version}
+          />
+        </Flex>
+      )}
       {/* Readme and Api Reference Area */}
       {assemblyResponse.data && !assemblyResponse.loading && (
         <PackageDocs

--- a/src/views/Package/components/ChooseSubmodule/ChooseSubmodule.tsx
+++ b/src/views/Package/components/ChooseSubmodule/ChooseSubmodule.tsx
@@ -1,5 +1,5 @@
 import { ArrowBackIcon, ChevronDownIcon } from "@chakra-ui/icons";
-import { Button, Flex, useDisclosure, useToken } from "@chakra-ui/react";
+import { Button, Divider, Stack, useDisclosure } from "@chakra-ui/react";
 import type { Assembly } from "jsii-reflect";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
@@ -20,11 +20,10 @@ export const ChooseSubmodule: FunctionComponent<ChooseSubmoduleProps> = ({
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const [borderColor, textColor] = useToken("colors", ["gray.100", "gray.800"]);
-  const btnHeight = useToken("space", "16");
-
   const currentSubmodule = query.get(QUERY_PARAMS.SUBMODULE);
-  const submoduleText = currentSubmodule ?? "Submodules";
+  const submoduleText = currentSubmodule
+    ? `Submodule: ${currentSubmodule}`
+    : "Choose Submodule";
 
   const [filter, setFilter] = useState("");
 
@@ -58,32 +57,32 @@ export const ChooseSubmodule: FunctionComponent<ChooseSubmoduleProps> = ({
   }, [assembly?.submodules, filter, getUrl]);
 
   return (
-    <Flex>
+    <Stack spacing={4} w="100%">
       {currentSubmodule && (
-        <Button
-          borderRadius="none"
-          borderRight={`1px solid ${borderColor}`}
-          color={textColor}
-          data-testid="choose-submodule-go-back"
-          h={btnHeight}
-          onClick={onGoBack}
-          title="Back to construct root"
-          variant="ghost"
-        >
-          <ArrowBackIcon aria-label="Back to construct root" />
-        </Button>
+        <>
+          <Button
+            borderRadius="none"
+            data-testid="choose-submodule-go-back"
+            leftIcon={<ArrowBackIcon aria-label="Back to construct root" />}
+            onClick={onGoBack}
+            title="Back to construct root"
+            variant="link"
+          >
+            {assembly?.name}
+          </Button>
+          <Divider />
+        </>
       )}
       <Button
         borderRadius="none"
-        color={textColor}
+        color="blue.500"
         data-testid="choose-submodule-search-trigger"
         disabled={!assembly?.submodules.length}
         flexGrow={1}
-        h={btnHeight}
         onClick={onOpen}
         rightIcon={<ChevronDownIcon />}
         title="Choose Submodule"
-        variant="ghost"
+        variant="link"
       >
         {submoduleText}
       </Button>
@@ -94,6 +93,6 @@ export const ChooseSubmodule: FunctionComponent<ChooseSubmoduleProps> = ({
         onInputChange={setFilter}
         submodules={submodules}
       />
-    </Flex>
+    </Stack>
   );
 };

--- a/src/views/Package/components/LanguageSelection/LanguageSelection.tsx
+++ b/src/views/Package/components/LanguageSelection/LanguageSelection.tsx
@@ -1,4 +1,3 @@
-import { Flex } from "@chakra-ui/react";
 import type { Assembly } from "jsii-reflect";
 import type { FunctionComponent } from "react";
 import { LanguageBar } from "../../../../components/LanguageBar";
@@ -8,7 +7,6 @@ import {
   TEMP_SUPPORTED_LANGUAGES,
 } from "../../../../constants/languages";
 import { useLanguage } from "../../../../hooks/useLanguage";
-import { UseConstruct } from "../UseConstruct";
 
 export interface LanguageSelectionProps {
   assembly: Assembly;
@@ -29,18 +27,13 @@ export const LanguageSelection: FunctionComponent<LanguageSelectionProps> = ({
   ] as Language[];
 
   return (
-    <Flex align="center" justify="space-between">
-      <Flex direction="column">
-        <LanguageBar
-          selectedLanguage={targets.includes(language) ? language : targets[0]}
-          setSelectedLanguage={setLanguage}
-          showDisabled
-          targetLanguages={targets.filter((target) =>
-            TEMP_SUPPORTED_LANGUAGES.includes(target)
-          )}
-        />
-      </Flex>
-      <UseConstruct packageName={assembly.name} version={assembly.version} />
-    </Flex>
+    <LanguageBar
+      selectedLanguage={targets.includes(language) ? language : targets[0]}
+      setSelectedLanguage={setLanguage}
+      showDisabled
+      targetLanguages={targets.filter((target) =>
+        TEMP_SUPPORTED_LANGUAGES.includes(target)
+      )}
+    />
   );
 };

--- a/src/views/Package/components/PackageDetails/PackageDetails.tsx
+++ b/src/views/Package/components/PackageDetails/PackageDetails.tsx
@@ -1,9 +1,10 @@
-import { Center, Divider, Grid, Spinner } from "@chakra-ui/react";
+import { Center, Divider, Flex, Grid, Spinner } from "@chakra-ui/react";
 import type { Assembly } from "jsii-reflect";
 import { FunctionComponent } from "react";
 import type { Metadata } from "../../../../api/package/metadata";
 import { Card } from "../../../../components/Card";
 import type { UseRequestResponse } from "../../../../hooks/useRequest";
+import { LanguageSelection } from "../LanguageSelection";
 import { OperatorArea } from "../OperatorArea";
 import { PackageHeader } from "../PackageHeader";
 
@@ -33,23 +34,27 @@ export const PackageDetails: FunctionComponent<PackageDetailsProps> = ({
   }
 
   return (
-    <Grid
-      as={Card}
-      gap={4}
-      templateColumns={["1fr", null, "3fr auto 2fr"]}
-      templateRows="auto"
-    >
-      <PackageHeader
-        description={assembly.data.spec.description}
-        tags={assembly.data.spec.keywords ?? []}
-        title={assembly.data.spec.name}
-      />
-      <Divider display={["none", null, "initial"]} orientation="vertical" />
-      <Divider
-        display={["initial", "initial", "none"]}
-        orientation="horizontal"
-      />
-      <OperatorArea assembly={assembly.data} metadata={metadata.data} />
-    </Grid>
+    <Flex as={Card} direction="column">
+      <Grid
+        gap={4}
+        templateColumns={["1fr", null, "3fr auto 2fr"]}
+        templateRows="auto"
+      >
+        <PackageHeader
+          description={assembly.data.spec.description}
+          tags={assembly.data.spec.keywords ?? []}
+          title={assembly.data.spec.name}
+        />
+        <Divider display={["none", null, "initial"]} orientation="vertical" />
+        <Divider
+          display={["initial", "initial", "none"]}
+          orientation="horizontal"
+        />
+        <OperatorArea assembly={assembly.data} metadata={metadata.data} />
+      </Grid>
+      <Flex justify={["center", null, "start"]} px={2} py={4}>
+        <LanguageSelection assembly={assembly.data} />
+      </Flex>
+    </Flex>
   );
 };

--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -94,7 +94,7 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
       borderTopColor="gray.100"
       columnGap={4}
       h="100%"
-      templateColumns="1fr 3fr"
+      templateColumns={["1fr", null, "1fr 3fr"]}
       width="100%"
     >
       <Flex
@@ -102,21 +102,22 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
         borderRight="1px solid"
         borderRightColor="gray.100"
         direction="column"
+        display={["none", null, "flex"]}
         maxHeight={`calc(100vh - ${TOP_OFFSET})`}
         overflow="hidden auto"
         p={0}
         position="sticky"
         top={TOP_OFFSET}
       >
-        <Box
+        <Flex
           borderBottom="1px solid"
           borderColor="gray.100"
           justify="center"
-          p={0}
+          py={4}
         >
           <ChooseSubmodule assembly={assembly} />
-        </Box>
-        <Box overflowY="auto">
+        </Flex>
+        <Box overflowY="auto" pt={4}>
           <NavTree items={navItems} />
         </Box>
       </Flex>
@@ -129,8 +130,8 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
           "a:target:before": {
             content: `""`,
             display: "block",
-            height: "40px",
-            marginTop: `-40px`,
+            height: TOP_OFFSET,
+            marginTop: `calc(-1 * ${TOP_OFFSET})`,
             visibility: "hidden",
           },
         }}

--- a/src/views/Package/components/UseConstruct/UseConstruct.tsx
+++ b/src/views/Package/components/UseConstruct/UseConstruct.tsx
@@ -45,10 +45,7 @@ export const UseConstruct: FunctionComponent<UseConstructProps> = ({
   const header = LANGUAGE_NAME_MAP[language];
 
   const trigger = (
-    <CodePopoverTrigger
-      disabled={!TEMP_SUPPORTED_LANGUAGES.includes(language)}
-      size="lg"
-    >
+    <CodePopoverTrigger disabled={!TEMP_SUPPORTED_LANGUAGES.includes(language)}>
       Use Construct
     </CodePopoverTrigger>
   );


### PR DESCRIPTION
This work sets up the package page to be ready for mobile nav functionality. The main change is that the language bar has been moved to the package details card, and the side nav is hidden on mobile. In a follow up, the side nav will be rendered in the mobile nav drawer.

Additionally, this PR moves the `CatalogSearchInputs` component into a separate file per [this comment](https://github.com/cdklabs/construct-hub-webapp/pull/180#discussion_r668119441) 

![Screen Shot 2021-07-12 at 3 54 27 PM](https://user-images.githubusercontent.com/8749859/125355814-175cf900-e32b-11eb-9064-7c1f2cf78ccc.png)
![Screen Shot 2021-07-12 at 3 54 41 PM](https://user-images.githubusercontent.com/8749859/125355818-17f58f80-e32b-11eb-874b-8e95e4acef5e.png)
