### PR TITLE
fix: submodule selection is visible even for packages that don't have any submodules

### DIFF
--- a/src/views/Package/components/ChooseSubmodule/ChooseSubmodule.test.tsx
+++ b/src/views/Package/components/ChooseSubmodule/ChooseSubmodule.test.tsx
@@ -39,6 +39,11 @@ describe("<ChooseSubmodule />", () => {
     expect(queryByTestId("choose-submodule-search-form")).not.toBeNull();
   });
 
+  it("renders nothing if no submodules", () => {
+    const { queryByTestId } = renderComponent({} as any);
+    expect(queryByTestId("choose-submodule-search-trigger")).toBeNull();
+  });
+
   it("only displays back button when a submodule is present", () => {
     let { queryByTestId } = renderComponent();
     expect(queryByTestId("choose-submodule-go-back")).toBeNull();

--- a/src/views/Package/components/ChooseSubmodule/ChooseSubmodule.tsx
+++ b/src/views/Package/components/ChooseSubmodule/ChooseSubmodule.tsx
@@ -18,6 +18,7 @@ export const ChooseSubmodule: FunctionComponent<ChooseSubmoduleProps> = ({
   const { push } = useHistory();
   const query = useQueryParams();
 
+  const allSubmodules = Object.keys(assembly?.submodules ?? {});
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const currentSubmodule = query.get(QUERY_PARAMS.SUBMODULE);
@@ -42,7 +43,7 @@ export const ChooseSubmodule: FunctionComponent<ChooseSubmoduleProps> = ({
   );
 
   const submodules = useMemo(() => {
-    let results = Object.keys(assembly?.submodules ?? {});
+    let results = allSubmodules;
 
     if (filter) {
       results = results.filter((fqn) =>
@@ -57,7 +58,11 @@ export const ChooseSubmodule: FunctionComponent<ChooseSubmoduleProps> = ({
         to: getUrl(name),
       };
     });
-  }, [assembly?.submodules, filter, getUrl]);
+  }, [allSubmodules, filter, getUrl]);
+
+  if (allSubmodules.length === 0) {
+    return null;
+  }
 
   return (
     <Stack spacing={4} w="100%">
@@ -80,7 +85,6 @@ export const ChooseSubmodule: FunctionComponent<ChooseSubmoduleProps> = ({
         borderRadius="none"
         color="blue.500"
         data-testid="choose-submodule-search-trigger"
-        disabled={!Object.keys(assembly?.submodules ?? {}).length}
         flexGrow={1}
         onClick={onOpen}
         rightIcon={<ChevronDownIcon />}


### PR DESCRIPTION
When a package doesn't contain submodules, we currently show the selection as disabled:

<img width="1156" alt="Screen Shot 2021-07-15 at 3 08 43 PM" src="https://user-images.githubusercontent.com/1428812/125793543-74ca5763-1623-42f8-8796-db52bf96dbbf.png">

This seems un-necessary and just takes up screen space.

This PR simply hides it in such a case:

<img width="844" alt="Screen Shot 2021-07-15 at 3 55 08 PM" src="https://user-images.githubusercontent.com/1428812/125793623-8126547e-38e1-4bb6-8e84-071135d1553a.png">
