### PR TITLE
fix: only part of dropdown link is clickable

### DIFF
--- a/src/components/NavPopover/NavPopoverContent.tsx
+++ b/src/components/NavPopover/NavPopoverContent.tsx
@@ -17,7 +17,7 @@ export interface NavPopoverContentProps extends MenuListProps {
 
 const Link: FunctionComponent<ILink> = ({ display, isNavLink, url }) =>
   isNavLink ? (
-    <NavLink color="blue.500" to={url}>
+    <NavLink color="blue.500" to={url} w="100%">
       {display}
     </NavLink>
   ) : (


### PR DESCRIPTION
Fixes #41

(This outline only appears briefly after you click it and before the new page loads)
<img width="353" alt="Screen Shot 2021-10-20 at 12 15 20 PM" src="https://user-images.githubusercontent.com/5008987/138157259-f7cd1a4e-b009-4efa-819a-de9899ce41ec.png">
