### PR TITLE
feat: improved mobile nav UX

### DIFF
--- a/cypress/integration/header.spec.ts
+++ b/cypress/integration/header.spec.ts
@@ -86,7 +86,12 @@ describe("Header", () => {
       cy.getByDataTest(headerTestIds.navOpen).should("be.visible").click();
       cy.getByDataTest(headerTestIds.mobileNav)
         .should("be.visible")
-        .within(checkMenuInteractions);
+        .within(() => {
+          cy.getByDataTest(headerTestIds.gettingStartedMenu).should(
+            "be.visible"
+          );
+          cy.getByDataTest(headerTestIds.resourcesMenu).should("be.visible");
+        });
     });
   });
 

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -9,8 +9,8 @@ import {
   Stack,
 } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
-import { Documentation } from "./Documentation";
-import { Resources } from "./Resources";
+import { DOCUMENTATION, RESOURCES } from "../../constants/links";
+import { MobileNavLinks } from "./MobileNavLinks";
 import testIds from "./testIds";
 import { Title } from "./Title";
 export interface MobileNavProps {
@@ -26,15 +26,30 @@ export const MobileNav: FunctionComponent<MobileNavProps> = ({
     <Portal>
       <Drawer isOpen={isOpen} onClose={onClose} placement="left" size="xs">
         <DrawerOverlay />
+
         <DrawerContent data-testid={testIds.mobileNav}>
           <DrawerCloseButton />
-          <DrawerHeader display="flex" justifyContent="center">
+
+          <DrawerHeader display="flex" justifyContent="start">
             <Title />
           </DrawerHeader>
+
           <DrawerBody>
             <Stack align="start" justify="start" spacing={4}>
-              <Documentation />
-              <Resources />
+              <MobileNavLinks
+                sections={[
+                  {
+                    title: "Getting Started",
+                    items: DOCUMENTATION,
+                    testId: testIds.gettingStartedMenu,
+                  },
+                  {
+                    title: "Resources",
+                    items: RESOURCES,
+                    testId: testIds.resourcesMenu,
+                  },
+                ]}
+              />
             </Stack>
           </DrawerBody>
         </DrawerContent>

--- a/src/components/Header/MobileNavLinks.tsx
+++ b/src/components/Header/MobileNavLinks.tsx
@@ -1,0 +1,103 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  Flex,
+  Heading,
+} from "@chakra-ui/react";
+import { Fragment, FunctionComponent } from "react";
+import { ExternalLink } from "../ExternalLink";
+import { NavLink } from "../NavLink";
+import type { IMenuItems, ILink } from "../NavPopover";
+
+const linkProps = {
+  color: "blue.500",
+  py: 2,
+  w: "full",
+};
+
+const Link: FunctionComponent<ILink> = ({ display, isNavLink, url }) =>
+  isNavLink ? (
+    <NavLink to={url} {...linkProps}>
+      {display}
+    </NavLink>
+  ) : (
+    <ExternalLink
+      alignItems="center"
+      display="flex"
+      hasWarning={false}
+      href={url}
+      justifyContent="space-between"
+      {...linkProps}
+    >
+      {display}
+    </ExternalLink>
+  );
+
+interface MobileNavLinksContentProps {
+  testId?: string;
+  title: string;
+  items: IMenuItems;
+}
+
+const MobileNavLinksContent: FunctionComponent<MobileNavLinksContentProps> = ({
+  title,
+  items,
+  testId,
+}) => (
+  <AccordionItem data-testid={testId} w="full">
+    <AccordionButton px={0} py={4}>
+      <Box flex="1" textAlign="left">
+        <Heading as="h3" size="sm">
+          {title}
+        </Heading>
+      </Box>
+
+      <AccordionIcon />
+    </AccordionButton>
+
+    <AccordionPanel p={0} w="full">
+      <Flex direction="column" w="full">
+        {items.map((item, itemIdx) => {
+          if ("links" in item) {
+            return (
+              <Fragment key={`${item.display}-${itemIdx}`}>
+                <Heading as="h4" borderBottom="base" py={4} size="xs">
+                  {item.display}
+                </Heading>
+
+                {item.links.map((link, linkIdx) => (
+                  <Link {...link} key={`${link.display}-${linkIdx}`} />
+                ))}
+              </Fragment>
+            );
+          }
+
+          return <Link {...item} key={`${item.display}-${itemIdx}`} />;
+        })}
+      </Flex>
+    </AccordionPanel>
+  </AccordionItem>
+);
+
+interface MobileNavLinksProps {
+  sections: MobileNavLinksContentProps[];
+}
+
+export const MobileNavLinks: FunctionComponent<MobileNavLinksProps> = ({
+  sections,
+}) => (
+  <Accordion
+    allowMultiple
+    allowToggle
+    defaultIndex={sections.map((_, i) => i)}
+    w="full"
+  >
+    {sections.map((section, idx) => (
+      <MobileNavLinksContent key={`section-${idx}`} {...section} />
+    ))}
+  </Accordion>
+);

--- a/src/components/Header/MobileNavLinks.tsx
+++ b/src/components/Header/MobileNavLinks.tsx
@@ -65,7 +65,7 @@ const MobileNavLinksContent: FunctionComponent<MobileNavLinksContentProps> = ({
           if ("links" in item) {
             return (
               <Fragment key={`${item.display}-${itemIdx}`}>
-                <Heading as="h4" borderBottom="base" pt={4} pb={2} size="xs">
+                <Heading as="h4" borderBottom="base" pb={2} pt={4} size="xs">
                   {item.display}
                 </Heading>
 

--- a/src/components/Header/MobileNavLinks.tsx
+++ b/src/components/Header/MobileNavLinks.tsx
@@ -65,7 +65,7 @@ const MobileNavLinksContent: FunctionComponent<MobileNavLinksContentProps> = ({
           if ("links" in item) {
             return (
               <Fragment key={`${item.display}-${itemIdx}`}>
-                <Heading as="h4" borderBottom="base" py={4} size="xs">
+                <Heading as="h4" borderBottom="base" pt={4} pb={2} size="xs">
                   {item.display}
                 </Heading>
 


### PR DESCRIPTION
Fixes #482

Re-implements the mobile nav links to be displayed in an accordion which is open by default. This prevents the need to open a popover, which is a poor experience for mobile. Additionally, it allows sections to be collapsed

<img width="386" alt="Screen Shot 2021-11-03 at 2 20 12 PM" src="https://user-images.githubusercontent.com/8749859/140195244-cde96cb2-33ae-4d43-b016-f0480b651dae.png">
