### PR TITLE
fix: revert .projenrc to before build time config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ jspm_packages/
 !/react-app-env.d.ts
 cypress/videos/
 cypress/screenshots/
+public/data
 !/.github/workflows/release.yml

--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,6 @@ tsconfig.tsbuildinfo
 /.eslintrc.json
 /tsconfig.eslint.json
 /build/
-src/__fixtures__
 !/build
 /public
+src/__fixtures__

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -73,6 +73,9 @@
         },
         {
           "exec": "react-app-rewired build"
+        },
+        {
+          "spawn": "package"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -142,13 +142,22 @@ const project = new web.ReactTypeScriptProject({
   project.eslint.addIgnorePattern("jest.config.ts");
 })();
 
-// test fixtures
-project.npmignore.addPatterns("src/__fixtures__");
+// synthesize project files before build
+// see https://github.com/projen/projen/issues/754
+const buildTask = project.tasks.tryFind("build");
+buildTask.spawn(project.packageTask);
 
 // npm tarball will only include the contents of the "build"
 // directory, which is the output of our static website.
 project.npmignore.addPatterns("!/build");
 project.npmignore.addPatterns("/public");
+
+// test fixtures
+project.npmignore.addPatterns("src/__fixtures__");
+
+// these are development assemblies fetched specifically
+// by each developer.
+project.gitignore.exclude("public/data");
 
 // Proxy requests to awscdk.io for local testing
 project.package.addField("proxy", "https://constructs.dev/");
@@ -190,7 +199,7 @@ project.eslint.addOverride({
 });
 
 // rewire cra tasks, all apart from eject.
-rewireCRA(project.tasks.tryFind("build"));
+rewireCRA(buildTask);
 rewireCRA(project.tasks.tryFind("test"));
 rewireCRA(project.tasks.tryFind("dev"));
 


### PR DESCRIPTION
Another attempt at fixing bundle content to include the build file. Verified that running `yarn build && yarn package` results in a tarball with the expected build directory.

Fixes #