### PR TITLE
chore: fetch package data from network instead of cache by default

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -12,7 +12,7 @@ import { clientsClaim, setCacheNameDetails } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, createHandlerBoundToURL } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
-import { StaleWhileRevalidate } from "workbox-strategies";
+import { NetworkFirst, StaleWhileRevalidate } from "workbox-strategies";
 import { API_PATHS } from "./constants/url";
 
 declare const self: ServiceWorkerGlobalScope;
@@ -94,10 +94,11 @@ registerRoute(
   ({ url }) =>
     url.origin === self.origin &&
     url.pathname.endsWith(API_PATHS.ASSEMBLY_SUFFIX),
-  new StaleWhileRevalidate({
+  new NetworkFirst({
     fetchOptions,
     cacheName: "assembly-jsii",
     plugins: [new ExpirationPlugin({ maxEntries: 100 })],
+    networkTimeoutSeconds: 3,
   })
 );
 
@@ -105,10 +106,11 @@ registerRoute(
   ({ url }) =>
     url.origin === self.origin &&
     url.pathname.endsWith(API_PATHS.METADATA_SUFFIX),
-  new StaleWhileRevalidate({
+  new NetworkFirst({
     fetchOptions,
     cacheName: "assembly-metadata",
     plugins: [new ExpirationPlugin({ maxEntries: 100 })],
+    networkTimeoutSeconds: 3,
   })
 );
 
@@ -116,17 +118,19 @@ registerRoute(
   ({ url }) =>
     url.origin === self.origin &&
     url.pathname.endsWith(API_PATHS.CATALOG_SUFFIX),
-  new StaleWhileRevalidate({
+  new NetworkFirst({
     fetchOptions,
     cacheName: "assembly-catalog",
+    networkTimeoutSeconds: 3,
   })
 );
 
 registerRoute(
   ({ url }) =>
     url.origin === self.origin && url.pathname.endsWith(API_PATHS.STATS),
-  new StaleWhileRevalidate({
+  new NetworkFirst({
     fetchOptions,
     cacheName: "stats",
+    networkTimeoutSeconds: 3,
   })
 );


### PR DESCRIPTION
Should fix #512

Updating caching policies implemented by our service worker which is being used to support PWA functionality such as using the website offline.

Currently, if the user has visited the website previously but they have old data cached, the service worker will request data "from both the cache and the network in parallel" per the `StaleWhileRevalidate` policy. This will update the cache with the newest data, but this data will only be served on subsequent responses, which explains existing behavior where the user only sees new data after a refresh.

This PR changes updates the service worker so that dynamic data sources such as the package catalog will first attempt to return the response from the network, and only fall back to the cache if no response is received. In doing so the app should still work gracefully in offline scenarios.