### PR TITLE
chore: shadow-ban packages with a specific keyword

### DIFF
--- a/src/api/catalog-search/catalog-search.ts
+++ b/src/api/catalog-search/catalog-search.ts
@@ -65,20 +65,26 @@ export class CatalogSearchAPI {
   public readonly constructFrameworks: CatalogConstructFrameworks;
 
   constructor(catalogData: CatalogPackage[], stats: PackageStats) {
-    const catalogMap = catalogData.reduce((map, pkg) => {
-      const { name, version } = pkg;
-      const id = [name, version].join("@");
+    const catalogMap = catalogData
+      // Packages with the "construct-hub/hide-from-search" keyword are shadow-banned from search results
+      .filter((pkg) => !pkg.keywords?.includes('construct-hub/hide-from-search'))
+      .reduce(
+        (map, pkg) => {
+          const { name, version } = pkg;
+          const id = [name, version].join("@");
 
-      const downloads = stats.packages[name]?.downloads?.npm ?? 0;
+          const downloads = stats.packages[name]?.downloads?.npm ?? 0;
 
-      map.set(id, {
-        ...pkg,
-        downloads,
-        id,
-      });
+          map.set(id, {
+            ...pkg,
+            downloads,
+            id,
+          });
 
-      return map;
-    }, new Map());
+          return map;
+        },
+        new Map<string, CatalogPackage & { readonly downloads: number, readonly id: string; }>(),
+      );
 
     this.map = this.sort(catalogMap, CatalogSearchSort.PublishDateDesc);
 

--- a/src/api/catalog-search/catalog-search.ts
+++ b/src/api/catalog-search/catalog-search.ts
@@ -9,6 +9,11 @@ import { FILTER_FUNCTIONS, SORT_FUNCTIONS } from "./util";
 export interface ExtendedCatalogPackage extends CatalogPackage {
   id: string;
   downloads: number;
+
+  scope?: string;
+  packageName?: string;
+  authorName?: string;
+  authorEmail?: string;
 }
 
 export interface CatalogConstructFrameworks {
@@ -83,7 +88,7 @@ export class CatalogSearchAPI {
         });
 
         return map;
-      }, new Map<string, any>());
+      }, new Map<string, ExtendedCatalogPackage>());
 
     this.map = this.sort(catalogMap, CatalogSearchSort.PublishDateDesc);
 
@@ -110,14 +115,14 @@ export class CatalogSearchAPI {
 
         if (typeof author === "string") {
           pkg.authorName = author;
-        }
+        } else {
+          if (author?.name) {
+            pkg.authorName = author.name;
+          }
 
-        if (author?.name) {
-          pkg.authorName = author.name;
-        }
-
-        if (author?.email) {
-          pkg.authorEmail = author.email;
+          if (author?.email) {
+            pkg.authorEmail = author.email;
+          }
         }
 
         this.add(pkg);

--- a/src/api/catalog-search/catalog-search.ts
+++ b/src/api/catalog-search/catalog-search.ts
@@ -67,24 +67,23 @@ export class CatalogSearchAPI {
   constructor(catalogData: CatalogPackage[], stats: PackageStats) {
     const catalogMap = catalogData
       // Packages with the "construct-hub/hide-from-search" keyword are shadow-banned from search results
-      .filter((pkg) => !pkg.keywords?.includes('construct-hub/hide-from-search'))
-      .reduce(
-        (map, pkg) => {
-          const { name, version } = pkg;
-          const id = [name, version].join("@");
+      .filter(
+        (pkg) => !pkg.keywords?.includes("construct-hub/hide-from-search")
+      )
+      .reduce((map, pkg) => {
+        const { name, version } = pkg;
+        const id = [name, version].join("@");
 
-          const downloads = stats.packages[name]?.downloads?.npm ?? 0;
+        const downloads = stats.packages[name]?.downloads?.npm ?? 0;
 
-          map.set(id, {
-            ...pkg,
-            downloads,
-            id,
-          });
+        map.set(id, {
+          ...pkg,
+          downloads,
+          id,
+        });
 
-          return map;
-        },
-        new Map<string, any>(),
-      );
+        return map;
+      }, new Map<string, any>());
 
     this.map = this.sort(catalogMap, CatalogSearchSort.PublishDateDesc);
 

--- a/src/api/catalog-search/catalog-search.ts
+++ b/src/api/catalog-search/catalog-search.ts
@@ -83,7 +83,7 @@ export class CatalogSearchAPI {
 
           return map;
         },
-        new Map<string, CatalogPackage & { readonly downloads: number, readonly id: string; }>(),
+        new Map<string, any>(),
       );
 
     this.map = this.sort(catalogMap, CatalogSearchSort.PublishDateDesc);

--- a/src/api/package/packages.ts
+++ b/src/api/package/packages.ts
@@ -4,6 +4,7 @@ import { Metadata } from "./metadata";
 
 export interface Author {
   readonly name: string;
+  readonly email?: string;
   readonly url: string;
 }
 


### PR DESCRIPTION
We have a probe package that gets a new version published every 3 hours,
and we don't want this to pollute search results, or steal a "recently
updated" slot away from a more deserving package...

We are hence registering the `construct-hub/hide-from-search` keyword
on such packages, which should effectively cause the package to never
be shown on search results, or in the "what's new" section.
