### PR TITLE
fix: home page not rendering when package has no keywords

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -262,6 +262,14 @@
         }
       ]
     },
+    "test:update": {
+      "name": "test:update",
+      "steps": [
+        {
+          "exec": "npx react-app-rewired test -u"
+        }
+      ]
+    },
     "release": {
       "name": "release",
       "description": "Prepare a release from \"main\" branch",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -154,6 +154,10 @@ const project = new web.ReactTypeScriptProject({
     exec: "npx react-app-rewired test",
   });
 
+  project.addTask("test:update", {
+    exec: "npx react-app-rewired test -u",
+  });
+
   project.eslint.addIgnorePattern("jest.config.ts");
 })();
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "proxy-server": "npx projen proxy-server",
     "proxy-server:ci": "npx projen proxy-server:ci",
     "test:unit": "npx projen test:unit",
+    "test:update": "npx projen test:update",
     "release": "npx projen release",
     "projen": "npx projen"
   },

--- a/src/__fixtures__/catalog.json
+++ b/src/__fixtures__/catalog.json
@@ -3466,6 +3466,45 @@
       },
       "name": "platform-constructs",
       "version": "0.0.7"
+    },
+    {
+      "author": {
+        "name": "Amazon Web Services",
+        "url": "https://aws.amazon.com",
+        "organization": false
+      },
+      "description": "High level abstractions on top of cdk8s",
+      "languages": {
+        "java": {
+          "package": "org.cdk8s.plus17",
+          "maven": {
+            "groupId": "org.cdk8s",
+            "artifactId": "cdk8s-plus-17"
+          }
+        },
+        "python": {
+          "distName": "cdk8s-plus-17",
+          "module": "cdk8s_plus_17"
+        },
+        "dotnet": {
+          "namespace": "Org.Cdk8s.Plus17",
+          "packageId": "Org.Cdk8s.Plus17"
+        },
+        "go": {
+          "moduleName": "github.com/cdk8s-team/cdk8s-plus-17-go"
+        }
+      },
+      "license": "Apache-2.0",
+      "major": 1,
+      "metadata": {
+        "constructFramework": {
+          "name": "cdk8s",
+          "majorVersion": 1
+        },
+        "date": "Mon, 27 Sep 2021 12:11:02 GMT"
+      },
+      "name": "cdk8s-plus-17",
+      "version": "1.0.0-beta.83"
     }
   ]
 }

--- a/src/api/catalog-search/__snapshots__/catalog-search.test.ts.snap
+++ b/src/api/catalog-search/__snapshots__/catalog-search.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`CatalogSearchAPI Snapshots Returns consistent filter results 1`] = `
 Array [
+  "cdk8s-plus-17@1.0.0-beta.83",
   "@charlesdotfish/smtp-credentials-cdk-construct@1.0.14",
   "cdk-changelog-slack-notify@0.1.15",
   "halloumi-ses@0.0.1",
@@ -217,6 +218,7 @@ Array [
   "cdk8s-mongo-sts@0.0.8",
   "cdk8s-op@0.1.0",
   "cdk8s-plus@0.33.0-pre.713769883c9b4fe0ec443d0e776155d720b65cb6",
+  "cdk8s-plus-17@1.0.0-beta.83",
   "cdk8s-redis-sts@0.0.5",
   "cdkactions@0.2.3",
   "cdkfoldingathome@0.2.3",

--- a/src/api/catalog-search/__snapshots__/util.test.ts.snap
+++ b/src/api/catalog-search/__snapshots__/util.test.ts.snap
@@ -407,6 +407,10 @@ Array [
     "name": "cdk8s-plus",
   },
   Object {
+    "date": "Mon, 27 Sep 2021 12:11:02 GMT",
+    "name": "cdk8s-plus-17",
+  },
+  Object {
     "date": "Thu, 11 Feb 2021 14:33:00 GMT",
     "name": "cdk8s-redis-sts",
   },
@@ -1006,6 +1010,10 @@ Array [
   Object {
     "date": "Mon, 05 Jul 2021 04:08:27 GMT",
     "name": "@charlesdotfish/smtp-credentials-cdk-construct",
+  },
+  Object {
+    "date": "Mon, 27 Sep 2021 12:11:02 GMT",
+    "name": "cdk8s-plus-17",
   },
 ]
 `;

--- a/src/api/package/packages.ts
+++ b/src/api/package/packages.ts
@@ -13,7 +13,7 @@ export interface CatalogPackage {
   version: string;
   description: string;
   author: Author | string;
-  keywords: string[];
+  keywords?: string[];
   metadata: Metadata;
 }
 

--- a/src/components/CatalogCard/CatalogCard.tsx
+++ b/src/components/CatalogCard/CatalogCard.tsx
@@ -117,7 +117,7 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
                 Official
               </PackageTag>
             ) : null,
-            ...pkg.keywords
+            ...(pkg.keywords ?? [])
               .filter((v) => Boolean(v) && !KEYWORD_IGNORE_LIST.has(v))
               .slice(0, 3)
               .map((tag) => {

--- a/src/hooks/useCatalogResults/useCatalogResults.test.ts
+++ b/src/hooks/useCatalogResults/useCatalogResults.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./useCatalogResults";
 
 const catalogFixture = catalog as Packages;
+const numPackages = catalogFixture.packages.length;
 
 const defaultOptions: UseCatalogResultsOptions = {
   offset: 0,
@@ -64,6 +65,6 @@ describe("useCatalogResults", () => {
       limit: 50,
     });
 
-    expect(offsetTest.current.page).toHaveLength(25);
+    expect(offsetTest.current.page).toHaveLength(numPackages % 50);
   });
 });


### PR DESCRIPTION
I found a surprising bug when testing the website against my updated instance of the Construct Hub, where the home page simply went blank because of an error "w.keywords is undefined" coming from CatalogCard.tsx. This is caused because packages are now ingested on the backend even if they might not have CDK keywords (https://github.com/cdklabs/construct-hub/pull/330), so the "keywords" field may be null. This fixes the error by changing the type of keywords to possibly be undefined.

I also added a projen task for updating snapshots, as well as a package to the catalog.json fixture so that we have a reference example of packages without any keywords.