### PR TITLE
feat: proxy server for local + ci builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup kernel for React, increase watchers
-        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf &&
-          sudo sysctl -p
       - name: Cypress Run
         uses: cypress-io/github-action@v2
         with:
-          start: yarn start:ci
-          wait-on: http://localhost:3000
+          start: yarn proxy-server:build
+          wait-on: http://localhost:3100

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,5 +59,10 @@ jobs:
       - name: Cypress Run
         uses: cypress-io/github-action@v2
         with:
-          start: yarn proxy-server:build
+          start: yarn proxy-server:ci
           wait-on: http://localhost:3000
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,4 +60,4 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           start: yarn proxy-server:build
-          wait-on: http://localhost:3100
+          wait-on: http://localhost:3000

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -94,6 +94,14 @@
       "type": "build"
     },
     {
+      "name": "express",
+      "type": "build"
+    },
+    {
+      "name": "express-http-proxy",
+      "type": "build"
+    },
+    {
       "name": "json-schema",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -247,7 +247,7 @@
       "name": "proxy-server:ci",
       "steps": [
         {
-          "exec": "REACT_APP_CYPRESS=true REACT_APP_HAS_ANALYTICS=false npx react-app-rewired build && yarn proxy-server"
+          "exec": "npx react-app-rewired build && yarn proxy-server"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -243,8 +243,8 @@
         }
       ]
     },
-    "proxy-server:build": {
-      "name": "proxy-server:build",
+    "proxy-server:ci": {
+      "name": "proxy-server:ci",
       "steps": [
         {
           "exec": "npx react-app-rewired build && yarn proxy-server"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -235,11 +235,19 @@
         }
       ]
     },
-    "start:ci": {
-      "name": "start:ci",
+    "proxy-server": {
+      "name": "proxy-server",
       "steps": [
         {
-          "exec": "CHOKIDAR_USEPOLLING=1 npx react-app-rewired start"
+          "exec": "node ./proxy"
+        }
+      ]
+    },
+    "proxy-server:build": {
+      "name": "proxy-server:build",
+      "steps": [
+        {
+          "exec": "npx react-app-rewired build && yarn proxy-server"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -247,7 +247,7 @@
       "name": "proxy-server:ci",
       "steps": [
         {
-          "exec": "npx react-app-rewired build && yarn proxy-server"
+          "exec": "REACT_APP_CYPRESS=true REACT_APP_HAS_ANALYTICS=false npx react-app-rewired build && yarn proxy-server"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -97,7 +97,7 @@ const project = new web.ReactTypeScriptProject({
     });
 
     project.addTask("proxy-server:ci", {
-      exec: "REACT_APP_CYPRESS=true REACT_APP_HAS_ANALYTICS=false npx react-app-rewired build && yarn proxy-server",
+      exec: "npx react-app-rewired build && yarn proxy-server",
     });
   })();
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -119,7 +119,7 @@ const project = new web.ReactTypeScriptProject({
           uses: "cypress-io/github-action@v2",
           with: {
             start: "yarn proxy-server:build",
-            "wait-on": "http://localhost:3100",
+            "wait-on": "http://localhost:3000",
           },
         },
       ],

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -97,7 +97,7 @@ const project = new web.ReactTypeScriptProject({
     });
 
     project.addTask("proxy-server:ci", {
-      exec: "npx react-app-rewired build && yarn proxy-server",
+      exec: "REACT_APP_CYPRESS=true REACT_APP_HAS_ANALYTICS=false npx react-app-rewired build && yarn proxy-server",
     });
   })();
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -96,7 +96,7 @@ const project = new web.ReactTypeScriptProject({
       exec: "node ./proxy",
     });
 
-    project.addTask("proxy-server:build", {
+    project.addTask("proxy-server:ci", {
       exec: "npx react-app-rewired build && yarn proxy-server",
     });
   })();
@@ -118,8 +118,16 @@ const project = new web.ReactTypeScriptProject({
           name: "Cypress Run",
           uses: "cypress-io/github-action@v2",
           with: {
-            start: "yarn proxy-server:build",
+            start: "yarn proxy-server:ci",
             "wait-on": "http://localhost:3000",
+          },
+        },
+        {
+          uses: "actions/upload-artifact@v1",
+          if: "failure()",
+          with: {
+            name: "cypress-screenshots",
+            path: "cypress/screenshots",
           },
         },
       ],

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,9 @@
 {
-  "baseUrl": "http://localhost:3000"
+  "baseUrl": "http://localhost:3000",
+  "blockedHosts": [
+    "*.awsstatic.com",
+    "*omtrdc.net",
+    "*.shortbread.aws.dev"
+  ],
+  "chromeWebSecurity": false
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cypress:open": "npx projen cypress:open",
     "cypress:run": "npx projen cypress:run",
     "proxy-server": "npx projen proxy-server",
-    "proxy-server:build": "npx projen proxy-server:build",
+    "proxy-server:ci": "npx projen proxy-server:ci",
     "test:unit": "npx projen test:unit",
     "release": "npx projen release",
     "projen": "npx projen"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eject": "npx projen eject",
     "cypress:open": "npx projen cypress:open",
     "cypress:run": "npx projen cypress:run",
-    "start:ci": "npx projen start:ci",
+    "proxy-server": "npx projen proxy-server",
+    "proxy-server:build": "npx projen proxy-server:build",
     "test:unit": "npx projen test:unit",
     "release": "npx projen release",
     "projen": "npx projen"
@@ -57,6 +58,8 @@
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-react": "^7.25.2",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "express": "^4.17.1",
+    "express-http-proxy": "^1.6.2",
     "json-schema": "^0.3.0",
     "npm-check-updates": "^11",
     "prettier": "^2.4.1",

--- a/proxy.js
+++ b/proxy.js
@@ -1,10 +1,14 @@
+/**
+ * @fileoverview A simple proxy server to test the locally built webapp against real data.
+ * This is only intended for local testing + testing in CI
+ */
 const express = require("express");
 const path = require("path");
 const proxy = require("express-http-proxy");
 const proxyUrl = require("./package.json").proxy;
 
 const app = express();
-const port = process.env.PORT || 3100;
+const port = process.env.PORT || 3000;
 
 const buildDir = path.join(__dirname, "build");
 

--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,21 @@
+const express = require("express");
+const path = require("path");
+const proxy = require("express-http-proxy");
+const proxyUrl = require("./package.json").proxy;
+
+const app = express();
+const port = process.env.PORT || 3100;
+
+const buildDir = path.join(__dirname, "build");
+
+app.use(express.static(buildDir));
+
+app.use(proxy(proxyUrl));
+
+app.get("*", (req, res) => {
+  res.sendFile(path.join(buildDir, "index.html"));
+});
+
+app.listen(port);
+
+console.log("Proxy server started on port ", port);

--- a/src/lib/shortbread/shortbread.ts
+++ b/src/lib/shortbread/shortbread.ts
@@ -41,10 +41,6 @@ let instance: Shortbread | undefined;
  */
 export const initialize = async () => {
   return new Promise<void>((resolve, reject) => {
-    if (process.env.REACT_APP_CYPRESS) {
-      reject();
-      return;
-    }
     // Wait until page has loaded first
     window.addEventListener("load", async () => {
       try {

--- a/src/lib/shortbread/shortbread.ts
+++ b/src/lib/shortbread/shortbread.ts
@@ -41,6 +41,10 @@ let instance: Shortbread | undefined;
  */
 export const initialize = async () => {
   return new Promise<void>((resolve, reject) => {
+    if (process.env.REACT_APP_CYPRESS) {
+      reject();
+      return;
+    }
     // Wait until page has loaded first
     window.addEventListener("load", async () => {
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5581,7 +5581,7 @@ debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, d
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
+debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -6147,6 +6147,11 @@ es6-iterator@2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
+es6-promise@^4.1.1:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
@@ -6587,6 +6592,15 @@ expect@^26.6.0, expect@^26.6.2:
     jest-matcher-utils "^26.6.2"
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
+
+express-http-proxy@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/express-http-proxy/-/express-http-proxy-1.6.2.tgz#e87152e45958cee4b91da2fdaa20a1ffd581204a"
+  integrity sha512-soP7UXySFdLbeeMYL1foBkEoZj6HELq9BDAOCr1sLRpqjPaFruN5o6+bZeC+7U4USWIl4JMKEiIvTeKJ2WQdlQ==
+  dependencies:
+    debug "^3.0.1"
+    es6-promise "^4.1.1"
+    raw-body "^2.3.0"
 
 express@^4.17.1:
   version "4.17.1"
@@ -7718,17 +7732,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
-  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
-
-http-errors@~1.7.2:
+http-errors@1.7.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -7738,6 +7742,16 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
 http-parser-js@>=0.5.1:
   version "0.5.3"
@@ -12092,6 +12106,16 @@ raw-body@2.4.0:
   dependencies:
     bytes "3.1.0"
     http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
+  integrity sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.3"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 


### PR DESCRIPTION
This PR implements a simple SPA server with proxying to our deployment which helps achieve the following:
1. Testing prod webapp builds locally
2. Faster E2E runtimes in CI, meaning less flakiness & quicker builds (to be verified). This is because we previously needed to run a dev server which is a much less optimized bundle