### PR TITLE
feat: add nofollow to user generated links

### DIFF
--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -11,14 +11,32 @@ export interface ExternalLinkProps extends LinkProps {
    * Prompts the user to confirm leaving the site. `true` by default
    */
   hasWarning?: boolean;
+  /**
+   * Adds the nofollow annotation to the anchor's rel attribute
+   */
+  noFollow?: boolean;
 }
 
 export const ExternalLink = forwardRef<ExternalLinkProps, "a">(
   (
-    { children, hasIcon = true, hasWarning = true, href, onClick, ...props },
+    {
+      children,
+      hasIcon = true,
+      hasWarning = true,
+      href,
+      onClick,
+      noFollow,
+      ...props
+    },
     ref
   ) => {
     const withPrompt = useExternalLinkWarning();
+
+    let rel = "noopener noreferrer";
+
+    if (hasWarning || noFollow) {
+      rel += " nofollow";
+    }
 
     return (
       <Link
@@ -27,6 +45,7 @@ export const ExternalLink = forwardRef<ExternalLinkProps, "a">(
         isExternal
         onClick={hasWarning ? withPrompt({ href, onClick }) : onClick}
         ref={ref}
+        rel={rel}
         {...props}
       >
         {children} {hasIcon && <ExternalLinkIcon mb={1} ml={2} />}

--- a/src/contexts/ExternalLinkWarning/ExternalLinkWarningModal.tsx
+++ b/src/contexts/ExternalLinkWarning/ExternalLinkWarningModal.tsx
@@ -2,7 +2,6 @@ import { ExternalLinkIcon } from "@chakra-ui/icons";
 import {
   Button,
   Checkbox,
-  Link,
   Modal,
   ModalBody,
   ModalContent,
@@ -18,6 +17,7 @@ import {
   MouseEventHandler,
   useState,
 } from "react";
+import { ExternalLink } from "../../components/ExternalLink";
 import {
   ExternalLinkPromptOptions,
   PREFERS_WARN_ON_EXTERNAL_LINK_CLICK,
@@ -93,7 +93,13 @@ export const ExternalLinkWarningModal: FunctionComponent<ExternalLinkWarningModa
               </Button>
 
               <Tooltip hasArrow label={href} placement="top">
-                <Link href={href} isExternal onClick={onProceed}>
+                <ExternalLink
+                  hasIcon={false}
+                  hasWarning={false}
+                  href={href}
+                  noFollow
+                  onClick={onProceed}
+                >
                   <Button
                     colorScheme="blue"
                     ml={4}
@@ -103,7 +109,7 @@ export const ExternalLinkWarningModal: FunctionComponent<ExternalLinkWarningModa
                   >
                     Proceed
                   </Button>
-                </Link>
+                </ExternalLink>
               </Tooltip>
             </ModalFooter>
           </ModalContent>


### PR DESCRIPTION
Fixes #361 

This PR adds the `nofollow` annotation to outgoing links which are user generated