### PR TITLE
fix: publisher name not shown on search results

### DIFF
--- a/src/api/package/packages.ts
+++ b/src/api/package/packages.ts
@@ -12,7 +12,7 @@ export interface CatalogPackage {
   languages: Partial<Record<Language, Record<string, unknown>>>;
   version: string;
   description: string;
-  author: Author;
+  author: Author | string;
   keywords: string[];
   metadata?: Metadata;
 }

--- a/src/components/CatalogCard/CatalogCard.tsx
+++ b/src/components/CatalogCard/CatalogCard.tsx
@@ -112,7 +112,11 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
             {publishDate}
           </Text>
 
-          {author.url ? (
+          {typeof author === "string" ? (
+            <Text data-testid={testIds.author} fontSize="sm" isTruncated>
+              {author}
+            </Text>
+          ) : author.url ? (
             <ExternalLink
               data-testid={testIds.author}
               fontSize="sm"
@@ -123,7 +127,7 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
             </ExternalLink>
           ) : (
             <Text data-testid={testIds.author} fontSize="sm" isTruncated>
-              {author.name}
+              {typeof author === "string" ? author : author.name}
             </Text>
           )}
 


### PR DESCRIPTION
When the publisher name is not an object (i.e: it is provided as a
string), it would not be rendered in the search results. This adds a
type check as appropriate to ensure the text is always rendered.

Fixes #206