### PR TITLE
fix: navigation items with backticks dont render properly

### DIFF
--- a/src/views/Package/components/PackageDocs/PackageDocs.tsx
+++ b/src/views/Package/components/PackageDocs/PackageDocs.tsx
@@ -18,11 +18,12 @@ export const appendItem = (itemTree: Item[], item: Element): Item[] => {
     return itemTree;
   }
 
-  const { headingId, headingTitle = "", headingLevel = "100" } = item.dataset;
+  const { headingId, headingLevel = "100" } = item.dataset;
+  const { innerText } = item;
   const level = parseInt(headingLevel);
 
   // Don't create nav items for items with no title / url
-  if (level > 3 || !headingTitle || !headingId) {
+  if (level > 3 || !innerText || !headingId) {
     return itemTree;
   }
 
@@ -32,7 +33,7 @@ export const appendItem = (itemTree: Item[], item: Element): Item[] => {
     return [
       ...itemTree,
       {
-        display: headingTitle,
+        display: innerText,
         url: `#${headingId}`,
         level,
         children: [],


### PR DESCRIPTION
Fixes #344 

This change updates the nav item parsing function to look at an element's innerText rather than it's dataset.headingTitle

Before:
<img width="1389" alt="Screen Shot 2021-08-31 at 11 16 18 AM" src="https://user-images.githubusercontent.com/8749859/131555050-40e9a432-1840-4c5f-9821-3ce3c7e13ba7.png">


After:
<img width="1341" alt="Screen Shot 2021-08-31 at 11 13 41 AM" src="https://user-images.githubusercontent.com/8749859/131554967-3fc86c1e-7801-473c-9b2e-2b5c3e0f346b.png">
