### PR TITLE
feat: search by author

### DIFF
--- a/src/components/CatalogCard/CatalogCard.tsx
+++ b/src/components/CatalogCard/CatalogCard.tsx
@@ -145,7 +145,7 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
           <UILnk
             color="blue.500"
             fontSize="sm"
-            href={`./search?q=${authorName}&offset=0`}
+            href={`./search?q=${authorName}`}
             onClick={(e) => e.stopPropagation()}
           >
             {authorName}

--- a/src/components/CatalogCard/CatalogCard.tsx
+++ b/src/components/CatalogCard/CatalogCard.tsx
@@ -3,6 +3,7 @@ import {
   Divider,
   Flex,
   LinkBox,
+  Link as UILnk,
   LinkOverlay,
   Stack,
   Text,
@@ -18,7 +19,6 @@ import {
 } from "../../constants/languages";
 import { createTestIds } from "../../util/createTestIds";
 import { getPackagePath } from "../../util/url";
-import { ExternalLink } from "../ExternalLink";
 import { LanguageSupportTooltip } from "../LanguageSupportTooltip";
 import { PackageTag } from "../PackageTag";
 import { Time } from "../Time";
@@ -77,6 +77,8 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
       language: currentLanguage,
       ...params,
     });
+
+  const authorName = typeof author === "string" ? author : author.name;
 
   return (
     <CatalogCardContainer isLink>
@@ -140,24 +142,14 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
             {publishDate}
           </Text>
 
-          {typeof author === "string" ? (
-            <Text data-testid={testIds.author} fontSize="sm" isTruncated>
-              {author}
-            </Text>
-          ) : author.url ? (
-            <ExternalLink
-              data-testid={testIds.author}
-              fontSize="sm"
-              href={author.url}
-              onClick={(e) => e.stopPropagation()}
-            >
-              {author.name}
-            </ExternalLink>
-          ) : (
-            <Text data-testid={testIds.author} fontSize="sm" isTruncated>
-              {typeof author === "string" ? author : author.name}
-            </Text>
-          )}
+          <UILnk
+            color="blue.500"
+            fontSize="sm"
+            href={`./search?q=${authorName}&offset=0`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {authorName}
+          </UILnk>
 
           {/* Language Support Icons */}
           <LinkBox align="center" as={Stack} direction="row">

--- a/src/components/CatalogCard/CatalogCard.tsx
+++ b/src/components/CatalogCard/CatalogCard.tsx
@@ -3,7 +3,7 @@ import {
   Divider,
   Flex,
   LinkBox,
-  Link as UILnk,
+  Link as UILink,
   LinkOverlay,
   Stack,
   Text,
@@ -18,7 +18,7 @@ import {
   TEMP_SUPPORTED_LANGUAGES,
 } from "../../constants/languages";
 import { createTestIds } from "../../util/createTestIds";
-import { getPackagePath } from "../../util/url";
+import { getPackagePath, getSearchPath } from "../../util/url";
 import { LanguageSupportTooltip } from "../LanguageSupportTooltip";
 import { PackageTag } from "../PackageTag";
 import { Time } from "../Time";
@@ -142,14 +142,15 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
             {publishDate}
           </Text>
 
-          <UILnk
+          <UILink
+            as={Link}
             color="blue.500"
+            data-testid={testIds.author}
             fontSize="sm"
-            href={`./search?q=${authorName}`}
-            onClick={(e) => e.stopPropagation()}
+            to={getSearchPath({ query: authorName })}
           >
             {authorName}
-          </UILnk>
+          </UILink>
 
           {/* Language Support Icons */}
           <LinkBox align="center" as={Stack} direction="row">


### PR DESCRIPTION
In the result cards, clicking on the author will now result in a search query for that author, instead of going to the author UR, which will now only be available from the operator area of the package page. 

Closes https://github.com/cdklabs/construct-hub-webapp/issues/271