### PR TITLE
fix: 404 not displayed on packages/@scope/

### DIFF
--- a/src/views/Packages/Packages.tsx
+++ b/src/views/Packages/Packages.tsx
@@ -1,23 +1,30 @@
 import type { FunctionComponent } from "react";
 import { Switch, Route, useRouteMatch } from "react-router-dom";
+import { NotFound } from "../NotFound";
 import { Package } from "../Package";
 import { PackageLatest } from "../PackageLatest";
 
+const nameRegexp = "[^@\\/]+";
+const scopeRegexp = "@[^\\/]+";
+
 export const Packages: FunctionComponent = () => {
   const { path } = useRouteMatch();
+
   return (
     <Switch>
-      <Route exact path={`${path}/:name`}>
+      <Route
+        exact
+        path={`${path}/:scope(${scopeRegexp})?/:name(${nameRegexp})`}
+      >
         <PackageLatest />
       </Route>
-      <Route exact path={`${path}/:scope/:name`}>
-        <PackageLatest />
-      </Route>
-      <Route path={`${path}/:name/v/:version`}>
+      <Route
+        path={`${path}/:scope(${scopeRegexp})?/:name(${nameRegexp})/v/:version`}
+      >
         <Package />
       </Route>
-      <Route path={`${path}/:scope/:name/v/:version`}>
-        <Package />
+      <Route path="*">
+        <NotFound />
       </Route>
     </Switch>
   );


### PR DESCRIPTION
Tightends down routing of the `packages/` scope so that it correctly
renders an HTTP 404 upon trying to hit an npm scope page, which is not
supported.

This ensures the `/@scope/` component has the `@` prefix, and that the
`/name/` component does not have an `@` in it's value.

Fixes #187