### PR TITLE
fix: catalog card tags zIndex too high

### DIFF
--- a/src/components/CatalogCard/CatalogCard.tsx
+++ b/src/components/CatalogCard/CatalogCard.tsx
@@ -126,6 +126,7 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
                     language={currentLanguage}
                     mr={1}
                     value={`"${tag}"`}
+                    zIndex="0 !important"
                   >
                     {tag}
                   </PackageTag>

--- a/src/components/PackageTag/PackageTag.tsx
+++ b/src/components/PackageTag/PackageTag.tsx
@@ -1,13 +1,14 @@
 import { Tag, TagLabel, TagProps } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
-import { Link } from "react-router-dom";
 import { Language } from "../../constants/languages";
 import { getSearchPath } from "../../util/url";
+import { NavLink } from "../NavLink";
 
 export interface PackageTagProps extends TagProps {
   language?: Language;
   value: string;
   label?: string;
+  zIndex?: string | number;
 }
 
 export const PackageTag: FunctionComponent<PackageTagProps> = ({
@@ -15,16 +16,23 @@ export const PackageTag: FunctionComponent<PackageTagProps> = ({
   language,
   value,
   label = value,
+  zIndex,
   ...tagProps
 }) => {
   return (
-    <Link
+    <NavLink
       aria-label={`Tag: ${label}`}
       to={getSearchPath({ query: `${value}`, language })}
+      zIndex={zIndex}
     >
-      <Tag {...tagProps}>
+      <Tag
+        _hover={{
+          textDecoration: "underline",
+        }}
+        {...tagProps}
+      >
         <TagLabel>{children}</TagLabel>
       </Tag>
-    </Link>
+    </NavLink>
   );
 };


### PR DESCRIPTION
Before:
<img width="498" alt="Screen Shot 2021-08-31 at 5 18 33 PM" src="https://user-images.githubusercontent.com/8749859/131592065-239e85b3-8ee9-42ca-b2cd-ea6f767fc8c7.png">

After:
<img width="326" alt="Screen Shot 2021-08-31 at 5 18 22 PM" src="https://user-images.githubusercontent.com/8749859/131592082-6dc7dd86-a7f5-4a19-be39-d233445a432c.png">
