### PR TITLE
feat: Review: Search Page

### DIFF
--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -1,5 +1,5 @@
 import searchBar from "components/SearchBar/testIds";
-import homeRedesign from "views/HomeRedesign/testIds";
+import home from "views/Home/testIds";
 import { getSearchPath } from "util/url";
 import { CDKType, CDKTYPE_RENDER_MAP } from "constants/constructs";
 import {
@@ -17,12 +17,12 @@ describe("Home (Redesign / WIP)", () => {
     });
 
     it("has heading and subtitle", () => {
-      cy.getByDataTest(homeRedesign.heroHeader).should("be.visible");
-      cy.getByDataTest(homeRedesign.heroSubtitle).should("be.visible");
+      cy.getByDataTest(home.heroHeader).should("be.visible");
+      cy.getByDataTest(home.heroSubtitle).should("be.visible");
     });
 
     it("has search capabilities from home page", () => {
-      cy.getByDataTest(homeRedesign.page).within(() => {
+      cy.getByDataTest(home.page).within(() => {
         cy.getByDataTest(searchBar.input)
           .should("be.visible")
           .type("@aws-cdk", { force: true });
@@ -43,17 +43,17 @@ describe("Home (Redesign / WIP)", () => {
     });
 
     it("has expected sections and content", () => {
-      cy.getByDataTest(homeRedesign.infoContainer)
+      cy.getByDataTest(home.infoContainer)
         .should("be.visible")
         .within(() => {
-          cy.getByDataTest(homeRedesign.infoSection)
+          cy.getByDataTest(home.infoSection)
             .should("have.length", 2)
             .each((el) => {
               cy.wrap(el).within(() => {
-                cy.getByDataTest(homeRedesign.infoSectionHeading).should(
+                cy.getByDataTest(home.infoSectionHeading).should(
                   "be.visible"
                 );
-                cy.getByDataTest(homeRedesign.infoSectionDescription).should(
+                cy.getByDataTest(home.infoSectionDescription).should(
                   "be.visible"
                 );
               });
@@ -62,10 +62,10 @@ describe("Home (Redesign / WIP)", () => {
     });
 
     it("has cdkType icon links with search urls", () => {
-      cy.getByDataTest(homeRedesign.infoSection)
+      cy.getByDataTest(home.infoSection)
         .first()
         .within(() => {
-          cy.getByDataTest(homeRedesign.infoSectionIcon).each((el, index) => {
+          cy.getByDataTest(home.infoSectionIcon).each((el, index) => {
             const cdkType = [CDKType.awscdk, CDKType.cdk8s, CDKType.cdktf][
               index
             ];
@@ -87,10 +87,10 @@ describe("Home (Redesign / WIP)", () => {
     });
 
     it("has language icon links with search urls", () => {
-      cy.getByDataTest(homeRedesign.infoSection)
+      cy.getByDataTest(home.infoSection)
         .last()
         .within(() => {
-          cy.getByDataTest(homeRedesign.infoSectionIcon).each((el, index) => {
+          cy.getByDataTest(home.infoSectionIcon).each((el, index) => {
             const language = Object.keys(LANGUAGE_NAME_MAP).filter((l) =>
               TEMP_SUPPORTED_LANGUAGES.has(l as Language)
             )[index] as Language;
@@ -113,11 +113,11 @@ describe("Home (Redesign / WIP)", () => {
   describe("Featured Section", () => {
     it("has a header and 4 cards", () => {
       cy.visit("/");
-      cy.getByDataTest(homeRedesign.featuredContainer)
+      cy.getByDataTest(home.featuredContainer)
         .should("be.visible")
         .within(() => {
-          cy.getByDataTest(homeRedesign.featuredHeader).should("be.visible");
-          cy.getByDataTest(homeRedesign.featuredGrid)
+          cy.getByDataTest(home.featuredHeader).should("be.visible");
+          cy.getByDataTest(home.featuredGrid)
             .should("be.visible")
             .within(() => {
               cy.getByDataTest(packageCard.wideContainer).should(
@@ -133,8 +133,8 @@ describe("Home (Redesign / WIP)", () => {
         featuredPackages: undefined,
       });
 
-      cy.getByDataTest(homeRedesign.featuredContainer).within(() => {
-        cy.getByDataTest(homeRedesign.featuredHeader).should(
+      cy.getByDataTest(home.featuredContainer).within(() => {
+        cy.getByDataTest(home.featuredHeader).should(
           "have.text",
           "Recently updated"
         );
@@ -177,8 +177,8 @@ describe("Home (Redesign / WIP)", () => {
         featuredPackages,
       });
 
-      cy.getByDataTest(homeRedesign.featuredContainer).within(() => {
-        cy.getByDataTest(homeRedesign.featuredHeader).should(
+      cy.getByDataTest(home.featuredContainer).within(() => {
+        cy.getByDataTest(home.featuredHeader).should(
           "have.text",
           "Featured packages"
         );
@@ -195,17 +195,17 @@ describe("Home (Redesign / WIP)", () => {
 
   describe("CDK Type Section", () => {
     it("has heading, description, 4 tabs, 4 cards, and a see all button", () => {
-      cy.getByDataTest(homeRedesign.cdkTypeSection).within(() => {
-        cy.getByDataTest(homeRedesign.cdkTypeSectionHeading).should(
+      cy.getByDataTest(home.cdkTypeSection).within(() => {
+        cy.getByDataTest(home.cdkTypeSectionHeading).should(
           "be.visible"
         );
-        cy.getByDataTest(homeRedesign.cdkTypeSectionDescription).should(
+        cy.getByDataTest(home.cdkTypeSectionDescription).should(
           "be.visible"
         );
 
-        cy.getByDataTest(homeRedesign.cdkTypeTab).should("have.length", 4);
+        cy.getByDataTest(home.cdkTypeTab).should("have.length", 4);
 
-        cy.getByDataTest(homeRedesign.packageGrid)
+        cy.getByDataTest(home.packageGrid)
           .first()
           .within(() => {
             cy.getByDataTest(packageCard.wideContainer).should(
@@ -214,13 +214,13 @@ describe("Home (Redesign / WIP)", () => {
             );
           });
 
-        cy.getByDataTest(homeRedesign.cdkTypeSeeAllButton).should("be.visible");
+        cy.getByDataTest(home.cdkTypeSeeAllButton).should("be.visible");
       });
     });
 
     it("reveals different cards for respective tabs", () => {
-      cy.getByDataTest(homeRedesign.cdkTypeSection).within(() => {
-        cy.getByDataTest(homeRedesign.cdkTypeTab).each((tab, index) => {
+      cy.getByDataTest(home.cdkTypeSection).within(() => {
+        cy.getByDataTest(home.cdkTypeTab).each((tab, index) => {
           const cdkType: CDKType | undefined = [
             undefined,
             CDKType.awscdk,
@@ -235,7 +235,7 @@ describe("Home (Redesign / WIP)", () => {
           }
 
           // Verify current tab's package grid is visible and others are not
-          cy.getByDataTest(homeRedesign.packageGrid).each((grid, gridIndex) => {
+          cy.getByDataTest(home.packageGrid).each((grid, gridIndex) => {
             cy.wrap(grid).should(
               index === gridIndex ? "be.visible" : "not.be.visible"
             );
@@ -245,9 +245,9 @@ describe("Home (Redesign / WIP)", () => {
     });
     it("has a see all button which opens the correct search url", () => {
       const testSeeAll = (cdkType: CDKType | undefined, index: number) => {
-        cy.getByDataTest(homeRedesign.cdkTypeTab).eq(index).click();
+        cy.getByDataTest(home.cdkTypeTab).eq(index).click();
 
-        cy.getByDataTest(homeRedesign.cdkTypeSeeAllButton)
+        cy.getByDataTest(home.cdkTypeSeeAllButton)
           .eq(index)
           .should(
             "have.attr",

--- a/src/views/SearchRedesign/CDKFilter.tsx
+++ b/src/views/SearchRedesign/CDKFilter.tsx
@@ -78,7 +78,7 @@ export const CDKFilter: FunctionComponent = () => {
     <>
       <RadioFilter
         data-testid={testIds.cdkTypeFilter}
-        hint="Constructs support distinct output types: AWS CDK libraries output Cloudformation Templates, CDK8s libraries output Kubernetes manifests, and CDKtf libraries output Terraform Configuration. The Construct Hub attempts to detect the output type of each library, but results are not guaranteed to be completely accurate."
+        hint="Choose the right CDK for your IAC technology: AWS CDK for AWS CloudFormation, CDKtf for Terraform, or CDK8s for Kubernetes."
         name="CDK Type"
         onValueChange={onCdkTypeChange}
         options={[
@@ -91,9 +91,7 @@ export const CDKFilter: FunctionComponent = () => {
       {!!(majorsOptions && majorsOptions.length > 1) && (
         <RadioFilter
           data-testid={testIds.cdkVersionFilter}
-          hint={`Allows you to filter by a major version of your selected CDK Type: (${
-            CDKTYPE_NAME_MAP[cdkType!]
-          })`}
+          hint="Choose the major version of the CDK you're using to see only constructs that will work with that version."
           name="CDK Major Version"
           onValueChange={onCdkMajorChange}
           options={[

--- a/src/views/SearchRedesign/FilterHeading.tsx
+++ b/src/views/SearchRedesign/FilterHeading.tsx
@@ -5,10 +5,8 @@ import {
   Text,
   Popover,
   IconButton,
-  PopoverHeader,
   PopoverTrigger,
   PopoverBody,
-  PopoverCloseButton,
   PopoverArrow,
   PopoverContent,
 } from "@chakra-ui/react";
@@ -29,7 +27,7 @@ export const FilterHeading: FunctionComponent<FilterHeadingProps> = ({
         {name}
       </Heading>
       {hint ? (
-        <Popover colorScheme="dark" placement="top-end" strategy="fixed">
+        <Popover colorScheme="dark" placement="right" strategy="fixed">
           <PopoverTrigger>
             <IconButton
               aria-label={`Hint: ${name}`}
@@ -43,13 +41,12 @@ export const FilterHeading: FunctionComponent<FilterHeadingProps> = ({
           </PopoverTrigger>
           <PopoverContent
             bg="gray.700"
+            borderRadius="base"
             color="white"
             fontSize="sm"
             shadow="whiteAlpha.300"
           >
-            <PopoverHeader>Hint: {name}</PopoverHeader>
-            <PopoverCloseButton />
-            <PopoverArrow />
+            <PopoverArrow bg="gray.700" />
             <PopoverBody>
               <Text>{hint}</Text>
             </PopoverBody>

--- a/src/views/SearchRedesign/LanguageFilter.tsx
+++ b/src/views/SearchRedesign/LanguageFilter.tsx
@@ -42,7 +42,7 @@ export const LanguageFilter: FunctionComponent = () => {
   return (
     <CheckboxFilter
       data-testid={testIds.languagesFilter}
-      hint="Select one or more programming languages to filter by. Results will match at least one of the selected languages. If no languages are selected, results will not be filtered by langauges."
+      hint="Choose one or more languages. Results include constructs foruse with at least one of the selected languages."
       name="Programming Language"
       onValueChange={onLanguagesChange}
       options={languageOptions}

--- a/src/views/SearchRedesign/LanguageFilter.tsx
+++ b/src/views/SearchRedesign/LanguageFilter.tsx
@@ -42,7 +42,7 @@ export const LanguageFilter: FunctionComponent = () => {
   return (
     <CheckboxFilter
       data-testid={testIds.languagesFilter}
-      hint="Choose one or more languages. Results include constructs foruse with at least one of the selected languages."
+      hint="Choose one or more languages. Results include constructs for use with at least one of the selected languages."
       name="Programming Language"
       onValueChange={onLanguagesChange}
       options={languageOptions}


### PR DESCRIPTION
Fixes #600 
Fixes #590 
Fixes #591 

Note: For the purpose of the screenshot I hard-coded the tooltips to be open by default. Additionally, the hint for the `Publisher` (currently phrased as Author) group will require a backend feature

*The typo in the language popover `foruse` has been fixed*
<img width="643" alt="Screen Shot 2021-11-04 at 4 01 49 PM" src="https://user-images.githubusercontent.com/8749859/140432120-5545024f-e927-4502-97f4-136fafa211a3.png">
