### PR TITLE
fix: table width issue in md

### DIFF
--- a/src/components/Markdown/Table.tsx
+++ b/src/components/Markdown/Table.tsx
@@ -13,9 +13,7 @@ import { FunctionComponent } from "react";
 
 const Table: FunctionComponent = ({ children }) => (
   <Box maxW="100%" overflowX="auto">
-    <ChakraTable variant="striped" w="min">
-      {children}
-    </ChakraTable>
+    <ChakraTable variant="striped">{children}</ChakraTable>
   </Box>
 );
 


### PR DESCRIPTION
Fixes #347 

Before:
<img width="1349" alt="Screen Shot 2021-08-31 at 4 19 08 PM" src="https://user-images.githubusercontent.com/8749859/131587910-0368c7e7-ff18-4438-baa7-a0b77eeee49e.png">

After:
<img width="1328" alt="Screen Shot 2021-08-31 at 4 19 23 PM" src="https://user-images.githubusercontent.com/8749859/131587918-1b43cee5-3b00-450e-8794-9b503d598509.png">
