### PR TITLE
feat: Lazy Load Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,18 @@
 import { Grid } from "@chakra-ui/react";
-import type { FunctionComponent } from "react";
-import { Switch, Route } from "react-router-dom";
+import { FunctionComponent, lazy } from "react";
+import { Switch } from "react-router-dom";
 import { DevPreviewBanner } from "./components/DevPreviewBanner";
 import { Footer } from "./components/Footer";
 import { Header } from "./components/Header";
+import { LazyRoute } from "./components/LazyRoute";
 import { ROUTES } from "./constants/url";
-import { FAQ } from "./views/FAQ";
-import { Home } from "./views/Home";
-import { NotFound } from "./views/NotFound";
-import { Packages } from "./views/Packages";
-import { SearchResults } from "./views/SearchResults";
-import { SiteTerms } from "./views/SiteTerms";
+
+const FAQ = lazy(() => import("./views/FAQ"));
+const Home = lazy(() => import("./views/Home"));
+const NotFound = lazy(() => import("./views/NotFound"));
+const Packages = lazy(() => import("./views/Packages"));
+const SearchResults = lazy(() => import("./views/SearchResults"));
+const SiteTerms = lazy(() => import("./views/SiteTerms"));
 
 export const App: FunctionComponent = () => {
   return (
@@ -28,24 +30,12 @@ export const App: FunctionComponent = () => {
       <Header />
       <DevPreviewBanner />
       <Switch>
-        <Route exact path={ROUTES.FAQ}>
-          <FAQ />
-        </Route>
-        <Route exact path={ROUTES.HOME}>
-          <Home />
-        </Route>
-        <Route exact path={ROUTES.SITE_TERMS}>
-          <SiteTerms />
-        </Route>
-        <Route path={ROUTES.PACKAGES}>
-          <Packages />
-        </Route>
-        <Route exact path={ROUTES.SEARCH}>
-          <SearchResults />
-        </Route>
-        <Route path="*">
-          <NotFound />
-        </Route>
+        <LazyRoute component={FAQ} exact path={ROUTES.FAQ} />
+        <LazyRoute component={Home} exact path={ROUTES.HOME} />
+        <LazyRoute component={SiteTerms} exact path={ROUTES.SITE_TERMS} />
+        <LazyRoute component={Packages} path={ROUTES.PACKAGES} />
+        <LazyRoute component={SearchResults} exact path={ROUTES.SEARCH} />
+        <LazyRoute component={NotFound} path="*" />
       </Switch>
       <Footer />
     </Grid>

--- a/src/components/LazyRoute/LazyRoute.tsx
+++ b/src/components/LazyRoute/LazyRoute.tsx
@@ -7,7 +7,7 @@ export interface LazyRouteProps extends RouteProps {
 }
 
 /**
- * A wrapper around the react-router-dom which takes in a lazy loaded component
+ * A wrapper around the react-router-dom <Route /> which takes in a lazy loaded component
  * and wraps it with <Suspense /> and a generic <PageLoader /> fallback
  *
  * Usage:

--- a/src/components/LazyRoute/LazyRoute.tsx
+++ b/src/components/LazyRoute/LazyRoute.tsx
@@ -1,0 +1,32 @@
+import { FunctionComponent, LazyExoticComponent, Suspense } from "react";
+import { Route, RouteProps } from "react-router-dom";
+import { PageLoader } from "../PageLoader";
+
+export interface LazyRouteProps extends RouteProps {
+  component: LazyExoticComponent<FunctionComponent>;
+}
+
+/**
+ * A wrapper around the react-router-dom which takes in a lazy loaded component
+ * and wraps it with <Suspense /> and a generic <PageLoader /> fallback
+ *
+ * Usage:
+ * ```tsx
+ * import { lazy } from "react";
+ *
+ * const MyComponent = lazy(() => import("./path/to/MyComponent"));
+ *
+ * <LazyRoute path="/" component={MyComponent} />
+ *
+ * ```
+ */
+export const LazyRoute: FunctionComponent<LazyRouteProps> = ({
+  component: Component,
+  ...routeProps
+}) => (
+  <Route {...routeProps}>
+    <Suspense fallback={<PageLoader />}>
+      <Component />
+    </Suspense>
+  </Route>
+);

--- a/src/components/LazyRoute/index.ts
+++ b/src/components/LazyRoute/index.ts
@@ -1,0 +1,1 @@
+export * from "./LazyRoute";

--- a/src/components/PageLoader/PageLoader.tsx
+++ b/src/components/PageLoader/PageLoader.tsx
@@ -1,0 +1,8 @@
+import { Center, Spinner } from "@chakra-ui/react";
+import type { FunctionComponent } from "react";
+
+export const PageLoader: FunctionComponent = () => (
+  <Center>
+    <Spinner size="xl" />
+  </Center>
+);

--- a/src/components/PageLoader/index.ts
+++ b/src/components/PageLoader/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageLoader";

--- a/src/views/FAQ/index.ts
+++ b/src/views/FAQ/index.ts
@@ -1,1 +1,2 @@
 export * from "./FAQ";
+export { FAQ as default } from "./FAQ";

--- a/src/views/Home/index.ts
+++ b/src/views/Home/index.ts
@@ -1,1 +1,2 @@
 export * from "./Home";
+export { Home as default } from "./Home";

--- a/src/views/NotFound/index.ts
+++ b/src/views/NotFound/index.ts
@@ -1,1 +1,2 @@
 export * from "./NotFound";
+export { NotFound as default } from "./NotFound";

--- a/src/views/Package/index.ts
+++ b/src/views/Package/index.ts
@@ -1,1 +1,2 @@
 export * from "./Package";
+export { Package as default } from "./Package";

--- a/src/views/PackageLatest/index.ts
+++ b/src/views/PackageLatest/index.ts
@@ -1,1 +1,2 @@
 export * from "./PackageLatest";
+export { PackageLatest as default } from "./PackageLatest";

--- a/src/views/Packages/index.ts
+++ b/src/views/Packages/index.ts
@@ -1,1 +1,2 @@
 export * from "./Packages";
+export { Packages as default } from "./Packages";

--- a/src/views/SearchResults/index.ts
+++ b/src/views/SearchResults/index.ts
@@ -1,1 +1,2 @@
 export * from "./SearchResults";
+export { SearchResults as default } from "./SearchResults";

--- a/src/views/SiteTerms/index.ts
+++ b/src/views/SiteTerms/index.ts
@@ -1,1 +1,2 @@
 export * from "./SiteTerms";
+export { SiteTerms as default } from "./SiteTerms";


### PR DESCRIPTION
This work is done in anticipation of a few redesigns, but also has benefits independent of the upcoming redesign work.

When pages load now, only the code for the requested view will be downloaded to the client. This means:
- Smaller initial bundle size as we are no longer downloading every page's code on on first load
- Features which are not enabled will not be sent to the client