### PR TITLE
fix: show loading spinner when switching languages

### DIFF
--- a/src/views/Package/Package.tsx
+++ b/src/views/Package/Package.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from "@chakra-ui/react";
+import { Box, Center, Spinner, Stack } from "@chakra-ui/react";
 import { FunctionComponent, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { fetchAssembly } from "../../api/package/assembly";
@@ -64,6 +64,9 @@ export const Package: FunctionComponent = () => {
     assemblyResponse.loading ||
     assemblyResponse.error ||
     assemblyResponse.data?.targets?.[language.toString()] != null;
+  const isLoadingDocs =
+    !metadataResponse.loading &&
+    (assemblyResponse.loading || markdownResponse.loading);
 
   return (
     <Page
@@ -84,6 +87,10 @@ export const Package: FunctionComponent = () => {
         {isSupported ? (
           hasError ? (
             <PackageDocsError language={language}></PackageDocsError>
+          ) : isLoadingDocs ? (
+            <Center minH="200px">
+              <Spinner size="xl" />
+            </Center>
           ) : (
             hasDocs && (
               <PackageDocs


### PR DESCRIPTION
Improves the user experience by showing a loading spinner when you are switching between languages (for some docs, this can take multiple seconds). The existing experience is that a loading spinner only appears when you load the page for the first time.

Screenshot:
<img width="1484" alt="Screen Shot 2021-09-29 at 2 43 18 PM" src="https://user-images.githubusercontent.com/5008987/135352880-c171895f-d0e6-49f3-917c-8e5478b959ec.png">
 