### PR TITLE
chore: Faq link shouldnt be external

### DIFF
--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -29,7 +29,7 @@ export const ExternalLink = forwardRef<ExternalLinkProps, "a">(
         ref={ref}
         {...props}
       >
-        {children} {hasIcon && <ExternalLinkIcon mb={1} />}
+        {children} {hasIcon && <ExternalLinkIcon mb={1} ml={2} />}
       </Link>
     );
   }

--- a/src/components/NavPopover/NavPopoverContent.tsx
+++ b/src/components/NavPopover/NavPopoverContent.tsx
@@ -17,7 +17,9 @@ export interface NavPopoverContentProps extends MenuListProps {
 
 const Link: FunctionComponent<ILink> = ({ display, isNavLink, url }) =>
   isNavLink ? (
-    <NavLink to={url}>{display}</NavLink>
+    <NavLink color="blue.500" to={url}>
+      {display}
+    </NavLink>
   ) : (
     <ExternalLink
       alignItems="center"

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -1,7 +1,7 @@
 import type { IMenuItems } from "../components/NavPopover";
 
 export const DOCUMENTATION: IMenuItems = [
-  { display: "FAQ", url: "https://constructs.dev/faq" },
+  { display: "FAQ", isNavLink: true, url: "/faq" },
   {
     display: "Construct Hub on GitHub",
     url: "https://github.com/cdklabs/construct-hub",

--- a/src/contexts/Analytics/Analytics.tsx
+++ b/src/contexts/Analytics/Analytics.tsx
@@ -29,7 +29,7 @@ export const AnalyticsProvider: FunctionComponent = ({ children }) => {
         return;
       }
 
-      window?.AWSMA?.ready(() => {
+      window?.AWSMA?.ready?.(() => {
         document.dispatchEvent(
           new CustomEvent(window.AWSMA.TRIGGER_EVENT, { detail: opts })
         );


### PR DESCRIPTION
Fixes #315
Fixes #321 

This PR updates the FAQ link to point to /faq rather than constructs.dev/faq as well as preventing it from opening new tab. Additionally, a quick fix to our analytics handler was made to prevent page crashing with certain adblock filters