### PR TITLE
fix: CDK type tab state not remembered

### DIFF
--- a/src/hooks/useHistoryState/index.ts
+++ b/src/hooks/useHistoryState/index.ts
@@ -1,0 +1,1 @@
+export { useHistoryState } from "./useHistoryState";

--- a/src/hooks/useHistoryState/useHistoryState.ts
+++ b/src/hooks/useHistoryState/useHistoryState.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { useHistory } from "react-router-dom";
+
+export const useHistoryState = <T>(
+  key: string,
+  initialValue: T
+): [T, (t: T) => void] => {
+  const history = useHistory();
+  const [rawState, rawSetState] = useState<T>(() => {
+    const value = (history.location.state as any)?.[key];
+    return value ?? initialValue;
+  });
+  const setState = (value: T) => {
+    history.replace({
+      ...history.location,
+      state: {
+        ...(history.location.state as any),
+        [key]: value,
+      },
+    });
+    rawSetState(value);
+  };
+  return [rawState, setState];
+};

--- a/src/views/Home/CDKTypeTabs.tsx
+++ b/src/views/Home/CDKTypeTabs.tsx
@@ -16,6 +16,7 @@ import { CatalogSearchSort } from "../../api/catalog-search/constants";
 import { NavLink } from "../../components/NavLink";
 import { CDKType, CDKTYPE_RENDER_MAP } from "../../constants/constructs";
 import { useCatalogResults } from "../../hooks/useCatalogResults";
+import { useHistoryState } from "../../hooks/useHistoryState";
 import { getSearchPath } from "../../util/url";
 import { SECTION_PADDING } from "./constants";
 import { PackageGrid } from "./PackageGrid";
@@ -87,6 +88,8 @@ export const CDKTypeTabs: FunctionComponent = () => {
     sort: CatalogSearchSort.DownloadsDesc,
   });
 
+  const [tabIndex, setTabIndex] = useHistoryState("cdkTypeTab", 0);
+
   return (
     <Flex
       bg="white"
@@ -118,7 +121,12 @@ export const CDKTypeTabs: FunctionComponent = () => {
         community and companies and organizations like Terraform, CNCF, AWS and
         more.
       </Text>
-      <Tabs isFitted variant="line">
+      <Tabs
+        defaultIndex={tabIndex}
+        isFitted
+        onChange={(index) => setTabIndex(index)}
+        variant="line"
+      >
         <TabList>
           <PackageTab data={anyCDKType} />
 


### PR DESCRIPTION
Previously, there was a UX bug where the user could select a CDK type tab on the home page, click on a package card, navigate back, and then the tab they had selected would be reset. This fixes the bug by associating the tab state with the navigation history.