### PR TITLE
fix: headings are not prominent enough

### DIFF
--- a/src/components/Markdown/Code.tsx
+++ b/src/components/Markdown/Code.tsx
@@ -17,7 +17,7 @@ export const Code: FunctionComponent<CodeProps> = ({
   if (inline) {
     return (
       <InlineCode
-        bg="gray.50"
+        bg="gray.100"
         border="1px solid"
         borderColor="gray.100"
         borderRadius="md"

--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -49,7 +49,7 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
         data-heading-title={title}
         id={id}
         replace
-        sx={{ "> code": { color: "black", fontSize: "inherit" } }}
+        sx={{ "> code": { color: "blue.800", fontSize: "inherit" } }}
         to={`#${id}`}
       >
         {children}

--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -49,6 +49,7 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
         data-heading-title={title}
         id={id}
         replace
+        sx={{ "> code": { color: "black", fontSize: "inherit" } }}
         to={`#${id}`}
       >
         {children}

--- a/src/components/Markdown/List.tsx
+++ b/src/components/Markdown/List.tsx
@@ -2,11 +2,11 @@ import { UnorderedList, OrderedList, ListItem } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 
 export const Ul: FunctionComponent = ({ children }) => (
-  <UnorderedList mx={0}>{children}</UnorderedList>
+  <UnorderedList>{children}</UnorderedList>
 );
 
 export const Ol: FunctionComponent = ({ children }) => (
-  <OrderedList mx={0}>{children}</OrderedList>
+  <OrderedList>{children}</OrderedList>
 );
 
 export const Li: FunctionComponent = ({ children }) => (
@@ -14,9 +14,14 @@ export const Li: FunctionComponent = ({ children }) => (
     sx={{
       "em:first-of-type": {
         mr: 2,
+        fontStyle: "italic",
+        fontSize: "small",
       },
       "&::marker": {
         color: "blue.500",
+      },
+      code: {
+        fontSize: "small",
       },
     }}
   >


### PR DESCRIPTION
This PR fixes:

- List items were not aligned with the text (they appeared more on the left). This was solved by removing any explicit margin definitions and letting the markdown component handle it.
- Headings which were formatted with `pre` (i.e properties/parameters) received a smaller font size than their appropriate h-level since this is what the `Code` element does. Resolve by applying special CSS selector to override this behavior. Also changed to color to black and reserve blue colors to links only.
- Increase grey background for those headings to create a clear distinction between them and other headings. 
- Fix list item prefixes in metadata to be *italic*, as originally intended and decrease font size of metadata.

### Before

<img width="667" alt="Screen Shot 2021-07-20 at 11 42 28 PM" src="https://user-images.githubusercontent.com/1428812/126462951-66458a28-c60b-4839-901b-b82a498b5f50.png">
 
### After

<img width="661" alt="Screen Shot 2021-07-20 at 11 41 57 PM" src="https://user-images.githubusercontent.com/1428812/126463018-2a9daefc-2f46-43ad-8a5f-351faddcde77.png">

Fixes https://github.com/cdklabs/construct-hub/issues/201