### PR TITLE
feat: doc styles

### DIFF
--- a/src/components/Code/Code.tsx
+++ b/src/components/Code/Code.tsx
@@ -21,8 +21,7 @@ export const Code: FunctionComponent<CodeProps> = ({ code, language }) => {
       {(props) => (
         <Box
           as="pre"
-          border="1px solid"
-          borderColor="blue.100"
+          border="base"
           borderRadius="md"
           boxShadow="base"
           className={props.className}

--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -3,6 +3,7 @@ import { Children, FunctionComponent, ReactNode } from "react";
 import ReactDOMServer from "react-dom/server";
 import { sanitize } from "../../util/sanitize-anchor";
 import { NavLink } from "../NavLink";
+import { Hr } from "./Hr";
 
 interface HeadingResolverProps {
   level: number;
@@ -14,7 +15,7 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
   children,
 }) => {
   const size: string = ["2xl", "xl", "lg", "md", "sm", "xs"][level - 1];
-  const marginY: number = [8, 7, 6, 5, 5, 4][level - 1];
+  const marginY: number = [10, 10, 10, 8, 8, 8][level - 1];
   const elem = `h${level}` as As<any>;
 
   // Use DOMParser to look for data attribute for link ID
@@ -40,19 +41,34 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
 
   const id = dataElement?.dataset.headingId ?? sanitize(title);
 
+  const isH3OrLarger = level < 4;
+
   return (
-    <Heading as={elem} color="blue.800" level={level} my={marginY} size={size}>
-      <NavLink
-        data-heading-id={id}
-        data-heading-level={level}
-        data-heading-title={title}
-        id={id}
-        replace
-        sx={{ "> code": { color: "blue.800", fontSize: "inherit" } }}
-        to={`#${id}`}
+    <>
+      <Heading
+        as={elem}
+        color="blue.800"
+        level={level}
+        mb={isH3OrLarger ? 0 : level}
+        mt={marginY}
+        size={size}
       >
-        {children}
-      </NavLink>
-    </Heading>
+        <NavLink
+          data-heading-id={id}
+          data-heading-level={level}
+          data-heading-title={title}
+          id={id}
+          replace
+          sx={{ "> code": { color: "blue.800", fontSize: "inherit" } }}
+          to={`#${id}`}
+        >
+          {children}
+        </NavLink>
+      </Heading>
+      {isH3OrLarger && (
+        // If there's an adjacent HR from the source md, do a magic trick and make it disappear
+        <Hr mb={marginY} mt={0} sx={{ "& + hr": { display: "none" } }} />
+      )}
+    </>
   );
 };

--- a/src/components/Markdown/Hr.tsx
+++ b/src/components/Markdown/Hr.tsx
@@ -2,5 +2,5 @@ import { Divider, DividerProps } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 
 export const Hr: FunctionComponent<DividerProps> = (props) => (
-  <Divider my={4} {...props} />
+  <Divider my={10} {...props} />
 );

--- a/src/components/Markdown/List.tsx
+++ b/src/components/Markdown/List.tsx
@@ -12,6 +12,7 @@ export const Ol: FunctionComponent = ({ children }) => (
 export const Li: FunctionComponent = ({ children }) => (
   <ListItem
     lineHeight="tall"
+    mb={2}
     sx={{
       "em:first-of-type": {
         mr: 2,

--- a/src/components/Markdown/List.tsx
+++ b/src/components/Markdown/List.tsx
@@ -11,6 +11,7 @@ export const Ol: FunctionComponent = ({ children }) => (
 
 export const Li: FunctionComponent = ({ children }) => (
   <ListItem
+    lineHeight="tall"
     sx={{
       "em:first-of-type": {
         mr: 2,

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -128,7 +128,7 @@ export const Markdown: FunctionComponent<{
     ].join("\n");
   }
   return (
-    <Box sx={{ "& > *": { mb: 4 }, "& > :first-child": { mt: 0 } }}>
+    <Box sx={{ "& > *": { mb: 8 }, "& > p": { lineHeight: "taller" } }}>
       <ReactMarkdown
         components={components}
         rehypePlugins={rehypePlugins}

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -128,7 +128,13 @@ export const Markdown: FunctionComponent<{
     ].join("\n");
   }
   return (
-    <Box sx={{ "& > *": { mb: 8 }, "& > p": { lineHeight: "taller" } }}>
+    <Box
+      px={8}
+      sx={{
+        "& > *": { mb: 8 },
+        "& > p": { lineHeight: "taller" },
+      }}
+    >
       <ReactMarkdown
         components={components}
         rehypePlugins={rehypePlugins}

--- a/src/components/Markdown/Table.tsx
+++ b/src/components/Markdown/Table.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Table as ChakraTable,
   Thead,
   Tbody,
@@ -10,8 +11,12 @@ import {
 } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
 
-export const Table: FunctionComponent = ({ children }) => (
-  <ChakraTable variant="striped">{children}</ChakraTable>
+const Table: FunctionComponent = ({ children }) => (
+  <Box maxW="100%" overflowX="auto">
+    <ChakraTable variant="striped" w="min">
+      {children}
+    </ChakraTable>
+  </Box>
 );
 
-export { Thead, Tbody, Tfoot, Tr, Th, Td, TableCaption };
+export { Table, Tfoot, Tbody, Td, Thead, Tr, Th, TableCaption };

--- a/src/components/NavTree/NavTree.tsx
+++ b/src/components/NavTree/NavTree.tsx
@@ -82,12 +82,15 @@ export const NavItem: FunctionComponent<NavItemProps> = ({
           />
         )}
         <LinkComponent
+          _hover={{ bg: "rgba(0, 124, 253, 0.05)" }}
           href={url}
           overflow="hidden"
-          pl={!showToggle ? 1 : 0}
+          pl={showToggle ? 1 : 2}
+          py={1.5}
           textOverflow="ellipsis"
           title={display}
           to={url}
+          w="100%"
           whiteSpace="nowrap"
         >
           {display}

--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -115,7 +115,7 @@ export const PackageDocs: FunctionComponent<PackageDocsProps> = ({
         h="max-content"
         maxWidth="100%"
         overflow="hidden"
-        p={4}
+        py={4}
         sx={{
           a: {
             scrollMarginTop: TOP_OFFSET,


### PR DESCRIPTION
Updates:
- H1-H3 in markdown have a divider under them
- Line heights for markdown text increased
- Divider spacing increased
- Nav Tree items line height increased
- Nav Tree links have hover state

![Screen Shot 2021-07-29 at 12 39 13 PM](https://user-images.githubusercontent.com/8749859/127539720-5e0373c0-1c67-48f8-9063-1abc083bd354.png)
![Screen Shot 2021-07-29 at 12 40 27 PM](https://user-images.githubusercontent.com/8749859/127539724-451dda70-3878-4db7-9569-27a2fb5d0758.png)
