### PR TITLE
feat: hide dependencies for now

### DIFF
--- a/src/views/Package/components/OperatorArea/OperatorArea.tsx
+++ b/src/views/Package/components/OperatorArea/OperatorArea.tsx
@@ -5,7 +5,8 @@ import type { Metadata } from "../../../../api/package/metadata";
 import { ExternalLink } from "../../../../components/ExternalLink";
 import { LicenseLink, LICENSE_LINKS } from "../../../../components/LicenseLink";
 import { Time } from "../../../../components/Time";
-import { DependencyDropdown } from "../DependencyDropdown";
+// FIXME: We are temporarily hiding dependencies as they are not all present in s3
+// import { DependencyDropdown } from "../DependencyDropdown";
 
 export interface OperatorAreaProps {
   assembly?: Assembly;
@@ -78,11 +79,11 @@ export const OperatorArea: FunctionComponent<OperatorAreaProps> = ({
   return (
     <Flex direction="column" textAlign={["center", null, "initial"]}>
       {details.length && <UnorderedList ml={0}>{details}</UnorderedList>}
-      {assembly?.dependencies && (
+      {/* {assembly?.dependencies && (
         <Box mt={4}>
           <DependencyDropdown dependencies={assembly.dependencies} />
         </Box>
-      )}
+      )} */}
     </Flex>
   );
 };


### PR DESCRIPTION
Fixes #156 

Temporarily hiding the Dependency Dropdown as not all dependencies are available in s3