### PR TITLE
fix: dependency links are broken

### DIFF
--- a/src/api/package/util.ts
+++ b/src/api/package/util.ts
@@ -14,3 +14,11 @@ export const getAssetsPath = (
   const suffix = `/v${version}`;
   return `${prefix}${body}${suffix}`;
 };
+
+export const sanitizeVersion = (ver: string) => {
+  let sanitized = ver;
+  if (sanitized.startsWith("~") || sanitized.startsWith("^")) {
+    sanitized = sanitized.substring(1);
+  }
+  return sanitized;
+};

--- a/src/views/Package/components/DependencyDropdown/DependencyDropdown.tsx
+++ b/src/views/Package/components/DependencyDropdown/DependencyDropdown.tsx
@@ -1,6 +1,7 @@
 import { ChevronDownIcon, LinkIcon } from "@chakra-ui/icons";
 import { Menu, MenuButton, Button, MenuItem, MenuList } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
+import { sanitizeVersion } from "../../../../api/package/util";
 import { NavLink } from "../../../../components/NavLink";
 
 export interface DependencyDropdownProps {
@@ -37,7 +38,7 @@ export const DependencyDropdown: FunctionComponent<DependencyDropdownProps> = ({
             <NavLink
               h="100%"
               p={2}
-              to={`/packages/${name}/v/${version}`}
+              to={`/packages/${name}/v/${sanitizeVersion(version)}`}
               w="100%"
             >
               {`${name} - ${version}`}

--- a/src/views/PackageLatest/PackageLatest.test.tsx
+++ b/src/views/PackageLatest/PackageLatest.test.tsx
@@ -48,7 +48,7 @@ test("throws if missing package", () => {
   expect(() => buildRedirectUrl(catalog, "missing-package")).toThrow();
 });
 
-test("throws if multiple packages", () => {
+test("selects latest major version if multiple versions", () => {
   const catalog: Packages = {
     packages: [
       {
@@ -77,10 +77,11 @@ test("throws if multiple packages", () => {
           date: "publish date",
         },
         name: "my-package",
-        version: "1.109.0",
+        version: "2.109.0",
       },
     ],
   };
 
-  expect(() => buildRedirectUrl(catalog, "my-package")).toThrow();
+  const url = buildRedirectUrl(catalog, "my-package");
+  expect(url).toEqual("/packages/my-package/v/2.109.0");
 });

--- a/src/views/PackageLatest/PackageLatest.tsx
+++ b/src/views/PackageLatest/PackageLatest.tsx
@@ -2,13 +2,18 @@ import { Center, Spinner } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 import { Redirect, useParams } from "react-router-dom";
 import { Packages } from "../../api/package/packages";
-import { getFullPackageName } from "../../api/package/util";
+import { getFullPackageName, sanitizeVersion } from "../../api/package/util";
 import { useCatalog } from "../../contexts/Catalog";
 
 interface RouteParams {
   name: string;
   scope?: string;
 }
+
+const extractMajor = (ver: string) => {
+  let sanitized = sanitizeVersion(ver);
+  return sanitized.split(".")[0];
+};
 
 const findPackage = (catalog: Packages, pkg: string) => {
   const packages = catalog.packages.filter((p) => p.name === pkg);
@@ -18,7 +23,11 @@ const findPackage = (catalog: Packages, pkg: string) => {
   }
 
   if (packages.length > 1) {
-    throw new Error(`Multiple packages found for ${pkg} in catalog`);
+    return packages.sort((p1, p2) => {
+      const mv1 = extractMajor(p1.version);
+      const mv2 = extractMajor(p2.version);
+      return mv2.localeCompare(mv1);
+    })[0];
   }
 
   return packages[0];


### PR DESCRIPTION
Dependency links didn't remove the `^` from the version number. Now we sanitize the version string and removing any leading `^` or `~`. 

In addition, now that we have multiple major versions (this was actually true before as well) - the package latest redirection was broken for those package. Now it will redirect to the latest major version. 