### PR TITLE
feat: sort search result by publish date

### DIFF
--- a/src/api/package/packages.ts
+++ b/src/api/package/packages.ts
@@ -14,7 +14,7 @@ export interface CatalogPackage {
   description: string;
   author: Author | string;
   keywords: string[];
-  metadata?: Metadata;
+  metadata: Metadata;
 }
 
 export interface Packages {

--- a/src/hooks/useCatalogResults/useCatalogResults.ts
+++ b/src/hooks/useCatalogResults/useCatalogResults.ts
@@ -39,7 +39,14 @@ export const useCatalogResults = ({
       );
     }
 
-    return filtered;
+    return filtered.sort((p1, p2) => {
+      const d1 = new Date(p1.metadata.date);
+      const d2 = new Date(p2.metadata.date);
+      if (d1 === d2) {
+        return 0;
+      }
+      return d1 < d2 ? 1 : -1;
+    });
   }, [data?.packages, error, language, loading, query]);
 
   const pageLimit = results ? Math.floor(results.length / limit) : 0;


### PR DESCRIPTION
Makes a lot more sense to display recently published packages first, so lets use this as a very basic sorting mechanism. 

![Screen Shot 2021-07-20 at 12 47 55 PM](https://user-images.githubusercontent.com/1428812/126303369-393e674f-7774-4735-9811-f27c30d9b819.png)

Closes https://github.com/cdklabs/construct-hub-webapp/issues/216
