### PR TITLE
chore: fix metadata access

### DIFF
--- a/src/api/package/packages.ts
+++ b/src/api/package/packages.ts
@@ -14,7 +14,7 @@ export interface CatalogPackage {
   description: string;
   author: Author;
   keywords: string[];
-  metadata: Metadata;
+  metadata?: Metadata;
 }
 
 export interface Packages {

--- a/src/components/CatalogCard/CatalogCard.tsx
+++ b/src/components/CatalogCard/CatalogCard.tsx
@@ -45,15 +45,16 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
     );
   }
 
-  const publishDate = (
+  const publishDate = pkg.metadata?.date ? (
     <Time
       date={new Date(pkg.metadata.date)}
       fontSize="sm"
       format="MMMM dd, yyyy"
     />
-  );
+  ) : null;
 
-  const { author, languages } = pkg;
+  const author = pkg.author ?? {};
+  const languages = pkg.languages ?? {};
   const targets = Object.keys(languages) as Language[];
 
   return (

--- a/src/hooks/useCatalogResults/useCatalogResults.test.ts
+++ b/src/hooks/useCatalogResults/useCatalogResults.test.ts
@@ -1,11 +1,14 @@
 import { renderHook, cleanup } from "@testing-library/react-hooks";
-import catalogFixture from "../../__fixtures__/catalog.json";
+import catalog from "../../__fixtures__/catalog.json";
+import { Packages } from "../../api/package/packages";
 import { Languages } from "../../constants/languages";
 import { useCatalog } from "../../contexts/Catalog";
 import {
   useCatalogResults,
   UseCatalogResultsOptions,
 } from "./useCatalogResults";
+
+const catalogFixture = catalog as Packages;
 
 const defaultOptions: UseCatalogResultsOptions = {
   offset: 0,


### PR DESCRIPTION
The `<CatalogCard />` had some risky / optimistic property access. Updates the catalog type to reflect that metadata _may_ not always be present on a package and handles it more gracefully