### PR TITLE
fix: default sorts for search links on home page

### DIFF
--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -114,7 +114,7 @@ describe("Home (Redesign / WIP)", () => {
 
             cy.wrap(el)
               .should("have.text", CDKTYPE_RENDER_MAP[cdkType].name)
-              .should("have.attr", "href", getSearchPath({ cdkType }))
+              .should("have.attr", "href", getSearchPath({ cdkType, sort: CatalogSearchSort.DownloadsDesc }))
               .find("img")
               .should("have.attr", "src", CDKTYPE_RENDER_MAP[cdkType].imgsrc);
           });
@@ -135,7 +135,7 @@ describe("Home (Redesign / WIP)", () => {
               .should(
                 "have.attr",
                 "href",
-                getSearchPath({ languages: [language] })
+                getSearchPath({ languages: [language], sort: CatalogSearchSort.DownloadsDesc })
               );
           });
         });
@@ -297,7 +297,7 @@ describe("Home (Redesign / WIP)", () => {
             "href",
             getSearchPath({
               cdkType,
-              sort: cdkType ? CatalogSearchSort.DownloadsDesc : undefined,
+              sort: cdkType ? CatalogSearchSort.DownloadsDesc : CatalogSearchSort.PublishDateDesc,
             })
           );
       };

--- a/src/views/HomeRedesign/CDKTypeTabs.tsx
+++ b/src/views/HomeRedesign/CDKTypeTabs.tsx
@@ -51,7 +51,9 @@ const PackageTabPanel = forwardRef<PackageTabProps & TabPanelProps, "div">(
             onClick={() => window.scrollTo(0, 0)}
             to={getSearchPath({
               cdkType,
-              sort: cdkType ? CatalogSearchSort.DownloadsDesc : undefined,
+              sort: cdkType
+                ? CatalogSearchSort.DownloadsDesc
+                : CatalogSearchSort.PublishDateDesc,
             })}
           >
             <Button colorScheme="blue" my={8}>

--- a/src/views/HomeRedesign/Info.tsx
+++ b/src/views/HomeRedesign/Info.tsx
@@ -1,5 +1,6 @@
 import { Divider, Flex, Grid, Image, Stack } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
+import { CatalogSearchSort } from "../../api/catalog-search/constants";
 import { NavLink } from "../../components/NavLink";
 import { CDKType, CDKTYPE_RENDER_MAP } from "../../constants/constructs";
 import {
@@ -32,7 +33,10 @@ export const Info: FunctionComponent = () => (
             <NavLink
               data-testid={testIds.infoSectionIcon}
               key={cdktype}
-              to={getSearchPath({ cdkType: cdktype as CDKType })}
+              to={getSearchPath({
+                cdkType: cdktype as CDKType,
+                sort: CatalogSearchSort.DownloadsDesc,
+              })}
             >
               <Stack align="center" color="blue.500" spacing={2}>
                 <Image aria-label={name} h={8} src={imgsrc} />
@@ -68,7 +72,10 @@ export const Info: FunctionComponent = () => (
             <NavLink
               data-testid={testIds.infoSectionIcon}
               key={language}
-              to={getSearchPath({ languages: [language as Language] })}
+              to={getSearchPath({
+                languages: [language as Language],
+                sort: CatalogSearchSort.DownloadsDesc,
+              })}
             >
               <Stack align="center" color="blue.500" key={language} spacing={2}>
                 <Icon aria-label={name} h={8} w={8} />


### PR DESCRIPTION
Updates the default search sort for several links on the home page. Now all links default to sorting by # of downloads, except for the "See all constructs" link (when no CDK type or filter is specified), which will default to sorting by newest.