### PR TITLE
Revert "chore: safari css fixes"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ export const App: FunctionComponent = () => {
       bg="gray.50"
       gridTemplateColumns="1fr"
       gridTemplateRows="auto 1fr auto"
-      h="100%"
       inset={0}
       maxW="100vw"
       overflow="hidden auto"

--- a/src/components/CodePopover/CodePopover.tsx
+++ b/src/components/CodePopover/CodePopover.tsx
@@ -11,8 +11,6 @@ import {
   Text,
   useClipboard,
   useDisclosure,
-  useMediaQuery,
-  useToken,
 } from "@chakra-ui/react";
 import { FunctionComponent, ReactNode, useRef } from "react";
 import { createTestIds } from "../../util/createTestIds";
@@ -51,14 +49,12 @@ export const CodePopover: FunctionComponent<CodePopoverProps> = ({
   const { hasCopied, onCopy } = useClipboard(code);
   const disclosure = useDisclosure();
   const focusRef = useRef<HTMLButtonElement>(null);
-  const mdBreakpoint = useToken("breakpoints", "md");
-  const [isMd] = useMediaQuery(`(min-width: ${mdBreakpoint})`);
 
   return (
     <Popover
       initialFocusRef={focusRef}
       isLazy
-      placement={isMd ? "bottom-end" : "bottom"}
+      placement="bottom-end"
       {...disclosure}
     >
       <PopoverTrigger>{trigger}</PopoverTrigger>

--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -115,6 +115,7 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
       </Flex>
       <Box
         maxWidth="100%"
+        overflow="hidden"
         p={4}
         sx={{
           a: {


### PR DESCRIPTION
Reverts cdklabs/construct-hub-webapp#228

While I did test on multiple browsers, I did not test breakpoints thoroughly, this has caused regressions on small non-mobile breakpoints and will need to be revisited.