### PR TITLE
feat: Dev Preview Banner + card adjustments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Grid } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 import { Switch, Route } from "react-router-dom";
+import { DevPreviewBanner } from "./components/DevPreviewBanner";
 import { Footer } from "./components/Footer";
 import { Header } from "./components/Header";
 import { ROUTES } from "./constants/url";
@@ -17,7 +18,7 @@ export const App: FunctionComponent = () => {
       as="main"
       bg="gray.50"
       gridTemplateColumns="1fr"
-      gridTemplateRows="auto 1fr auto"
+      gridTemplateRows="auto auto 1fr auto"
       h="100%"
       inset={0}
       maxW="100vw"
@@ -25,6 +26,7 @@ export const App: FunctionComponent = () => {
       position="fixed"
     >
       <Header />
+      <DevPreviewBanner />
       <Switch>
         <Route exact path={ROUTES.FAQ}>
           <FAQ />

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -9,8 +9,10 @@ export const Card = forwardRef<CardProps, "div">((props, ref) => {
   return (
     <Box
       bg="white"
+      border="1px solid"
+      borderColor="blue.100"
       borderRadius="md"
-      boxShadow="base"
+      boxShadow="md"
       p={2}
       ref={ref}
       {...props}

--- a/src/components/CatalogCard/CatalogCardContainer.tsx
+++ b/src/components/CatalogCard/CatalogCardContainer.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { Card } from "../Card";
 
 const CardContainer: FunctionComponent = ({ children }) => (
-  <Card border="1px solid" borderColor="blue.100" h={64} p={0} w="100%">
+  <Card h={64} p={0} w="100%">
     <Grid
       as="article"
       h="100%"

--- a/src/components/DevPreviewBanner/DevPreviewBanner.tsx
+++ b/src/components/DevPreviewBanner/DevPreviewBanner.tsx
@@ -24,6 +24,7 @@ export const DevPreviewBanner: FunctionComponent = () => {
     <Box h="max-content">
       <Collapse in={isOpen}>
         <Card
+          aria-label="Developer Preview Banner"
           bg="blue.500"
           border="none"
           boxShadow="none"
@@ -32,6 +33,7 @@ export const DevPreviewBanner: FunctionComponent = () => {
           mx={4}
           p={4}
           position="relative"
+          role="alertdialog"
         >
           <InfoOutlineIcon h={5} left={4} position="absolute" top={4} w={5} />
           <Text fontSize="md" mx={8} textAlign="center">

--- a/src/components/DevPreviewBanner/DevPreviewBanner.tsx
+++ b/src/components/DevPreviewBanner/DevPreviewBanner.tsx
@@ -1,0 +1,60 @@
+import { CloseIcon } from "@chakra-ui/icons";
+import {
+  Box,
+  IconButton,
+  Collapse,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
+import type { FunctionComponent } from "react";
+import { Card } from "../Card";
+import { ExternalLink } from "../ExternalLink";
+
+const STORAGE_KEY = "showing-dev-preview-banner";
+
+export const DevPreviewBanner: FunctionComponent = () => {
+  const { isOpen, onClose } = useDisclosure({
+    defaultIsOpen: JSON.parse(
+      window.sessionStorage.getItem(STORAGE_KEY) ?? "true"
+    ),
+    onClose: () => window.sessionStorage.setItem(STORAGE_KEY, "false"),
+  });
+
+  return (
+    <Box h="max-content">
+      <Collapse in={isOpen}>
+        <Card
+          bg="white"
+          color="blue.800"
+          mt={4}
+          mx={4}
+          p={4}
+          position="relative"
+        >
+          <Text fontSize="md" mr={8} textAlign="center">
+            This application is in Developer Preview. Some features may change.
+            If you find any issues, please report them{" "}
+            <ExternalLink
+              hasWarning={false}
+              href="https://github.com/cdklabs/construct-hub-webapp/issues"
+            >
+              here
+            </ExternalLink>
+          </Text>
+          <IconButton
+            aria-label="Dismiss banner"
+            colorScheme="blue"
+            icon={<CloseIcon />}
+            onClick={onClose}
+            position="absolute"
+            right={4}
+            size="sm"
+            top="50%"
+            transform="translateY(-50%)"
+            variant="ghost"
+          />
+        </Card>
+      </Collapse>
+    </Box>
+  );
+};

--- a/src/components/DevPreviewBanner/DevPreviewBanner.tsx
+++ b/src/components/DevPreviewBanner/DevPreviewBanner.tsx
@@ -1,4 +1,4 @@
-import { CloseIcon } from "@chakra-ui/icons";
+import { CloseIcon, InfoOutlineIcon } from "@chakra-ui/icons";
 import {
   Box,
   IconButton,
@@ -24,33 +24,37 @@ export const DevPreviewBanner: FunctionComponent = () => {
     <Box h="max-content">
       <Collapse in={isOpen}>
         <Card
-          bg="white"
-          color="blue.800"
+          bg="blue.500"
+          border="none"
+          boxShadow="none"
+          color="white"
           mt={4}
           mx={4}
           p={4}
           position="relative"
         >
-          <Text fontSize="md" mr={8} textAlign="center">
+          <InfoOutlineIcon h={5} left={4} position="absolute" top={4} w={5} />
+          <Text fontSize="md" mx={8} textAlign="center">
             This application is in Developer Preview. Some features may change.
             If you find any issues, please report them{" "}
             <ExternalLink
+              color="inherit"
               hasWarning={false}
               href="https://github.com/cdklabs/construct-hub-webapp/issues"
+              textDecoration="underline"
             >
               here
             </ExternalLink>
           </Text>
           <IconButton
             aria-label="Dismiss banner"
-            colorScheme="blue"
+            colorScheme="white"
             icon={<CloseIcon />}
             onClick={onClose}
             position="absolute"
             right={4}
-            size="sm"
-            top="50%"
-            transform="translateY(-50%)"
+            size="xs"
+            top={3}
             variant="ghost"
           />
         </Card>

--- a/src/components/DevPreviewBanner/DevPreviewBanner.tsx
+++ b/src/components/DevPreviewBanner/DevPreviewBanner.tsx
@@ -37,7 +37,7 @@ export const DevPreviewBanner: FunctionComponent = () => {
         >
           <InfoOutlineIcon h={5} left={4} position="absolute" top={4} w={5} />
           <Text fontSize="md" mx={8} textAlign="center">
-            This application is in Developer Preview. Some features may change.
+            This application is in Beta. Some features may change.
             If you find any issues, please report them{" "}
             <ExternalLink
               color="inherit"

--- a/src/components/DevPreviewBanner/DevPreviewBanner.tsx
+++ b/src/components/DevPreviewBanner/DevPreviewBanner.tsx
@@ -37,8 +37,8 @@ export const DevPreviewBanner: FunctionComponent = () => {
         >
           <InfoOutlineIcon h={5} left={4} position="absolute" top={4} w={5} />
           <Text fontSize="md" mx={8} textAlign="center">
-            This application is in Beta. Some features may change.
-            If you find any issues, please report them{" "}
+            This application is in Beta. Some features may change. If you find
+            any issues, please report them{" "}
             <ExternalLink
               color="inherit"
               hasWarning={false}

--- a/src/components/DevPreviewBanner/index.ts
+++ b/src/components/DevPreviewBanner/index.ts
@@ -1,0 +1,1 @@
+export * from "./DevPreviewBanner";

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Grid, GridItem, GridItemProps } from "@chakra-ui/react";
+import { Box, Grid, GridItem, GridItemProps } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
 import { Community } from "./Community";
 import { GettingStarted } from "./GettingStarted";
@@ -16,13 +16,14 @@ export const Header: FunctionComponent = () => {
       alignItems="center"
       as="header"
       bg="white"
+      borderBottom="1px solid"
+      borderBottomColor="blue.100"
       boxShadow="base"
       data-testid="header"
       gap={4}
       gridTemplateColumns={{
         base: "1fr 3fr 1fr",
-        md: "2fr 3fr 2fr",
-        lg: "1fr 2fr 1fr",
+        md: "minmax(200px, 2fr) minmax(200px, 3fr) 2fr",
       }}
       gridTemplateRows="1fr"
       maxW="100vw"
@@ -55,14 +56,18 @@ export const Header: FunctionComponent = () => {
         justifySelf={{ base: "start", md: "end" }}
       >
         <Grid
-          alignItems="center"
           display={{ base: "none", md: "grid" }}
           gridTemplateColumns="1fr 1fr"
           gridTemplateRows="1fr"
+          placeItems="center"
           w="100%"
         >
-          <GettingStarted />
-          <Community />
+          <Box>
+            <GettingStarted />
+          </Box>
+          <Box>
+            <Community />
+          </Box>
         </Grid>
         <NavButton />
       </HeaderItem>

--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -41,14 +41,7 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
   const id = dataElement?.dataset.headingId ?? sanitize(title);
 
   return (
-    <Heading
-      _notFirst={{ mt: marginY }}
-      as={elem}
-      color="blue.800"
-      level={level}
-      mb={marginY}
-      size={size}
-    >
+    <Heading as={elem} color="blue.800" level={level} my={marginY} size={size}>
       <NavLink
         data-heading-id={id}
         data-heading-level={level}

--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -14,7 +14,7 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
   children,
 }) => {
   const size: string = ["2xl", "xl", "lg", "md", "sm", "xs"][level - 1];
-  const mb: number = [8, 7, 6, 5, 5, 4][level - 1];
+  const marginY: number = [8, 7, 6, 5, 5, 4][level - 1];
   const elem = `h${level}` as As<any>;
 
   // Use DOMParser to look for data attribute for link ID
@@ -41,7 +41,14 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
   const id = dataElement?.dataset.headingId ?? sanitize(title);
 
   return (
-    <Heading as={elem} color="blue.800" level={level} mb={mb} size={size}>
+    <Heading
+      _notFirst={{ mt: marginY }}
+      as={elem}
+      color="blue.800"
+      level={level}
+      mb={marginY}
+      size={size}
+    >
       <NavLink
         data-heading-id={id}
         data-heading-level={level}

--- a/src/components/Markdown/Hr.tsx
+++ b/src/components/Markdown/Hr.tsx
@@ -1,10 +1,11 @@
-import { Divider } from "@chakra-ui/react";
+import { Divider, DividerProps } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 
-export const Hr: FunctionComponent = () => (
+export const Hr: FunctionComponent<DividerProps> = (props) => (
   <Divider
     borderBottomWidth="2px"
     borderColor="rgba(0, 124, 253, 0.15)"
     my={4}
+    {...props}
   />
 );

--- a/src/components/Markdown/Hr.tsx
+++ b/src/components/Markdown/Hr.tsx
@@ -2,5 +2,9 @@ import { Divider } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 
 export const Hr: FunctionComponent = () => (
-  <Divider borderBottomWidth="2px" my={4} />
+  <Divider
+    borderBottomWidth="2px"
+    borderColor="rgba(0, 124, 253, 0.15)"
+    my={4}
+  />
 );

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -116,7 +116,7 @@ export const Markdown: FunctionComponent<{
         };
 
   return (
-    <Box sx={{ "& > *": { mb: 4 } }}>
+    <Box sx={{ "& > *": { mb: 4 }, "& > :first-child": { mt: 0 } }}>
       <ReactMarkdown
         components={components}
         rehypePlugins={rehypePlugins}

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -28,7 +28,7 @@ export const Home: FunctionComponent = () => {
   });
 
   return (
-    <>
+    <Box position="relative">
       <Picture
         alt={""}
         h="540px"
@@ -81,6 +81,6 @@ export const Home: FunctionComponent = () => {
           setOffset={setOffset}
         />
       </Box>
-    </>
+    </Box>
   );
 };

--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -80,8 +80,6 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
   return (
     <Grid
       bg="white"
-      borderTop="1px solid"
-      borderTopColor="gray.100"
       columnGap={4}
       h="100%"
       templateColumns={{ base: "1fr", md: "1fr 3fr" }}
@@ -90,7 +88,7 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
       <Flex
         alignSelf="stretch"
         borderRight="1px solid"
-        borderRightColor="gray.100"
+        borderRightColor="blue.50"
         direction="column"
         display={{ base: "none", md: "flex" }}
         maxHeight={`calc(100vh - ${TOP_OFFSET})`}
@@ -102,7 +100,7 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
         {Object.keys(assembly?.submodules ?? {}).length > 0 && (
           <Flex
             borderBottom="1px solid"
-            borderColor="gray.100"
+            borderColor="blue.50"
             justify="center"
             py={4}
           >

--- a/src/views/Package/components/PackageDocsError/PackageDocsError.tsx
+++ b/src/views/Package/components/PackageDocsError/PackageDocsError.tsx
@@ -20,11 +20,12 @@ export const PackageDocsError: FunctionComponent<PackageDocsErrorProps> = ({
       align="center"
       fontSize="xl"
       fontStyle="oblique"
+      px={4}
       wordBreak="break-word"
     >
       Documentation in {language} is still not ready for this package. Come back
-      soon. If this issue persists, please let us know by creting an {issueLink}
-      .
+      soon. If this issue persists, please let us know by creating an{" "}
+      {issueLink}.
     </Text>
   );
 };

--- a/src/views/SearchResults/SearchResults.tsx
+++ b/src/views/SearchResults/SearchResults.tsx
@@ -74,12 +74,12 @@ export const SearchResults: FunctionComponent = () => {
 
   return (
     <Flex direction="column" maxW="100vw">
-      <Box px={4} py={6}>
+      <Box px={4} py={4}>
         <CatalogSearch {...searchAPI} />
       </Box>
       <Divider />
-      <Box px={4} py={6}>
-        <Box pb={6}>
+      <Box px={4} py={4}>
+        <Box pb={4}>
           <ShowingDetails
             count={results.length}
             filtered={!!searchQuery}

--- a/src/views/SearchResults/SearchResults.tsx
+++ b/src/views/SearchResults/SearchResults.tsx
@@ -74,11 +74,11 @@ export const SearchResults: FunctionComponent = () => {
 
   return (
     <Flex direction="column" maxW="100vw">
-      <Box px={10} py={6}>
+      <Box px={4} py={6}>
         <CatalogSearch {...searchAPI} />
       </Box>
       <Divider />
-      <Box px={10} py={6}>
+      <Box px={4} py={6}>
         <Box pb={6}>
           <ShowingDetails
             count={results.length}

--- a/src/views/SearchResults/components/PageControls.tsx
+++ b/src/views/SearchResults/components/PageControls.tsx
@@ -23,7 +23,7 @@ export const PageControls: FunctionComponent<PageControlsProps> = ({
   return (
     <Grid
       alignItems="center"
-      pt={6}
+      pt={4}
       templateColumns="repeat(3, 1fr)"
       templateRows="1fr"
     >


### PR DESCRIPTION
Fixes https://github.com/cdklabs/construct-hub-webapp/issues/238

This PR implements a dismiss-able banner to indicate the application is in Dev Preview. The dismissal lasts for the duration of a session via the SessionStorage API

![Screen Shot 2021-07-26 at 11 45 12 AM](https://user-images.githubusercontent.com/8749859/127027087-b7cb0d79-6d99-443d-9cee-197109be6371.png)


Additional Changes:
- Enforces consistent layout spacing on pages
- Card border & shadow updated to further match design
- Documentation borders & dividers match design colors
- Headings in markdown have addition top margin (except first)
- Adjusted Heading layout to prevent word-break on logo for tablets