### PR TITLE
chore: disable preview banner dismissal

### DIFF
--- a/src/components/DevPreviewBanner/DevPreviewBanner.tsx
+++ b/src/components/DevPreviewBanner/DevPreviewBanner.tsx
@@ -1,28 +1,13 @@
-import { CloseIcon, InfoOutlineIcon } from "@chakra-ui/icons";
-import {
-  Box,
-  IconButton,
-  Collapse,
-  Text,
-  useDisclosure,
-} from "@chakra-ui/react";
+import { InfoOutlineIcon } from "@chakra-ui/icons";
+import { Box, Collapse, Text } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 import { Card } from "../Card";
 import { ExternalLink } from "../ExternalLink";
 
-const STORAGE_KEY = "showing-dev-preview-banner";
-
 export const DevPreviewBanner: FunctionComponent = () => {
-  const { isOpen, onClose } = useDisclosure({
-    defaultIsOpen: JSON.parse(
-      window.sessionStorage.getItem(STORAGE_KEY) ?? "true"
-    ),
-    onClose: () => window.sessionStorage.setItem(STORAGE_KEY, "false"),
-  });
-
   return (
     <Box h="max-content">
-      <Collapse in={isOpen}>
+      <Collapse in={true}>
         <Card
           aria-label="Preview Banner"
           bg="blue.500"
@@ -48,17 +33,6 @@ export const DevPreviewBanner: FunctionComponent = () => {
               here
             </ExternalLink>
           </Text>
-          <IconButton
-            aria-label="Dismiss banner"
-            colorScheme="white"
-            icon={<CloseIcon />}
-            onClick={onClose}
-            position="absolute"
-            right={4}
-            size="xs"
-            top={3}
-            variant="ghost"
-          />
         </Card>
       </Collapse>
     </Box>


### PR DESCRIPTION
Suggestion from @eladb to disable the ability to dismiss the preview banner - so that no one forgets. 

![Screen Shot 2021-07-29 at 3 51 59 PM](https://user-images.githubusercontent.com/1428812/127495436-f88ef5cb-f1e5-467e-9265-1b8aa930e2c2.png)
