### PR TITLE
remove duplicate text in FAQ

### DIFF
--- a/src/views/FAQ/FAQ.tsx
+++ b/src/views/FAQ/FAQ.tsx
@@ -60,12 +60,11 @@ export const FAQ: FunctionComponent = () => (
               Additionally, since one of the main goals of the Construct Hub is
               to enable an ecosystem of constructs that can be consumed by all
               CDK languages, your library <strong>must</strong> be compiled with{" "}
-              <FAQLink href="https://aws.github.io/jsii/">JSII</FAQLink>, which
-              is a TypeScript-based, which is a TypeScript-based programming
-              language for creating multi-language libraries. The Construct Hub
-              leverages the type information produced by the JSII compiler in
-              order to render the rich multi-language API reference displayed at
-              the Construct Hub.
+              <FAQLink href="https://aws.github.io/jsii/">JSII</FAQLink>, which is
+              a TypeScript-based programming language for creating multi-language 
+              libraries. The Construct Hub uses the type information produced 
+              by the JSII compiler in order to render the rich multi-language API 
+              reference displayed at the Construct Hub.
             </p>
             <p>
               The Construct Hub monitors all updates to the npm Registry and

--- a/src/views/FAQ/FAQ.tsx
+++ b/src/views/FAQ/FAQ.tsx
@@ -60,11 +60,11 @@ export const FAQ: FunctionComponent = () => (
               Additionally, since one of the main goals of the Construct Hub is
               to enable an ecosystem of constructs that can be consumed by all
               CDK languages, your library <strong>must</strong> be compiled with{" "}
-              <FAQLink href="https://aws.github.io/jsii/">JSII</FAQLink>, which is
-              a TypeScript-based programming language for creating multi-language 
-              libraries. The Construct Hub uses the type information produced 
-              by the JSII compiler in order to render the rich multi-language API 
-              reference displayed at the Construct Hub.
+              <FAQLink href="https://aws.github.io/jsii/">JSII</FAQLink>, which
+              is is a TypeScript-based programming language for creating
+              multi-language libraries. The Construct Hub uses the type
+              information produced by the JSII compiler in order to render the
+              rich multi-language API reference displayed at the Construct Hub.
             </p>
             <p>
               The Construct Hub monitors all updates to the npm Registry and


### PR DESCRIPTION
the phrase "which is a TypeScript-based" appeared twice in a row