### PR TITLE
chore: UI updates

### DIFF
--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -3,6 +3,7 @@ import { Children, FunctionComponent, ReactNode } from "react";
 import ReactDOMServer from "react-dom/server";
 import { sanitize } from "../../util/sanitize-anchor";
 import { NavLink } from "../NavLink";
+import { Hr } from "./Hr";
 
 interface HeadingResolverProps {
   level: number;
@@ -14,6 +15,7 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
   children,
 }) => {
   const size: string = ["2xl", "xl", "lg", "md", "sm", "xs"][level - 1];
+  const mb: number = [8, 7, 6, 5, 5, 4][level - 1];
   const elem = `h${level}` as As<any>;
 
   // Use DOMParser to look for data attribute for link ID
@@ -40,17 +42,18 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
   const id = dataElement?.dataset.headingId ?? sanitize(title);
 
   return (
-    <NavLink
-      data-heading-id={id}
-      data-heading-level={level}
-      data-heading-title={title}
-      id={id}
-      replace
-      to={`#${id}`}
-    >
-      <Heading as={elem} color="blue.800" level={level} my={4} size={size}>
+    <Heading as={elem} color="blue.800" level={level} mb={mb} size={size}>
+      <NavLink
+        data-heading-id={id}
+        data-heading-level={level}
+        data-heading-title={title}
+        id={id}
+        replace
+        to={`#${id}`}
+      >
         {children}
-      </Heading>
-    </NavLink>
+        {level < 3 && <Hr />}
+      </NavLink>
+    </Heading>
   );
 };

--- a/src/components/Markdown/Hr.tsx
+++ b/src/components/Markdown/Hr.tsx
@@ -1,4 +1,6 @@
 import { Divider } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 
-export const Hr: FunctionComponent = () => <Divider my={8} />;
+export const Hr: FunctionComponent = () => (
+  <Divider borderBottomWidth="2px" my={4} />
+);

--- a/src/components/Markdown/Text.tsx
+++ b/src/components/Markdown/Text.tsx
@@ -18,7 +18,7 @@ export const Blockquote: FunctionComponent = ({ children }) => (
     borderLeftColor="gray.200"
     borderRadius="md"
     p={2}
-    wordBreak="break-all"
+    wordBreak="break-word"
   >
     {children}
   </Box>

--- a/src/views/Package/components/DependencyDropdown/DependencyDropdown.tsx
+++ b/src/views/Package/components/DependencyDropdown/DependencyDropdown.tsx
@@ -23,9 +23,9 @@ export const DependencyDropdown: FunctionComponent<DependencyDropdownProps> = ({
     <Menu>
       <MenuButton
         as={Button}
-        bg="white"
-        leftIcon={<LinkIcon color="purple.600" />}
-        rightIcon={<ChevronDownIcon color="purple.600" h={6} w={6} />}
+        color="blue.500"
+        leftIcon={<LinkIcon />}
+        rightIcon={<ChevronDownIcon h={6} w={6} />}
         size="md"
         variant="outline"
       >

--- a/src/views/Package/components/PackageDetails/PackageDetails.tsx
+++ b/src/views/Package/components/PackageDetails/PackageDetails.tsx
@@ -37,6 +37,7 @@ export const PackageDetails: FunctionComponent<PackageDetailsProps> = ({
     <Flex as={Card} direction="column">
       <Grid
         gap={4}
+        overflow="hidden"
         templateColumns={{ base: "1fr", md: "3fr auto 2fr" }}
         templateRows="auto"
       >

--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -93,14 +93,16 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
         position="sticky"
         top={TOP_OFFSET}
       >
-        <Flex
-          borderBottom="1px solid"
-          borderColor="gray.100"
-          justify="center"
-          py={4}
-        >
-          <ChooseSubmodule assembly={assembly} />
-        </Flex>
+        {Object.keys(assembly?.submodules ?? {}).length > 0 && (
+          <Flex
+            borderBottom="1px solid"
+            borderColor="gray.100"
+            justify="center"
+            py={4}
+          >
+            <ChooseSubmodule assembly={assembly} />
+          </Flex>
+        )}
         <Box overflowY="auto" pt={4}>
           <NavTree items={navItems} />
         </Box>

--- a/src/views/Package/components/PackageHeader/PackageHeader.tsx
+++ b/src/views/Package/components/PackageHeader/PackageHeader.tsx
@@ -32,18 +32,21 @@ export const PackageHeader: FunctionComponent<PackageHeaderProps> = ({
           justify={{ base: "center", md: "initial" }}
           mt={3}
         >
-          {tags.map((tag) => (
-            <Flex
-              bg="gray.100"
-              borderRadius="sm"
-              justify="center"
-              key={tag}
-              mr={4}
-              p={2}
-            >
-              <Text>{tag.toUpperCase()}</Text>
-            </Flex>
-          ))}
+          {tags
+            .filter(Boolean)
+            .slice(0, 3)
+            .map((tag) => (
+              <Flex
+                bg="gray.100"
+                borderRadius="sm"
+                justify="center"
+                key={tag}
+                mr={4}
+                p={2}
+              >
+                <Text>{tag.toUpperCase()}</Text>
+              </Flex>
+            ))}
         </Flex>
       )}
     </Flex>


### PR DESCRIPTION
- Changes Dependency Dropdown colors to match theme
- Adds appropriate margins to markdown headings
- Adds dividers to markdown h1 & h2
- Hides the submodule box when no submodules are available (button was hidden though it's container wasn't)
- Fixes safari divider overflow issue
- Increases markdown divider width
- Reduces markdown divider margin-y
- Adjusts blockquote work-break to break entire words rather than mid-word
- Adjusts package header to only show first three non-empty keywords