### PR TITLE
feat: show ExternalLinkIcon for external links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ export const App: FunctionComponent = () => {
       bg="gray.50"
       gridTemplateColumns="1fr"
       gridTemplateRows="auto 1fr auto"
+      h="100%"
       inset={0}
       maxW="100vw"
       overflow="hidden auto"

--- a/src/components/CodePopover/CodePopover.tsx
+++ b/src/components/CodePopover/CodePopover.tsx
@@ -11,6 +11,8 @@ import {
   Text,
   useClipboard,
   useDisclosure,
+  useMediaQuery,
+  useToken,
 } from "@chakra-ui/react";
 import { FunctionComponent, ReactNode, useRef } from "react";
 import { createTestIds } from "../../util/createTestIds";
@@ -49,12 +51,14 @@ export const CodePopover: FunctionComponent<CodePopoverProps> = ({
   const { hasCopied, onCopy } = useClipboard(code);
   const disclosure = useDisclosure();
   const focusRef = useRef<HTMLButtonElement>(null);
+  const mdBreakpoint = useToken("breakpoints", "md");
+  const [isMd] = useMediaQuery(`(min-width: ${mdBreakpoint})`);
 
   return (
     <Popover
       initialFocusRef={focusRef}
       isLazy
-      placement="bottom-end"
+      placement={isMd ? "bottom-end" : "bottom"}
       {...disclosure}
     >
       <PopoverTrigger>{trigger}</PopoverTrigger>

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,17 +1,24 @@
+import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { forwardRef, Link, LinkProps } from "@chakra-ui/react";
 
-export interface ExternalLinkProps extends LinkProps {}
+export interface ExternalLinkProps extends LinkProps {
+  hasIcon?: boolean;
+}
 
-export const ExternalLink = forwardRef<ExternalLinkProps, "a">((props, ref) => {
-  return (
-    <Link
-      color="blue.500"
-      ref={ref}
-      rel="noopener noreferrer"
-      target="_blank"
-      {...props}
-    />
-  );
-});
+export const ExternalLink = forwardRef<ExternalLinkProps, "a">(
+  ({ hasIcon = true, children, ...props }, ref) => {
+    return (
+      <Link
+        color="blue.500"
+        ref={ref}
+        rel="noopener noreferrer"
+        target="_blank"
+        {...props}
+      >
+        {children} {hasIcon && <ExternalLinkIcon mb={1} />}
+      </Link>
+    );
+  }
+);
 
 ExternalLink.displayName = "ExternalLink";

--- a/src/components/Markdown/Text.tsx
+++ b/src/components/Markdown/Text.tsx
@@ -1,14 +1,41 @@
 import { Box, HTMLChakraProps, Link, Text } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
+import { ExternalLink } from "../ExternalLink";
 
-export const A: FunctionComponent<HTMLChakraProps<"a">> = ({
-  children,
-  ...linkProps
-}) => (
-  <Link color="blue.500" {...linkProps}>
-    {children}
-  </Link>
-);
+type AnchorComponent = FunctionComponent<HTMLChakraProps<"a">>;
+
+export const A: AnchorComponent = ({ children, href, ...linkProps }) => {
+  let Component: AnchorComponent = Link;
+
+  try {
+    if (href && href.startsWith("http")) {
+      const hostname = new URL(href).hostname;
+
+      if (hostname !== window.location.hostname) {
+        const External: AnchorComponent = (props) => (
+          <ExternalLink hasIcon {...props} />
+        );
+
+        Component = External;
+      }
+    }
+  } catch {
+    Component = Link;
+  }
+
+  return (
+    <Component
+      color="blue.500"
+      href={href}
+      // If we are rendering an img within the link (specifically stability banners),
+      // do not display the external link Icon
+      sx={{ "> img + svg": { display: "none" } }}
+      {...linkProps}
+    >
+      {children}
+    </Component>
+  );
+};
 
 export const Blockquote: FunctionComponent = ({ children }) => (
   <Box

--- a/src/components/NavPopover/NavPopoverContent.tsx
+++ b/src/components/NavPopover/NavPopoverContent.tsx
@@ -19,7 +19,16 @@ const Link: FunctionComponent<ILink> = ({ display, isNavLink, url }) =>
   isNavLink ? (
     <NavLink to={url}>{display}</NavLink>
   ) : (
-    <ExternalLink href={url}>{display}</ExternalLink>
+    <ExternalLink
+      alignItems="center"
+      display="flex"
+      hasIcon
+      href={url}
+      justifyContent="space-between"
+      w="100%"
+    >
+      {display}
+    </ExternalLink>
   );
 
 export const NavPopoverContent = forwardRef<NavPopoverContentProps, "div">(

--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -114,6 +114,7 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
         </Box>
       </Flex>
       <Box
+        h="max-content"
         maxWidth="100%"
         overflow="hidden"
         p={4}


### PR DESCRIPTION
This PR:
- Adds an ExternalLinkIcon to external links so that users have visual indication that a link will take them out of our site
- Fixes the reverted safari css changes

![Screen Shot 2021-07-20 at 11 52 08 AM](https://user-images.githubusercontent.com/8749859/126366018-2e85ec62-0171-4744-b1bb-cc9f83347fb9.png)
![Screen Shot 2021-07-20 at 11 52 20 AM](https://user-images.githubusercontent.com/8749859/126366021-0298edc4-13b0-44b8-81a2-ff12b7dbedf7.png)
![Screen Shot 2021-07-20 at 11 52 30 AM](https://user-images.githubusercontent.com/8749859/126366022-ae84adde-f662-41a3-aa18-df4d0d1fc0e7.png)
