### PR TITLE
fix: long api references do not load

### DIFF
--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -13,6 +13,8 @@ import { Ul, Ol, Li } from "./List";
 import { Table, Thead, Tbody, Tfoot, Tr, Th, Td, TableCaption } from "./Table";
 import { A, Blockquote, Em, P, Pre, Sup } from "./Text";
 
+const ONE_MEGABYTE = 1024 * 1024;
+
 const components = {
   a: A,
   blockquote: Blockquote,
@@ -115,6 +117,11 @@ export const Markdown: FunctionComponent<{
           return `https://${githubPrefix}/${owner}/${repo}/${githubSuffix}/${url}`;
         };
 
+  const byteLength = Buffer.byteLength(children);
+  if (byteLength > ONE_MEGABYTE) {
+    console.log(`Doc page is larger than 1MB, showing only README...`);
+    children = children.substring(0, children.lastIndexOf("# API Reference"));
+  }
   return (
     <Box sx={{ "& > *": { mb: 4 }, "& > :first-child": { mt: 0 } }}>
       <ReactMarkdown

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -121,6 +121,12 @@ export const Markdown: FunctionComponent<{
   if (byteLength > ONE_MEGABYTE) {
     console.log(`Doc page is larger than 1MB, showing only README...`);
     children = children.substring(0, children.lastIndexOf("# API Reference"));
+    children = [
+      children,
+      "# API Reference",
+      "The API Reference for this package could not be rendered.",
+      "If this issue persists, please let us know by creating an [issue](https://github.com/cdklabs/construct-hub-webapp/issues/new)",
+    ].join("\n");
   }
   return (
     <Box sx={{ "& > *": { mb: 4 }, "& > :first-child": { mt: 0 } }}>

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -119,7 +119,6 @@ export const Markdown: FunctionComponent<{
 
   const byteLength = Buffer.byteLength(children);
   if (byteLength > ONE_MEGABYTE) {
-    console.log(`Doc page is larger than 1MB, showing only README...`);
     children = children.substring(0, children.lastIndexOf("# API Reference"));
     children = [
       children,


### PR DESCRIPTION
An example would be: https://constructs.dev/packages/cdk-iam-floyd/v/0.218.0

This PR puts a hard limit of 1MB on the size of the docs page, anything above that will cause only the README to be displayed, along with a notice that the API reference couldn't be rendered. 

Note that the README displayed is the transliterated README, so at least we have that added value for those packages. 

This is just a stop-gap until we are able to resolve the issue, but at least we won't crash and stall browsers. 

![Screen Shot 2021-07-29 at 11 29 55 AM](https://user-images.githubusercontent.com/1428812/127467014-2367b6b5-3c6f-444f-b707-d2eb301d3f9e.png)
![Screen Shot 2021-07-29 at 12 15 53 PM](https://user-images.githubusercontent.com/1428812/127467051-c883c949-34e8-4af4-9962-4929312d80c9.png)
