### PR TITLE
feat: display custom package tags

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -1,9 +1,14 @@
 import { API_PATHS } from "../../constants/url";
 
-export interface PackageLinksConfig {
-  name: string;
-  value: string;
-  displayText?: string;
+export interface PackageLinkConfig {
+  linkLabel: string;
+  configKey: string;
+  linkText?: string;
+}
+
+export interface PackageTagConfig {
+  label: string;
+  color?: string;
 }
 
 export interface FeatureFlags {
@@ -13,7 +18,8 @@ export interface FeatureFlags {
 
 export interface Config {
   featureFlags?: FeatureFlags;
-  packageLinks?: PackageLinksConfig[];
+  packageLinks?: PackageLinkConfig[];
+  packageTags?: PackageTagConfig[];
 }
 
 const defaultConfig: Config = {};

--- a/src/api/package/metadata.ts
+++ b/src/api/package/metadata.ts
@@ -1,4 +1,5 @@
 import { API_PATHS } from "../../constants/url";
+import { PackageTagConfig } from "../config";
 import { getAssetsPath } from "./util";
 
 export interface Metadata {
@@ -9,6 +10,7 @@ export interface Metadata {
   packageLinks?: {
     [key: string]: string;
   };
+  packageTags?: PackageTagConfig[];
 }
 
 /**

--- a/src/contexts/Theme.tsx
+++ b/src/contexts/Theme.tsx
@@ -1,10 +1,15 @@
 import { ChakraProvider } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
-import { theme } from "../theme";
+import { PageLoader } from "../components/PageLoader";
+import { makeTheme } from "../theme";
+import { useConfig } from "./Config";
 
 export const Theme: FunctionComponent = ({ children }) => {
-  return (
-    <ChakraProvider resetCSS theme={theme}>
+  const { loading, data } = useConfig();
+  return loading ? (
+    <PageLoader />
+  ) : (
+    <ChakraProvider resetCSS theme={makeTheme(data!)}>
       {children}
     </ChakraProvider>
   );

--- a/src/theme/components/Tag.ts
+++ b/src/theme/components/Tag.ts
@@ -1,9 +1,11 @@
 import type { tagAnatomy } from "@chakra-ui/anatomy";
 import { theme } from "@chakra-ui/react";
-import type {
+import {
   PartsStyleInterpolation,
   StyleFunctionProps,
+  transparentize,
 } from "@chakra-ui/theme-tools";
+import { PackageTagConfig } from "../../api/config";
 
 const createVariant =
   (
@@ -25,22 +27,32 @@ const {
   components: { Tag: base },
 } = theme;
 
-export const Tag = {
-  ...base,
-  baseStyle: {
-    container: {
-      fontWeight: "normal",
+export const makeTag = (config: PackageTagConfig[]) => {
+  const customVariants = config.reduce((accum, { color }) => {
+    return color
+      ? {
+          ...accum,
+          [color]: createVariant(base.variants.subtle, {
+            background: transparentize(color, 0.1),
+            color: color,
+          }),
+        }
+      : accum;
+  }, {});
+  return {
+    ...base,
+    baseStyle: {
+      container: {
+        fontWeight: "normal",
+      },
     },
-  },
-  variants: {
-    ...base.variants,
-    subtle: createVariant(base.variants.subtle, {
-      background: "#F2F2F2",
-      color: "blue.800",
-    }),
-    official: createVariant(base.variants.subtle, {
-      background: "rgba(33, 150, 83, 0.1)",
-      color: "#219653",
-    }),
-  },
+    variants: {
+      ...base.variants,
+      subtle: createVariant(base.variants.subtle, {
+        background: "#F2F2F2",
+        color: "blue.800",
+      }),
+      ...customVariants,
+    },
+  };
 };

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,11 +1,18 @@
 import { theme } from "@chakra-ui/react";
+import { PackageTagConfig } from "../../api/config";
 import { Code } from "./Code";
 import { Divider } from "./Divider";
-import { Tag } from "./Tag";
+import { makeTag } from "./Tag";
 
-export const components = {
-  ...theme.components,
-  Code,
-  Divider,
-  Tag,
+interface ComponentsConfig {
+  Tag: PackageTagConfig[];
+}
+
+export const makeComponents = (config: ComponentsConfig) => {
+  return {
+    ...theme.components,
+    Code,
+    Divider,
+    Tag: makeTag(config.Tag),
+  };
 };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,8 +1,15 @@
 import { extendTheme } from "@chakra-ui/react";
-import { components } from "./components";
+import { Config } from "../api/config";
+import { makeComponents } from "./components";
 import { foundations } from "./foundations";
 
-export const theme = extendTheme({
-  ...foundations,
-  components,
-});
+export const makeTheme = (config: Config) => {
+  const componentsConfig = {
+    Tag: config.packageTags ?? [],
+  };
+
+  return extendTheme({
+    ...foundations,
+    components: makeComponents(componentsConfig),
+  });
+};

--- a/src/views/Package/components/OperatorArea/Details.tsx
+++ b/src/views/Package/components/OperatorArea/Details.tsx
@@ -1,7 +1,7 @@
 import { Box, ListItem, Text, UnorderedList } from "@chakra-ui/react";
 import type { Assembly } from "@jsii/spec";
 import { ReactNode, useMemo } from "react";
-import type { PackageLinksConfig } from "../../../../api/config";
+import type { PackageLinkConfig } from "../../../../api/config";
 import type { Metadata } from "../../../../api/package/metadata";
 import { ExternalLink } from "../../../../components/ExternalLink";
 import { LicenseLink, LICENSE_LINKS } from "../../../../components/LicenseLink";
@@ -10,7 +10,7 @@ import { getRepoUrlAndHost } from "../../../../util/url";
 
 export interface DetailsProps {
   assembly?: Assembly;
-  linksConfig?: PackageLinksConfig[];
+  linksConfig?: PackageLinkConfig[];
   metadata: Metadata;
 }
 
@@ -50,15 +50,15 @@ export const Details = ({ assembly, linksConfig, metadata }: DetailsProps) => {
 
     // Prioritize custom links when available
     if (linksConfig?.length) {
-      linksConfig.forEach(({ name, value, displayText }) => {
-        const target = (metadata?.packageLinks ?? {})[value];
+      linksConfig.forEach(({ linkLabel, configKey, linkText }) => {
+        const target = (metadata?.packageLinks ?? {})[configKey];
         if (target) {
           const link = (
-            <ExternalLink href={target}>{displayText ?? target}</ExternalLink>
+            <ExternalLink href={target}>{linkText ?? target}</ExternalLink>
           );
           items.push(
             <>
-              {name}: {link}
+              {linkLabel}: {link}
             </>
           );
         }

--- a/src/views/Package/components/OperatorArea/OperatorArea.tsx
+++ b/src/views/Package/components/OperatorArea/OperatorArea.tsx
@@ -1,14 +1,14 @@
 import { Box, Flex, Link } from "@chakra-ui/react";
 import type { Assembly } from "@jsii/spec";
 import { FunctionComponent } from "react";
-import { PackageLinksConfig } from "../../../../api/config";
+import { PackageLinkConfig } from "../../../../api/config";
 import type { Metadata } from "../../../../api/package/metadata";
 import { DependencyDropdown } from "../DependencyDropdown";
 import { Details } from "./Details";
 
 export interface OperatorAreaProps {
   assembly?: Assembly;
-  linksConfig?: PackageLinksConfig[];
+  linksConfig?: PackageLinkConfig[];
   metadata: Metadata;
 }
 

--- a/src/views/Package/components/PackageDetails/PackageDetails.tsx
+++ b/src/views/Package/components/PackageDetails/PackageDetails.tsx
@@ -4,6 +4,7 @@ import { FunctionComponent } from "react";
 import { Config } from "../../../../api/config";
 import type { Metadata } from "../../../../api/package/metadata";
 import { Card } from "../../../../components/Card";
+import { KEYWORD_IGNORE_LIST } from "../../../../constants/keywords";
 import type { UseRequestResponse } from "../../../../hooks/useRequest";
 import { LanguageSelection } from "../LanguageSelection";
 import { OperatorArea } from "../OperatorArea";
@@ -36,6 +37,14 @@ export const PackageDetails: FunctionComponent<PackageDetailsProps> = ({
       </Center>
     );
   }
+  const tags = [
+    ...(metadata.data?.packageTags ?? []),
+    ...(assembly.data.keywords
+      ?.filter((v) => Boolean(v) && !KEYWORD_IGNORE_LIST.has(v))
+      ?.map((label) => ({
+        label,
+      })) ?? []),
+  ];
 
   return (
     <Flex as={Card} direction="column">
@@ -47,7 +56,7 @@ export const PackageDetails: FunctionComponent<PackageDetailsProps> = ({
       >
         <PackageHeader
           description={assembly.data.description}
-          tags={assembly.data.keywords ?? []}
+          tags={tags}
           title={assembly.data.name}
           version={version}
         />

--- a/src/views/Package/components/PackageHeader/PackageHeader.tsx
+++ b/src/views/Package/components/PackageHeader/PackageHeader.tsx
@@ -1,13 +1,13 @@
 import { Flex, Heading, Stack, Text } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
+import { PackageTagConfig } from "../../../../api/config";
 import { PackageTag } from "../../../../components/PackageTag";
-import { KEYWORD_IGNORE_LIST } from "../../../../constants/keywords";
 import { useLanguage } from "../../../../hooks/useLanguage";
 
 export interface PackageHeaderProps {
   title: string;
   description: string;
-  tags: string[];
+  tags: PackageTagConfig[];
   version: string;
 }
 
@@ -46,31 +46,17 @@ export const PackageHeader: FunctionComponent<PackageHeaderProps> = ({
           justify={{ base: "center", md: "initial" }}
           mt={3}
         >
-          {title.startsWith("@aws-cdk/") ? (
+          {tags.slice(0, 3).map(({ label, color }) => (
             <PackageTag
-              key="official"
-              label="official"
+              key={label}
               language={currentLanguage}
               mr={2}
-              value="@aws-cdk"
-              variant="official"
+              value={label}
+              variant={color}
             >
-              Official
+              {label}
             </PackageTag>
-          ) : null}
-          {tags
-            .filter((v) => Boolean(v) && !KEYWORD_IGNORE_LIST.has(v))
-            .slice(0, 3)
-            .map((tag) => (
-              <PackageTag
-                key={tag}
-                language={currentLanguage}
-                mr={2}
-                value={tag}
-              >
-                {tag}
-              </PackageTag>
-            ))}
+          ))}
         </Flex>
       )}
     </Flex>


### PR DESCRIPTION
Displays custom package tags on the package page. Each package tag with
a unique color creates a new variant in the chakra theme.

Fixes #340