### PR TITLE
chore: remove duplicate packaging step

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -164,12 +164,7 @@
     },
     "pre-compile": {
       "name": "pre-compile",
-      "description": "Prepare the project for compilation",
-      "steps": [
-        {
-          "spawn": "package"
-        }
-      ]
+      "description": "Prepare the project for compilation"
     },
     "proxy-server": {
       "name": "proxy-server",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -176,9 +176,6 @@ const project = new web.ReactTypeScriptProject({
   project.addTask("analyze-exports", { exec: "node scripts/analyze-exports" });
 })();
 
-// synthesize project files before build
-project.projectBuild.preCompileTask.spawn(project.packageTask);
-
 // npm tarball will only include the contents of the "build"
 // directory, which is the output of our static website.
 project.npmignore.addPatterns("!/build");


### PR DESCRIPTION
Following #617 it appears the packaging step is now being called twice - this fixes so that packaging is performed at the very end of the build.