### PR TITLE
bug: close search modal on search

### DIFF
--- a/src/components/SearchModal/SearchModal.tsx
+++ b/src/components/SearchModal/SearchModal.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   UnorderedList,
 } from "@chakra-ui/react";
-import { FunctionComponent } from "react";
+import { FormEventHandler, FunctionComponent } from "react";
 import { useHistory } from "react-router-dom";
 import { QUERY_PARAMS, ROUTES } from "../../constants/url";
 import { useCatalogResults } from "../../hooks/useCatalogResults";
@@ -49,8 +49,13 @@ export const SearchModal: FunctionComponent<SearchModalProps> = ({
   const showResults = (query || language) && displayable.length > 0;
 
   const navigate = (to: string) => {
-    push(to);
     onClose();
+    push(to);
+  };
+
+  const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    onClose();
+    searchAPI.onSubmit(e);
   };
 
   return (
@@ -61,7 +66,7 @@ export const SearchModal: FunctionComponent<SearchModalProps> = ({
             <ModalCloseButton />
             <ModalHeader>Search modules or providers</ModalHeader>
             <ModalBody>
-              <Form onSubmit={searchAPI.onSubmit} pb={4}>
+              <Form onSubmit={onSubmit} pb={4}>
                 <Stack spacing={4}>
                   <CatalogSearchInputs {...searchAPI} />
                 </Stack>

--- a/src/views/Package/Package.tsx
+++ b/src/views/Package/Package.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Stack } from "@chakra-ui/react";
+import { Box, Stack } from "@chakra-ui/react";
 import { FunctionComponent, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { fetchAssembly } from "../../api/package/assembly";
@@ -10,7 +10,6 @@ import { useQueryParams } from "../../hooks/useQueryParams";
 import { useRequest } from "../../hooks/useRequest";
 import { PackageDetails } from "./components/PackageDetails";
 import { PackageDocs } from "./components/PackageDocs";
-import { UseConstruct } from "./components/UseConstruct";
 
 interface PathParams {
   name: string;
@@ -47,14 +46,6 @@ export const Package: FunctionComponent = () => {
           version={version}
         />
       </Box>
-      {assemblyResponse.data && (
-        <Flex justify="end" px={4}>
-          <UseConstruct
-            packageName={assemblyResponse.data.name}
-            version={assemblyResponse.data.version}
-          />
-        </Flex>
-      )}
       {/* Readme and Api Reference Area */}
       {markdownResponse.data &&
         !markdownResponse.loading &&

--- a/src/views/Package/components/ChooseSubmodule/SearchModal.tsx
+++ b/src/views/Package/components/ChooseSubmodule/SearchModal.tsx
@@ -39,8 +39,8 @@ export const SearchModal: FunctionComponent<SearchModalProps> = ({
 
   const navigate = useCallback(
     (to: string) => {
-      push(to);
       onClose();
+      push(to);
     },
     [onClose, push]
   );

--- a/src/views/Package/components/PackageDetails/PackageDetails.tsx
+++ b/src/views/Package/components/PackageDetails/PackageDetails.tsx
@@ -1,4 +1,4 @@
-import { Center, Divider, Flex, Grid, Spinner } from "@chakra-ui/react";
+import { Center, Divider, Flex, Grid, Spinner, Stack } from "@chakra-ui/react";
 import type { Assembly } from "@jsii/spec";
 import { FunctionComponent } from "react";
 import type { Metadata } from "../../../../api/package/metadata";
@@ -7,6 +7,7 @@ import type { UseRequestResponse } from "../../../../hooks/useRequest";
 import { LanguageSelection } from "../LanguageSelection";
 import { OperatorArea } from "../OperatorArea";
 import { PackageHeader } from "../PackageHeader";
+import { UseConstruct } from "../UseConstruct";
 
 interface PackageDetailsProps {
   assembly: UseRequestResponse<Assembly>;
@@ -56,9 +57,20 @@ export const PackageDetails: FunctionComponent<PackageDetailsProps> = ({
         />
         <OperatorArea assembly={assembly.data} metadata={metadata.data} />
       </Grid>
-      <Flex justify={{ base: "center", md: "start" }} px={2} py={4}>
+      <Stack
+        align="center"
+        direction={{ base: "column", md: "row" }}
+        justify={{ base: "center", md: "space-between" }}
+        px={2}
+        py={4}
+        spacing={4}
+      >
         <LanguageSelection assembly={assembly.data} />
-      </Flex>
+        <UseConstruct
+          packageName={assembly.data.name}
+          version={assembly.data.version}
+        />
+      </Stack>
     </Flex>
   );
 };


### PR DESCRIPTION
Fixes #207 

- Closes search modal on search
- Moves UseConstruct button so that it isn't so greedy with space