### PR TITLE
chore: nav tree ui updates

### DIFF
--- a/src/components/NavTree/NavTree.tsx
+++ b/src/components/NavTree/NavTree.tsx
@@ -60,13 +60,13 @@ export const NavItem: FunctionComponent<NavItemProps> = ({
   );
 
   return (
-    <Flex direction="column" pl={2}>
+    <Flex direction="column">
       <Flex align="center" color={linkIsActive ? "blue.500" : "gray.800"}>
         {showToggle && (
           <IconButton
             aria-label="expand-toggle"
             borderRadius="md"
-            h={2}
+            h={4}
             icon={
               disclosure.isOpen ? (
                 <ChevronDownIcon {...iconProps} />
@@ -74,17 +74,17 @@ export const NavItem: FunctionComponent<NavItemProps> = ({
                 <ChevronRightIcon {...iconProps} />
               )
             }
-            ml={-2}
+            ml={-1}
             onClick={disclosure.onToggle}
             size="xs"
             variant="link"
-            w={2}
+            w={4}
           />
         )}
         <LinkComponent
           href={url}
           overflow="hidden"
-          pl={!showToggle ? 4 : 0}
+          pl={!showToggle ? 1 : 0}
           textOverflow="ellipsis"
           title={display}
           to={url}
@@ -94,10 +94,21 @@ export const NavItem: FunctionComponent<NavItemProps> = ({
         </LinkComponent>
       </Flex>
       <Box
-        borderLeft={"1px solid"}
-        borderLeftColor="gray.100"
+        _before={{
+          // Creates a border without taking up any box space
+          // This is important to keep items perfectly aligned
+          bg: "gray.100",
+          bottom: 0,
+          content: `""`,
+          left: 0,
+          position: "absolute",
+          top: 0,
+          w: "1px",
+        }}
         display={showChildren ? "initial" : "none"}
-        ml={1}
+        ml={2}
+        pl={2}
+        position="relative"
       >
         {nestedItems}
       </Box>
@@ -107,7 +118,7 @@ export const NavItem: FunctionComponent<NavItemProps> = ({
 
 export const NavTree: FunctionComponent<NavTreeProps> = ({ items }) => {
   return (
-    <Flex direction="column" maxWidth="100%" overflowX="hidden">
+    <Flex direction="column" maxWidth="100%">
       {items.map((item, idx) => {
         return <NavItem {...item} key={idx} onOpen={undefined} />;
       })}

--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -93,8 +93,8 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
         display={{ base: "none", md: "flex" }}
         maxHeight={`calc(100vh - ${TOP_OFFSET})`}
         overflow="hidden auto"
-        p={0}
         position="sticky"
+        px={4}
         top={TOP_OFFSET}
       >
         {Object.keys(assembly?.submodules ?? {}).length > 0 && (
@@ -107,7 +107,7 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
             <ChooseSubmodule assembly={assembly} />
           </Flex>
         )}
-        <Box overflowY="auto" pt={4}>
+        <Box overflowY="auto" py={4}>
           <NavTree items={navItems} />
         </Box>
       </Flex>


### PR DESCRIPTION
Updates the Nav Tree to:
- Not cut off outlines for top & bottom elements
- Align children with their parent text rather than indent

![Screen Shot 2021-07-27 at 9 56 33 AM](https://user-images.githubusercontent.com/8749859/127177769-fad9806f-8f93-4ca5-b5f2-3d89ea4ba16f.png)
![Screen Shot 2021-07-27 at 9 56 46 AM](https://user-images.githubusercontent.com/8749859/127177771-d7150f0e-5903-4c23-b547-5db20e24434d.png)
