### PR TITLE
feat: upgrade construct-hub whenever a release is made

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,18 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     container:
       image: jsii/superchain:1-buster-slim-node14
+  upgrade_construct_hub:
+    name: Upgrade construct-hub
+    needs:
+      - release
+      - release_github
+      - release_npm
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Trigger upgrade workflow
+        run: gh api -X POST
+          /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches
+          --field ref="main"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -234,6 +234,26 @@ rewireCRA(buildTask);
 rewireCRA(project.tasks.tryFind("test"));
 rewireCRA(project.tasks.tryFind("dev"));
 
+// trigger construct-hub to pick up changes from construct-hub-webapp
+// whenever a new release is made
+project.release.addJobs({
+  upgrade_construct_hub: {
+    name: "Upgrade construct-hub",
+    runsOn: "ubuntu-latest",
+    permissions: {},
+    needs: ["release", "release_github", "release_npm"],
+    steps: [
+      {
+        name: "Trigger upgrade workflow",
+        run: 'gh api -X POST /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches --field ref="main"',
+        env: {
+          GITHUB_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
+        },
+      },
+    ],
+  },
+});
+
 project.synth();
 
 /**


### PR DESCRIPTION
Resolves part of https://github.com/cdklabs/construct-hub-internal/issues/56

This is a partial solution to improving deployment frequency. https://github.com/cdklabs/construct-hub by default only picks up changes from the web app once a day, but now it will pick up the new changes every time a new release is made.