### PR TITLE
fix: packaging

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -69,6 +69,9 @@
           "spawn": "compile"
         },
         {
+          "spawn": "package"
+        },
+        {
           "exec": "react-app-rewired build"
         }
       ]
@@ -165,6 +168,21 @@
       "steps": [
         {
           "exec": "tsc --build -w"
+        }
+      ]
+    },
+    "package": {
+      "name": "package",
+      "description": "Create an npm tarball",
+      "steps": [
+        {
+          "exec": "mkdir -p dist/js"
+        },
+        {
+          "exec": "yarn pack"
+        },
+        {
+          "exec": "mv *.tgz dist/js/"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -16,7 +16,7 @@ const project = new web.ReactTypeScriptProject({
   // in order to be able to publish this as an npm module.
   releaseToNpm: true,
   releaseWorkflow: true,
-  package: false,
+  package: true,
   tsconfig: {
     compilerOptions: {
       target: "es6",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "upgrade": "npx projen upgrade",
     "default": "npx projen default",
     "watch": "npx projen watch",
+    "package": "npx projen package",
     "eslint": "npx projen eslint",
     "dev": "npx projen dev",
     "eject": "npx projen eject",


### PR DESCRIPTION
Add packaging step back into release workflow so publish to npm isn't
broken.

This was initially removed because we are pushing the src code in the
npm tarball in addition to the build output to allow build time
configuration if needed, but the projen release workflow relies on the
output of the packaging step and can't publish succesfully without it.

Fixes #