### PR TITLE
bug: lock chakra version to fix dark mode bug

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -150,6 +150,7 @@
     },
     {
       "name": "@chakra-ui/react",
+      "version": "1.6.10",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -292,25 +292,25 @@
       },
       "steps": [
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@chakra-ui/react'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@chakra-ui/react'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@chakra-ui/react'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@chakra-ui/react'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@chakra-ui/react'"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/react-hooks @testing-library/user-event @types/jest @types/lunr @types/node @types/react @types/react-dom @types/react-helmet @types/react-router-dom @typescript-eslint/eslint-plugin @typescript-eslint/parser cypress eslint eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-prefer-arrow eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks express express-http-proxy json-schema npm-check-updates prettier projen react-app-rewired standard-version ts-unused-exports typescript @chakra-ui/anatomy @chakra-ui/icons @chakra-ui/theme-tools @emotion/react @emotion/styled @jsii/spec copy-to-clipboard date-fns framer-motion hast-util-sanitize jsii-reflect lunr prism-react-renderer react react-dom react-helmet react-markdown react-router-dom react-scripts rehype-raw rehype-sanitize remark-emoji remark-gfm web-vitals workbox-core workbox-expiration workbox-precaching workbox-routing workbox-strategies"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -29,6 +29,10 @@ const project = new web.ReactTypeScriptProject({
     prettier: true,
   },
 
+  depsUpgradeOptions: {
+    exclude: ["@chakra-ui/react"],
+  },
+
   deps: [
     "@chakra-ui/anatomy",
     "@chakra-ui/icons",
@@ -69,10 +73,12 @@ const project = new web.ReactTypeScriptProject({
     "eslint-plugin-react",
     "react-app-rewired",
   ],
+
   autoApproveOptions: {
     allowedUsernames: ["cdklabs-automation"],
     secret: "GITHUB_TOKEN",
   },
+
   autoApproveUpgrades: true,
 });
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -32,7 +32,7 @@ const project = new web.ReactTypeScriptProject({
   deps: [
     "@chakra-ui/anatomy",
     "@chakra-ui/icons",
-    "@chakra-ui/react",
+    "@chakra-ui/react@1.6.10",
     "@chakra-ui/theme-tools",
     "@emotion/react@^11",
     "@emotion/styled@^11",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@chakra-ui/anatomy": "*",
     "@chakra-ui/icons": "^1.0.17",
-    "@chakra-ui/react": "^1.6.12",
+    "@chakra-ui/react": "1.6.10",
     "@chakra-ui/theme-tools": "*",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -11,5 +11,9 @@ export const makeTheme = (config: Config) => {
   return extendTheme({
     ...foundations,
     components: makeComponents(componentsConfig),
+    config: {
+      initialColorMode: "light",
+      useSystemColorMode: false,
+    },
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,110 +1209,116 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chakra-ui/accordion@1.3.10":
-  version "1.3.10"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.3.10.tgz#0872a5a076825de5d2a08294a3152087dee8697a"
-  integrity sha512-jlhxPRAA/nbuksIMpvNZjKLSm03fo8ljmWbJRqZC00ExFyLuBJ2olGVm3MTge1CCfJiOVQuiR6e7/k6fXHDvoA==
+"@chakra-ui/accordion@1.3.8":
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.3.8.tgz#db48b81c5862b32faae0312d1d234c0aa90adc84"
+  integrity sha512-LsdRGct1hLEDUyuZp6db2VOYCvBXN1rdJEmnqJWFp8ppePApdccwow74dDQRuZSwe3B/JLBUQ54Cdk4YUH2aAg==
   dependencies:
     "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/icon" "1.1.13"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/icon" "1.1.12"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/transition" "1.3.8"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/transition" "1.3.6"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/alert@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.2.9.tgz#0cc9446d79644e7b3cfc2bcaf979be33a40e3d38"
-  integrity sha512-3vH1mY2TKauTka57fWu4REIlD5QeBC+Sr88CQx7ErCQbg/Yh9YvBwIt/4Eiy6IeLF/DofHy8Pe2R+bwlUIXXTw==
+"@chakra-ui/alert@1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.2.8.tgz#71f5b7ebe50201beacf8e75fe2f20df16fcda2f8"
+  integrity sha512-/91WfnGYGUDBeDlQ4I2ZAP+NHloAGPFsjNyw9if5dreeDA9zgOhUr2s4qj8uzZ9NtLurvWg7YMA8kqvmD/f7/w==
   dependencies:
-    "@chakra-ui/icon" "1.1.13"
+    "@chakra-ui/icon" "1.1.12"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/anatomy@*", "@chakra-ui/anatomy@1.1.0":
+"@chakra-ui/anatomy@*":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@chakra-ui/anatomy/-/anatomy-1.1.0.tgz#fa87417a2436e773be31fef3eb7f2005fa1c15f8"
   integrity sha512-Q9v5tAqX4m2oVUyO0MJn/tq7PpuHe44pJizo6Imwmp7VMDxGJ8lNBkh1mLA17ZIXWpgMRysbREOU/QPaq6hDVg==
   dependencies:
     "@chakra-ui/theme-tools" "^1.2.3"
 
-"@chakra-ui/avatar@1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.2.12.tgz#e19c17c4e28284b022be763b83f29b322ad86418"
-  integrity sha512-sbteyANEaesY8HuFiRXX41tMS+IqiA77r2854ra+KIvBGz4yhSiHkMI0Di1yqG5vBaDJvST9ygVgU4kG++Ce4g==
+"@chakra-ui/anatomy@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/anatomy/-/anatomy-1.0.1.tgz#62b4e372c8fc7caca0d0ee0f3b710b00220588b3"
+  integrity sha512-eMmusEHhQJn465txOdEUM2yx2A2DoRfMQWwAxoW4GwwbJTD6q8fuGEIf6jaTQ7QtDLcJ9JOkYA7C0f3SKRTGGg==
   dependencies:
-    "@chakra-ui/image" "1.0.22"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/theme-tools" "^1.2.1"
 
-"@chakra-ui/breadcrumb@1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.2.10.tgz#20a5d4f46c5948c06be56087bba7d31f174da720"
-  integrity sha512-2e3G9wLMCR9rf2j0eUuOL6uqmvhJe5r4hSITcDCM4cTuxfLnJPJcdDJ5Y2J+/eSDb2MUeXDozTzcSAnV/mZciw==
+"@chakra-ui/avatar@1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.2.11.tgz#7a7647339893ca419cf64f4fb5a7387456b6e64d"
+  integrity sha512-h+Fo0bjRQTgDgga0n9RCQtJtRgUc2KowMhfajzjFyhtspSfhZauSjazKqDtiPkzD7alc+herEGEMi0RQRuQXig==
   dependencies:
+    "@chakra-ui/image" "1.0.21"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/button@1.4.6":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.4.6.tgz#a8b4718523d66c33e8cea58522afd98f53c33b07"
-  integrity sha512-YcVZjM660LyfsGGZBPLtgaxFCEjZWin9lUAGME1iyAhVYGCj0nbNsXkClbGV/Q9EQhP7mPySm5N9GP9DzCaFzA==
-  dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/spinner" "1.1.14"
-    "@chakra-ui/utils" "1.8.4"
-
-"@chakra-ui/checkbox@1.5.10":
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.5.10.tgz#018eabc8c1062578a22155feb2e6255206c761fe"
-  integrity sha512-URS8wFK8DT6pk/KhdixlfDbyLYsLgEC9Iy4c53tOrcKEaSFf/hnyDIJ3w8xN0PxdO9F+UAhCbX4L6DGMgVD9ww==
-  dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
-    "@chakra-ui/visually-hidden" "1.0.16"
-
-"@chakra-ui/clickable@1.1.9":
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.1.9.tgz#29f5d637b6d3fcb9d86a9fdea0955c0344ac70d7"
-  integrity sha512-4uX1IRQbznPUAB3CeNZJK+wFNsGPdRt4NPz0GW7Mep6lw/A7rfyTBANBdM7hK2VMqBnIceS2goWbPftrrFIvhA==
+"@chakra-ui/breadcrumb@1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.2.9.tgz#d2b9af1c1bb31cfdd234a13cfbdd2b66bce40088"
+  integrity sha512-MYyG6Flnw6TXTvX1fS88SZs6R4m8DMQHn67V+mypDN5htWVHku4d1P3jAhuHganu3ql+C0K2E2Qve78gWMbi/g==
   dependencies:
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/close-button@1.1.13":
+"@chakra-ui/button@1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.4.5.tgz#dacb2d05b3c23c32fb877878640d2447af8408e4"
+  integrity sha512-fWwSpgM0h0e+TcXEq6cCJhHSRxTsKDvaE2KJa9KJcqKSjad6p4SSQf1UEw0TstxhrqbgvjDlvYcUjJ4MH6u04Q==
+  dependencies:
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/react-utils" "1.1.2"
+    "@chakra-ui/spinner" "1.1.13"
+    "@chakra-ui/utils" "1.8.3"
+
+"@chakra-ui/checkbox@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.5.8.tgz#560f2e406132dcad4931c221f11078f152b29744"
+  integrity sha512-eZK720TfnZ2aYs34MpfCyAou94TS5qjarAlE/UjkOH4XhZH49Pf6Ck6ai+7hrALn7yi61qVt0MoE5Dd2KsedYA==
+  dependencies:
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/react-utils" "1.1.2"
+    "@chakra-ui/utils" "1.8.3"
+    "@chakra-ui/visually-hidden" "1.0.15"
+
+"@chakra-ui/clickable@1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.1.8.tgz#561317e2c1745a053cc0208366ae081e5d99ae44"
+  integrity sha512-o17ljVD3qf2dsJqVhRX4V/xFtwJ9sAzCGcZrXV/O/dWAVDNuL8fGMdx5FileUVdFFi50w3tBuM4hxZRD5KNeGQ==
+  dependencies:
+    "@chakra-ui/react-utils" "1.1.2"
+    "@chakra-ui/utils" "1.8.3"
+
+"@chakra-ui/close-button@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.1.12.tgz#2aae729946bf7f47c23bc99b1db637ccebcdf1aa"
+  integrity sha512-ZuNNhkOfwFKdjUPHvwkRapCv8vto857wYYw/OtogDp6XcTYBPudeQl29nglhoI8fQAvEt7wmMZAZaTwAAW0dNQ==
+  dependencies:
+    "@chakra-ui/icon" "1.1.12"
+    "@chakra-ui/utils" "1.8.3"
+
+"@chakra-ui/color-mode@1.1.13":
   version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.1.13.tgz#72455f2db186f51e933d0524205e563bbdd8e28e"
-  integrity sha512-YuTeZAJ7VyuxFlCSc7IXhC6HDSN77zWf1EKZDiFJWzpLDVVCpgf4bw7klBBWVbno2bVcHY7OPQeflcokFJ9Idg==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.1.13.tgz#aacc2c113d370bd04715d9225ae02064c5f392b3"
+  integrity sha512-IYCOfeP+5a/OFmixNN2nkcZIRwC7qNb26I7zqZ/hEQYr4gZi7FKEthKjpvZWKCwLRSNiidhkaPLzAf+lhqM/Qg==
   dependencies:
-    "@chakra-ui/icon" "1.1.13"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/color-mode@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.2.0.tgz#e0d8d9028c9e9580663cc50072a0ba18375e0342"
-  integrity sha512-8oaFYqswjqfAKeMlK15q09tkB4ZDIlWpzUlSdh2jrJs3NCBacsSadH+y9lPexdfKfhCIn7jeHk2SDd8MYBgQHA==
+"@chakra-ui/control-box@1.0.16":
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.0.16.tgz#913bd8f125b494228be5c50dea70ecf990f0bc7d"
+  integrity sha512-Smkk9Olr6mhkUEktgGLw1oc4fZr58U3Ts5bMKJsTSBIRdsol+Tm3oFUzLKADD7udhMaz+7+aEx4WiTrg5tWzzA==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/react-env" "1.0.8"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/control-box@1.0.17":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.0.17.tgz#b1cc91bd43799bc88530450d10fe36a6e0d83a3e"
-  integrity sha512-q2bkaw33KEamuSXSdNxjVCYHMY7Z3lrZppD7CB2bT77uIQCTldVHEX99Qf8clTqwXuPgXDc81+/WXDAXqm1v3A==
+"@chakra-ui/counter@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.1.10.tgz#0112942f723290221c4e3464817567c6dae33e90"
+  integrity sha512-63LfIKK2duHyY9n8AfoXfwmQYkmNNaItAIB2ZNT230eTY0RwuKiAi+J4C/N9amxCB7EUw15gQphb2DjjL5D3GQ==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
-
-"@chakra-ui/counter@1.1.11":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.1.11.tgz#947dcbf0f161e9d6cd0cd93c36949ebfa035ef48"
-  integrity sha512-Z3SCtvXfBdkWiRCtx8S+7URcayUY5IfYAuXQKRkpt/vNwYCGPFT5dMFy/wafHNXx0T4Oaga5qdGHqmt8BsLqBw==
-  dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/utils" "1.8.3"
 
 "@chakra-ui/css-reset@1.0.0":
   version "1.0.0"
@@ -1326,42 +1332,49 @@
   dependencies:
     "@chakra-ui/react-utils" "^1.1.2"
 
-"@chakra-ui/editable@1.2.11":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.2.11.tgz#f980ed90c021a0d050749f18c94274613a35e57f"
-  integrity sha512-G8uVbtAACu11jSxoE2so2RNYyes5F0w9Yl6oqWjEKBvTJTO0lt588HduFp0uZ2ptagV/UEDiihWIr5M34orZrQ==
+"@chakra-ui/editable@1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.2.10.tgz#05c27d6bb2ae79fd1ac3579ca7c492c11385e9c7"
+  integrity sha512-UYhg60F46Z4W85amYV3f4KTKjxfDL3GxcAN5d9r/E75jHrluwd4YGr/nlVhg57AhFhteiPpIdQx/NQ68KQ2KJA==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
+    "@chakra-ui/hooks" "1.6.1"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/focus-lock@1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.1.12.tgz#888405a9f5802191679fb25acae735da5d6f7967"
-  integrity sha512-NirFUA34xxsY7tioCfYW8PCk16figLyKlYwRtHhAKfN2zajWft1XqEmmM1cQGiTo7EpbxdD24mReU1Sym2vvfQ==
+"@chakra-ui/focus-lock@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.1.11.tgz#e95babbb4eb0e884e340b30eddd968126dccb45f"
+  integrity sha512-piJwxQCxPIx5d9jPNr4aQ0BoDU1+tNecNKAoUz+U0mXa334O3DSb84cbsOjBQn9VBLV82FtmtvrF8FwrT9cl9Q==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
     react-focus-lock "2.5.0"
 
-"@chakra-ui/form-control@1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.4.3.tgz#a266dda19932604d59b41689bdaa0c8755e4e435"
-  integrity sha512-uHulh477WgB5YYoamcNdQpH6/p+Gf2Nk1sC6YzqhG6brJAoXWRxa5oazgpUt0U/AAlA+W1rMTciUKidGxM4Hbw==
+"@chakra-ui/form-control@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.4.2.tgz#24bfb549d504afdc4600a2d828ce5937600bbe04"
+  integrity sha512-VmoyNAh+bWj4p1ocMZDfrdJgo6pG+cgfJZ62YBSWZk7glK5ZsUNFZfd/TlxKkINKzDQyhBEEPzNjNV9TcVymmA==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/icon" "1.1.13"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/icon" "1.1.12"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/hooks@1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.6.2.tgz#35ad504710a1befce968eefb5e2d8f976cf4ca41"
-  integrity sha512-B4nAMFnwS7jamugVwl6JnALZJhxf4vxyZmwY1qjVSoe3lY8ZyqssI2TI6yla4WHa7gny2beG0SXS2+gCEGtwmA==
+"@chakra-ui/hooks@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.6.1.tgz#56e3bdb4e3d3b1dd827cf35b4be848817846e582"
+  integrity sha512-377Wvrt2BxpEY+1dDMsvm3J/E4GTdrxJM4fju24iUg0iFv87jg+jf6GXPsrZfdN6a9XfCCmclcmLxEH/0Trwpg==
   dependencies:
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
     compute-scroll-into-view "1.0.14"
     copy-to-clipboard "3.3.1"
+
+"@chakra-ui/icon@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.1.12.tgz#50a8929100c5dc2ed32c1b6930b67b09b63ed895"
+  integrity sha512-MVzsW+IqAYUGPjxOiEWu9kU3kl3gQ8tNONN77EyDEEcbqPOCgPOomitQ4/scmgSWWWOrAL+SvjlbykXtH8g6+Q==
+  dependencies:
+    "@chakra-ui/utils" "1.8.3"
 
 "@chakra-ui/icon@1.1.13":
   version "1.1.13"
@@ -1378,162 +1391,162 @@
     "@chakra-ui/icon" "1.1.13"
     "@types/react" "^17.0.0"
 
-"@chakra-ui/image@1.0.22":
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.0.22.tgz#421331f4c8ab6b13ef3e05fc5cb9c5a40a4c2179"
-  integrity sha512-+WRYWhZU0izZehwX5x52snIALd61NEY/9mHM/xWMEPl8kTivBhC6VrLv5xuhv5vJc21Witu8zuSttqF3j0V1iw==
+"@chakra-ui/image@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.0.21.tgz#ebd57a1198ec3ae6e0cb995db056d3d85269a4ec"
+  integrity sha512-efknvUiUPEarhOAivbel89RLlYR5sA2E5vvmmbPXp348TGBiVvpxrmtfuUKZjbaF6ZBkkZsVPk6zJFE1PgwJbA==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/input@1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.2.12.tgz#bc6f4cdcdb4bc7b135def1dadc6afb4b168a55ce"
-  integrity sha512-eiYVXIDAWCzAUNaDfsbHcr3xLwyY3K8w1VIczjxlnEl/s9zPczKO44OuP3aM/zQ5JHio3YPkR2WLQ0/8jdBckw==
+"@chakra-ui/input@1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.2.11.tgz#4e29b896e72518ab1ceaaf2a46e513bc20a0c291"
+  integrity sha512-/UaUcdSoVA2Bd9sdODnuNpK0+lI68fyigzHWe3z6lF1wmLZB546MxXxt70ZvZWsu+eJ41qBNpx81BZZ9zCJP8w==
   dependencies:
-    "@chakra-ui/form-control" "1.4.3"
+    "@chakra-ui/form-control" "1.4.2"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/layout@1.4.11":
-  version "1.4.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.4.11.tgz#1b64598d0d48da0e9f7bb3beb125faeb2f1c89b4"
-  integrity sha512-Aj7W89wJjWH+LPIUO+2IIeam6x+fPWOWDFczzkDwGm/2T/qMy+UJ6sO2Vs00plEvCf1yQamrdR9W3F9o1QIEEA==
+"@chakra-ui/layout@1.4.10":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.4.10.tgz#283804f206ea05d9158a7238ce2a1fa6cc954968"
+  integrity sha512-KtJOKCYyCzUBRrBRNAr9SAhvC6KtSxzIM1NynA0dJSGEVHdkeVchfoZRSNfji60T0vNVA6hVGdgBi9DjZlh02Q==
   dependencies:
-    "@chakra-ui/icon" "1.1.13"
+    "@chakra-ui/icon" "1.1.12"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/live-region@1.0.16":
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.0.16.tgz#1739f7aeb1bca0fc764c9ec62e742e0ce23b418d"
-  integrity sha512-U4fw8qgVfIq0xM6+LEARBlj0eiD7SY19f+/doeBaQTHwjVhQ4AflrQL6hm8jqpR7O9iHSUhW25S9yRRSfA+O9g==
+"@chakra-ui/live-region@1.0.15":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.0.15.tgz#996011f967523cbcb522adcfee8133410ec48b2b"
+  integrity sha512-Gl9q2Cb7xY68LoEo1qXGUyQp4A01Dd62apJY3Ox2RorcE7DiCQXr1KVGefiRBbcny/borbgrNVL9VcTl24ZNrA==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/media-query@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-1.1.5.tgz#4c80cb8c3cbad2e42758812f3a4941d0768b558d"
-  integrity sha512-9Dk1oJVJT9nRB3aVx2bzUMmPwlqm9dAj0GY+L8twg8MgaebjtxXlz3xqitRfdP2Wd1M0yiK6/vyicn4qB7C6Kg==
+"@chakra-ui/media-query@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-1.1.3.tgz#c25d6a83e77d39bf6e9a117ab90ea9d7db6695ab"
+  integrity sha512-/LdpMTCW7PLR2uWRwTYrWK7TZZI6MmVVlCCXicqNTfx8Seu87F54pr7D/T/nkxYOM419KF/gQQjGDUxl2N6V6Q==
   dependencies:
-    "@chakra-ui/react-env" "1.0.8"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/react-env" "1.0.7"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/menu@1.7.8":
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.7.8.tgz#43d5fd41b3a524e7574864890364fc385868c2fc"
-  integrity sha512-ut4hWKjTkUfT/hew5tvx3fE1um447zLijPcrFDyUwX780/IQAGV31bcJcGSMarLbsAgBOAaVaoiwBQvL0QLe2g==
+"@chakra-ui/menu@1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.7.6.tgz#33fedd70c37b4d079e7c124798e9f0230f6b9060"
+  integrity sha512-3O0zSvZrJmReM8iaeZ447KY4swMT/al0QJyloO7LNa3ex4uNQRw9ff5YXgKk+EURNvRwI75Lc2tEwpOHGNczWw==
   dependencies:
-    "@chakra-ui/clickable" "1.1.9"
+    "@chakra-ui/clickable" "1.1.8"
     "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/popper" "2.3.1"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/popper" "2.3.0"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/transition" "1.3.8"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/transition" "1.3.6"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/modal@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.9.4.tgz#8cb8b739c7d063eb94d72c8099bf12bd8e8157a8"
-  integrity sha512-TZ/XS/8uZwx7VCp1Lhf83U2BZNGj7djDbXJPeLp6VXZ1WYhwh1lF5A1H5RcH7WzN+kvrjv1rmSlTAXNlHTgDag==
+"@chakra-ui/modal@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.9.2.tgz#2401c41afdd77fdbfc7a4fc058c7836404f3d50f"
+  integrity sha512-5QPDca8q1YB0XgB6Whuj1B0dzRzSuYQS7demz3TOuEWHKcmNSz/hx3YprMFgEVEx0Awg3HaWomnyj7AG+m/2dQ==
   dependencies:
-    "@chakra-ui/close-button" "1.1.13"
-    "@chakra-ui/focus-lock" "1.1.12"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/portal" "1.2.11"
+    "@chakra-ui/close-button" "1.1.12"
+    "@chakra-ui/focus-lock" "1.1.11"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/portal" "1.2.10"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/transition" "1.3.8"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/transition" "1.3.6"
+    "@chakra-ui/utils" "1.8.3"
     aria-hidden "^1.1.1"
     react-remove-scroll "2.4.1"
 
-"@chakra-ui/number-input@1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.2.12.tgz#819970b6bc0ad386ef8f4a5b2eaeaf7ba49c71a6"
-  integrity sha512-0gLII6l6Nee8BH4yBDm/P6u4DIPt/TfbnRnKhuX8iAaxfC7YdOaLJFShQpa5UkQ/56Me98nb78+Zli56cc8FYg==
+"@chakra-ui/number-input@1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.2.11.tgz#ad3274cab7a745dd3d046b559ade2959f7742e29"
+  integrity sha512-tB4+SFyZrsDW3rzKoW+Wy34dQEZhqP2EMOnTflxIWxF4A66hf3Sz/6av0b6CEhlSsOd59QQd8GaT1FvHWdhz7A==
   dependencies:
-    "@chakra-ui/counter" "1.1.11"
-    "@chakra-ui/form-control" "1.4.3"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/icon" "1.1.13"
+    "@chakra-ui/counter" "1.1.10"
+    "@chakra-ui/form-control" "1.4.2"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/icon" "1.1.12"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/pin-input@1.6.7":
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.6.7.tgz#2a37ef9d5cabd27e648ddc5aa1942c8171bdb91b"
-  integrity sha512-lt45R03xM5cdKxG7l2uXVnxebxfFaGPxs3/Yj97lZ/yQaG8N7iYwIdPKDH26vAvBZFRZayQJTgtUcJpeK/dn0g==
+"@chakra-ui/pin-input@1.6.6":
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.6.6.tgz#df3d8d4e0678436b45f72fca7abe5590e8f44ad1"
+  integrity sha512-c4C4IT+FVIVc8uX4HQLlGdWCE3WqwH5ZBv393ukd7VGOfn8G/jmgOCafn2VbW8TsAwqpvQ/IH3TUbcFI75Drkg==
   dependencies:
     "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.6.2"
+    "@chakra-ui/hooks" "1.6.1"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/popover@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.9.1.tgz#2951f34867eff58fa1152b1bc8981ee188720c79"
-  integrity sha512-MtKvtntLQ5v3N+FUa4cPjd8EVNbNCCeTd/rPDdcH7HBnPqyDndtagE+GQGjseHmXuSY3nr7X+FnSsYktD+wnBg==
+"@chakra-ui/popover@1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.8.5.tgz#6d7a2bf29935bcbe1dbb3c16b4fd6d8f03811f12"
+  integrity sha512-SM10pQEIRSM7Y0Ygnuv0Skzxm8NES/UP9qcrfrFLJOMjmVxf52NZBPcNA4pIMEM4ocSHq6AyCHzhTXHr8a7HpQ==
   dependencies:
-    "@chakra-ui/close-button" "1.1.13"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/popper" "2.3.1"
+    "@chakra-ui/close-button" "1.1.12"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/popper" "2.3.0"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/popper@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-2.3.1.tgz#0e1c5ec405c5953a075beadd4e40c8d08c67db97"
-  integrity sha512-iRsJTWw27c7HN+304UxzT5tDssEsCKBsfXDL9cbgwyhs4D9GJQGqM3eJDHXvvd1DAf9WZuWzya3sjvl3YhPtPw==
+"@chakra-ui/popper@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-2.3.0.tgz#df76c1b38f6345ed31fd8cac597f9990297e630a"
+  integrity sha512-K3Bw4RqttnX6TegLCBcMIez3w8YJFhUyLIkGUH0g2OCGgOajwucryFjNpuWRwkH4xcQPHghS9OVPYxRYTB22xA==
   dependencies:
     "@chakra-ui/react-utils" "1.1.2"
     "@popperjs/core" "2.4.4"
 
-"@chakra-ui/portal@1.2.11":
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.2.11.tgz#4ec368940defa72890289f92e383dd5f22864541"
-  integrity sha512-APp7L0Ql4eCHY9OkcJevuzNj/I07hOsn3aHiJmfV3o2whEWd/0P1pkEG5eTb2Gul7WS9+fxaPUL5Zzl44jxkUQ==
+"@chakra-ui/portal@1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.2.10.tgz#3b482af86b16cf82cd2abc43fff229063701f8c7"
+  integrity sha512-fK5wyZcPZ9DIYsD2fzRWMHiaI2yal54BaojKmCKyBOzC3M1QLHwHF31qbyS7xbo0f2dtzsLPUz1bC0nsTwUXmA==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
+    "@chakra-ui/hooks" "1.6.1"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/progress@1.1.16":
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.1.16.tgz#cd2dd4e2338c4ca31e72555c5fbb57764d7fea64"
-  integrity sha512-zS1GcHAPvsoCRE7A/fM28ZxVVXo5Iymv0RqXEu2p4vs5HuZnRebB0elWiDNlkrnAPVPpN+qGVz5kVnnp9QsFIw==
+"@chakra-ui/progress@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.1.15.tgz#bff9ec7fa289d515879d343a05475eabb8820715"
+  integrity sha512-DFKAYUjkbsfFJ8T9B5fqGHyuHQeKrCaJgPQDRr9v9th8oRhuUGuKM2mHgCfkGbQwRWwF5ViWz38tSJLOcwPGng==
   dependencies:
-    "@chakra-ui/theme-tools" "1.2.3"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/theme-tools" "1.2.2"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/provider@1.6.11":
-  version "1.6.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/provider/-/provider-1.6.11.tgz#3d1d27293f8f17a579aa873fd21cdf67fc537053"
-  integrity sha512-yyH9yV/V7qV0hTaY5mV02cmWIK4ouV4gEbPabKsT+tkjxA/ygw98MZ8cjUptGv7u3OIRry/7AWgmT3IU8iKm8A==
+"@chakra-ui/provider@1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/provider/-/provider-1.6.9.tgz#9befa3b5b4c4f650237bc00d773c1278e8329efc"
+  integrity sha512-NS60y6AYTjngk+tNuNCvgJUo5VVSJeyzmm+3Ujvl3nKwHnsUrwvvug5XhPrZI3b3K9910BG6xk0+ptWqaHCWvQ==
   dependencies:
     "@chakra-ui/css-reset" "1.0.0"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/portal" "1.2.11"
-    "@chakra-ui/react-env" "1.0.8"
-    "@chakra-ui/system" "1.7.6"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/portal" "1.2.10"
+    "@chakra-ui/react-env" "1.0.7"
+    "@chakra-ui/system" "1.7.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/radio@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.3.13.tgz#d8f85303f9bfe76be3caf5d8b083c20b01e8ae2f"
-  integrity sha512-0bbnUYpA39WihLdYPb+xF/rDXiTvTiQCEVr75R0RTm19AmxvfnfJNdEzFb1nIfcu/uzlyFCSoe7OpPih1Pdquw==
+"@chakra-ui/radio@1.3.11":
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.3.11.tgz#970e7671063f7ddbe771e3cd1af88f14fec4aa5d"
+  integrity sha512-pV7bIucW1N99DeNQLE54zRhgU6kD/vg7bAfNU3kHhg14xYmuB3F/4S9ad22V41nM1/g9S66kqUPmEadvhKWsXg==
   dependencies:
-    "@chakra-ui/form-control" "1.4.3"
-    "@chakra-ui/hooks" "1.6.2"
+    "@chakra-ui/form-control" "1.4.2"
+    "@chakra-ui/hooks" "1.6.1"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
-    "@chakra-ui/visually-hidden" "1.0.16"
+    "@chakra-ui/utils" "1.8.3"
+    "@chakra-ui/visually-hidden" "1.0.15"
 
-"@chakra-ui/react-env@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/react-env/-/react-env-1.0.8.tgz#6e1f0861a89fc4fb4bd23f4a9b6b6ec6b74b5e7c"
-  integrity sha512-iA5D1BgcrXrwf0XIBMdvWced+9nH312KLPeQMYHZx8i0n9YqwyJBxUhcruyaKQB+m+NRO2sjkKLLH4wnCG9dwQ==
+"@chakra-ui/react-env@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/react-env/-/react-env-1.0.7.tgz#99116b574a8970d38b326669da48698aebfa2590"
+  integrity sha512-3ANGROM7wZL4lLiY5GCdslLhNv44xa4cykyBed9B/O0B0J4xqIbVCwLMV2aNSCXwwUChFgjmBsDvk0vnMvclmg==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
 "@chakra-ui/react-utils@1.1.2", "@chakra-ui/react-utils@^1.1.2":
   version "1.1.2"
@@ -1542,165 +1555,165 @@
   dependencies:
     "@chakra-ui/utils" "^1.7.0"
 
-"@chakra-ui/react@^1.6.12":
-  version "1.6.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/react/-/react-1.6.12.tgz#5225e2ea9fb3426006ccf01d1ac0fccabc3b9753"
-  integrity sha512-hlFZPU0ZApEbzdUoUyfr5PCX8UhO4qYmTrZRhWG4noQj/uQu5WkysSHW9k8dtBS2jGIctyY6BQjm7doaQv8Mqg==
+"@chakra-ui/react@1.6.10":
+  version "1.6.10"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/react/-/react-1.6.10.tgz#5f37181679c630376f7441a598db636c416f522e"
+  integrity sha512-eIPBRRssimuM+T1zIGtZ+2910BvjOirb85/iPfqJj2uQCCy/FGQvPUpU7QYJt30zsgyRzJGe/G7D8cJO0MFlzg==
   dependencies:
-    "@chakra-ui/accordion" "1.3.10"
-    "@chakra-ui/alert" "1.2.9"
-    "@chakra-ui/avatar" "1.2.12"
-    "@chakra-ui/breadcrumb" "1.2.10"
-    "@chakra-ui/button" "1.4.6"
-    "@chakra-ui/checkbox" "1.5.10"
-    "@chakra-ui/close-button" "1.1.13"
-    "@chakra-ui/control-box" "1.0.17"
-    "@chakra-ui/counter" "1.1.11"
+    "@chakra-ui/accordion" "1.3.8"
+    "@chakra-ui/alert" "1.2.8"
+    "@chakra-ui/avatar" "1.2.11"
+    "@chakra-ui/breadcrumb" "1.2.9"
+    "@chakra-ui/button" "1.4.5"
+    "@chakra-ui/checkbox" "1.5.8"
+    "@chakra-ui/close-button" "1.1.12"
+    "@chakra-ui/control-box" "1.0.16"
+    "@chakra-ui/counter" "1.1.10"
     "@chakra-ui/css-reset" "1.0.0"
-    "@chakra-ui/editable" "1.2.11"
-    "@chakra-ui/form-control" "1.4.3"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/icon" "1.1.13"
-    "@chakra-ui/image" "1.0.22"
-    "@chakra-ui/input" "1.2.12"
-    "@chakra-ui/layout" "1.4.11"
-    "@chakra-ui/live-region" "1.0.16"
-    "@chakra-ui/media-query" "1.1.5"
-    "@chakra-ui/menu" "1.7.8"
-    "@chakra-ui/modal" "1.9.4"
-    "@chakra-ui/number-input" "1.2.12"
-    "@chakra-ui/pin-input" "1.6.7"
-    "@chakra-ui/popover" "1.9.1"
-    "@chakra-ui/popper" "2.3.1"
-    "@chakra-ui/portal" "1.2.11"
-    "@chakra-ui/progress" "1.1.16"
-    "@chakra-ui/provider" "1.6.11"
-    "@chakra-ui/radio" "1.3.13"
-    "@chakra-ui/react-env" "1.0.8"
-    "@chakra-ui/select" "1.1.17"
-    "@chakra-ui/skeleton" "1.1.21"
-    "@chakra-ui/slider" "1.4.2"
-    "@chakra-ui/spinner" "1.1.14"
-    "@chakra-ui/stat" "1.1.14"
-    "@chakra-ui/switch" "1.2.13"
-    "@chakra-ui/system" "1.7.6"
-    "@chakra-ui/table" "1.2.8"
-    "@chakra-ui/tabs" "1.5.7"
-    "@chakra-ui/tag" "1.1.14"
-    "@chakra-ui/textarea" "1.1.16"
-    "@chakra-ui/theme" "1.11.1"
-    "@chakra-ui/toast" "1.3.4"
-    "@chakra-ui/tooltip" "1.3.14"
-    "@chakra-ui/transition" "1.3.8"
-    "@chakra-ui/utils" "1.8.4"
-    "@chakra-ui/visually-hidden" "1.0.16"
+    "@chakra-ui/editable" "1.2.10"
+    "@chakra-ui/form-control" "1.4.2"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/icon" "1.1.12"
+    "@chakra-ui/image" "1.0.21"
+    "@chakra-ui/input" "1.2.11"
+    "@chakra-ui/layout" "1.4.10"
+    "@chakra-ui/live-region" "1.0.15"
+    "@chakra-ui/media-query" "1.1.3"
+    "@chakra-ui/menu" "1.7.6"
+    "@chakra-ui/modal" "1.9.2"
+    "@chakra-ui/number-input" "1.2.11"
+    "@chakra-ui/pin-input" "1.6.6"
+    "@chakra-ui/popover" "1.8.5"
+    "@chakra-ui/popper" "2.3.0"
+    "@chakra-ui/portal" "1.2.10"
+    "@chakra-ui/progress" "1.1.15"
+    "@chakra-ui/provider" "1.6.9"
+    "@chakra-ui/radio" "1.3.11"
+    "@chakra-ui/react-env" "1.0.7"
+    "@chakra-ui/select" "1.1.16"
+    "@chakra-ui/skeleton" "1.1.19"
+    "@chakra-ui/slider" "1.4.1"
+    "@chakra-ui/spinner" "1.1.13"
+    "@chakra-ui/stat" "1.1.13"
+    "@chakra-ui/switch" "1.2.11"
+    "@chakra-ui/system" "1.7.4"
+    "@chakra-ui/table" "1.2.7"
+    "@chakra-ui/tabs" "1.5.6"
+    "@chakra-ui/tag" "1.1.13"
+    "@chakra-ui/textarea" "1.1.15"
+    "@chakra-ui/theme" "1.10.4"
+    "@chakra-ui/toast" "1.3.2"
+    "@chakra-ui/tooltip" "1.3.12"
+    "@chakra-ui/transition" "1.3.6"
+    "@chakra-ui/utils" "1.8.3"
+    "@chakra-ui/visually-hidden" "1.0.15"
 
-"@chakra-ui/select@1.1.17":
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.1.17.tgz#529518495876a910b215c1fbddc48ac1efd11d37"
-  integrity sha512-E+I6vZAxsmnzge8xxaj3AAuqhFEn3L3qVI/fAoA5xyjE0JgJwmrqVXYhDLBANTGnv1YoEohspEUPyc7U3LYabQ==
+"@chakra-ui/select@1.1.16":
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.1.16.tgz#ddf00b505c4ac6cc30c636a5c2924b42b6e6915c"
+  integrity sha512-2Hoq5B4ukEKLOn2TEnw07EGrFLM9ZDOXQltQ4MKXmjkw0EWCE9mwGbW1FK4pp+CW0Qmp34qiYhV6mzaC09iMgQ==
   dependencies:
-    "@chakra-ui/form-control" "1.4.3"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/form-control" "1.4.2"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/skeleton@1.1.21":
-  version "1.1.21"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.1.21.tgz#1b2cfe5422366a9f5e5dda6f3c8855d37cafb956"
-  integrity sha512-MQwitvzPk9JN9HgcM7Ggd4AX4j8T9GpMoNatGvjyPdcHW2hUa9wiLrblhoYGaM2pN/4ww4kUwRK5O3Nvame+fg==
+"@chakra-ui/skeleton@1.1.19":
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.1.19.tgz#c1c36f3b90de03d864350cfc53a0e8cf5dede353"
+  integrity sha512-+JoJxs28PirYmTAaPKabEPcVUWKjFqVvmN8ygK+p3poZQ6J4csCWv7DHbh2dHcvTXJFckuGqmQYFcflW11OoPg==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/media-query" "1.1.5"
-    "@chakra-ui/system" "1.7.6"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/media-query" "1.1.3"
+    "@chakra-ui/system" "1.7.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/slider@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.4.2.tgz#ac85b0def1e948cac08f8b809b8b52b8d1b03ef4"
-  integrity sha512-L+rNPGlmjcC1AiZ/BAgMfv+44pZS8NoWEGBkIIV3jCmGy/XMl8dkAL3EbdPHs/favQICKGsEmTV33AeAy0bVAQ==
+"@chakra-ui/slider@1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.4.1.tgz#c13c0fb28a34c159dd529cb377c7cdd6f1673a98"
+  integrity sha512-7RwnH0bSmZD8TQi7LcK3aszG80qzawE9i0OkIfiNODBOqY3ijI5mU6rFsXJ614gJTmNYD/1z08/E3SZYeBLZHQ==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
+    "@chakra-ui/hooks" "1.6.1"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/spinner@1.1.14":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.1.14.tgz#6bf579c9ab768b076af8c3bed96fde63a151cbc5"
-  integrity sha512-767yIR+RrM9iPXB77EvCrwTtaWhvR3p+vWyfPnRVEQR7kd6NDO696altdQZyUO0hVLyhr3bBPCXofSEChinFHA==
+"@chakra-ui/spinner@1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.1.13.tgz#ef2a8e52f882d86e7091c261bb9d772497f7e5e0"
+  integrity sha512-LpO24XfpkG6pAdcppayNjfdSX8pSHBoi1oxNKCI6JysNgBO+HCWdaz/LaJRB6WEIXZu764XtHEB/mTMdP7edyg==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
-    "@chakra-ui/visually-hidden" "1.0.16"
+    "@chakra-ui/utils" "1.8.3"
+    "@chakra-ui/visually-hidden" "1.0.15"
 
-"@chakra-ui/stat@1.1.14":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.1.14.tgz#72baab056c0da08fdff5fd65c03c443800b7b039"
-  integrity sha512-dhE8m0JeQcDouXEJiMTlXf8QkRhfozc3vfTcyBo4p+mZs4+QXOw1/jcxsPQBzJQ0kNYV8y7LDzJp+J62FoPX1g==
+"@chakra-ui/stat@1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.1.13.tgz#cac6f81d33ff22555f288c3dac8197f3895544f9"
+  integrity sha512-XV6AMKVj/iF3pmao4wK3gnW7meH0W9yfEREA5/8vif/9exvfX6KDz/04irjnFIO/cDu7QHQKQmXTnhe1zLwvMA==
   dependencies:
-    "@chakra-ui/icon" "1.1.13"
-    "@chakra-ui/utils" "1.8.4"
-    "@chakra-ui/visually-hidden" "1.0.16"
+    "@chakra-ui/icon" "1.1.12"
+    "@chakra-ui/utils" "1.8.3"
+    "@chakra-ui/visually-hidden" "1.0.15"
 
-"@chakra-ui/styled-system@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.13.0.tgz#64f743a223b5ffd5ad15aca43fbc93adc0ce2a5c"
-  integrity sha512-+pdJ2ZnIS2uqJhm2Lyi5asYGJnwrZcFH/4rje18e6wh39Y937EDr0XRuwqbqL9Lk2C4G1H/M1br0cAmO85kHIw==
+"@chakra-ui/styled-system@1.12.3":
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.12.3.tgz#e72de24399a1e98f7b3dcd8b0328ec764a4365c0"
+  integrity sha512-Rgan47tBgqvE6K6wKEMjRpK/pM+6aHvn18MoZFWcrMCMfd7QxGuhI9MHaQP8b20i11bjtTlUd6AGs3PEMl6ZyQ==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
     csstype "^3.0.6"
 
-"@chakra-ui/switch@1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.2.13.tgz#63daab2ed0f499d2409ec5e566ffbfca3d1be755"
-  integrity sha512-nD9Sm+d2NfI6sVA9Y14az3yHdCUMkk+h0n7pDughI2p3VMlG196li/bI8BSwnIa8y4XtpARSACo5dx8tWnOD1Q==
+"@chakra-ui/switch@1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.2.11.tgz#f54594d2713b3941d50c649884ffa0938fb8067c"
+  integrity sha512-3cZmLR0dQLQSrGQ8lJgsdxUNrek8ZpMdA8pzFASKOhge3goeHsbiyxFutbYagBYLmS573kFVHu/o/RDVnP5xxA==
   dependencies:
-    "@chakra-ui/checkbox" "1.5.10"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/checkbox" "1.5.8"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/system@1.7.6":
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.7.6.tgz#641b7c3d97fcd71eed3d085d585a40cd532815de"
-  integrity sha512-83h5Ky+Ks8ddeU77ozwZlyxU1+ESysmrJ0bGCohmD69LxUZHUrcK4csUOJl9AuZioufoQdYvR3xUJFEM8v0d2w==
+"@chakra-ui/system@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.7.4.tgz#183917e3c2cd81ab8c1591c7d7b741cf69c575cc"
+  integrity sha512-YZMPP+OCuV5edxXuwDPP7TEVl13Kziq0vf/GjgnCizcgUImSRL9eUaPcF4INvGbvS/rcAeG9mZn26DMpFwVV7g==
   dependencies:
-    "@chakra-ui/color-mode" "1.2.0"
+    "@chakra-ui/color-mode" "1.1.13"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/styled-system" "1.13.0"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/styled-system" "1.12.3"
+    "@chakra-ui/utils" "1.8.3"
     react-fast-compare "3.2.0"
 
-"@chakra-ui/table@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/table/-/table-1.2.8.tgz#1cf93db3855c572af19e47d544639639071a11e9"
-  integrity sha512-Ra6qM+8osM6EwGidn9jrzdIufo5tQ8WMJkuXyv9mByjJnzbr2EOQqexHHA8AwCMsxaFieWBG9QPuuDWavl8ptQ==
+"@chakra-ui/table@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/table/-/table-1.2.7.tgz#b5e02396b8c735d414c7121c988b6b82ee143539"
+  integrity sha512-fx7Hl1I16DCCD/pPBtkH/gl6ielUkLg8qQfPJ+5nbE8xrRM5Nxp2RqFuuFrJ0qGLZ+OZrshPm9r86JVrS6ZmOw==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/tabs@1.5.7":
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.5.7.tgz#c2c485b93dc6719ef117897e807f307551595753"
-  integrity sha512-+z9FsdY9Qukp9nShgh+LR/cMJGzwhGdgmav/AX/P/f/C/32PFYhmBZrKobHJwozYZeDebBeb8zhxqV8VROrfRQ==
+"@chakra-ui/tabs@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.5.6.tgz#f3edd6de2677389cad1d7c30d3130b8763bb7920"
+  integrity sha512-s83Bosv7aQkcE6ufaAx6yRur8bV2uIuVAaTczMv4oxH/5OU2wNwA4rGbdiPbrxDf9M8M0AuH/mqJ+2uSu7Vdxg==
   dependencies:
-    "@chakra-ui/clickable" "1.1.9"
+    "@chakra-ui/clickable" "1.1.8"
     "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.6.2"
+    "@chakra-ui/hooks" "1.6.1"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/tag@1.1.14":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.1.14.tgz#eb562be55751c2a04dcfe31d5863545c4ae855d9"
-  integrity sha512-FfROxP2WJIimYWr6IRuLnJlH6an4QoJvXMO98yQYSXqycsOcuVNA+XP3aRCa6+o9qcL95AqkAidkpXSd8+sHsw==
+"@chakra-ui/tag@1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.1.13.tgz#976f6e356248cecb7b4a00e64802f108bbcfc61e"
+  integrity sha512-p1BxgqFnDzVFQrBJ1EItM+BCNjfJ9vCjg5lQK13JeLWHa6kHR+2agzNgxH+F9jzhKGY17BHroc2YYW4yKzD61Q==
   dependencies:
-    "@chakra-ui/icon" "1.1.13"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/icon" "1.1.12"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/textarea@1.1.16":
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.1.16.tgz#2f9cab0dc5b4edd652c50979f9a424d84dc7208c"
-  integrity sha512-wXYmZSsoYspH3Rtzhb9joysIfzHlegds9ABlBeuothYqz6HEQg7+DiTIdVmqtMydExdU+fhxuhwQ/EIGXCronA==
+"@chakra-ui/textarea@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.1.15.tgz#9fdb3232573b13cab8a7a22aaa2b81c1c3d06f28"
+  integrity sha512-q6yvyEdZ+72Gq6eE76vJxCo5aZcYdiORJHTmELtJWo4h+a1ASd8OBdIkygbvqKnT/jssnH2b2S9kFf8EcEPkMg==
   dependencies:
-    "@chakra-ui/form-control" "1.4.3"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/form-control" "1.4.2"
+    "@chakra-ui/utils" "1.8.3"
 
-"@chakra-ui/theme-tools@*", "@chakra-ui/theme-tools@1.2.3", "@chakra-ui/theme-tools@^1.2.3":
+"@chakra-ui/theme-tools@*", "@chakra-ui/theme-tools@^1.2.1", "@chakra-ui/theme-tools@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.2.3.tgz#dfb93913a0e808b13db65fbd7d9d4489189e95ad"
   integrity sha512-4vYW5KiJHRpqiuAw6opDMdIOMywL47gCtFiOP1CwwObXxrHetEHyJvMt9qnx+AfSMyCFGyHz8sFjDmLc+v/jEA==
@@ -1708,46 +1721,64 @@
     "@chakra-ui/utils" "1.8.4"
     "@ctrl/tinycolor" "^3.4.0"
 
-"@chakra-ui/theme@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.11.1.tgz#bc439956d92e436ecc5c4b49b129218a439f3fd1"
-  integrity sha512-0E4Vb6AP/W400nj9qDUhT+LPzpz2fi99lBCffIwR53m9t+xWjWWdB7saXJ2Np1xKdkhGbzSpcn3Fo8Q3CzVM7w==
+"@chakra-ui/theme-tools@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.2.2.tgz#22feef17ee764f5989235c29f5ee3ffd25066f3a"
+  integrity sha512-+2xPTW7/rFr++Qu/ibZsM1dq5qmvvjg6+Af4SRZw1AvjGq4CTxuV7upXo5zJM3Q3OgzOtU9Q9RATap3fhEHkyA==
   dependencies:
-    "@chakra-ui/anatomy" "1.1.0"
-    "@chakra-ui/theme-tools" "1.2.3"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
+    "@ctrl/tinycolor" "^3.4.0"
 
-"@chakra-ui/toast@1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.3.4.tgz#c51651d71cf363db8ba3421ab9d99e065e19e5ed"
-  integrity sha512-0RMMldpvtita0zfFE5Jwp9JphUVL2P8jDfoiPJrqKD6K/7vT4dj3PyWhiIedes4yv4SM/dI3dnXKA8fChQaotQ==
+"@chakra-ui/theme@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.10.4.tgz#6d1a39066a3a2e9e073455204b880af0acf6067f"
+  integrity sha512-FaO5Qr1oGP+1JoCIotoqWT9RF0aguXmKjgz+4xDM8E+Gct6juuj+td43NfzeXr/FJXiXjL8u1G4RWxAeR2FxZQ==
   dependencies:
-    "@chakra-ui/alert" "1.2.9"
-    "@chakra-ui/close-button" "1.1.13"
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/theme" "1.11.1"
-    "@chakra-ui/transition" "1.3.8"
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/anatomy" "1.0.1"
+    "@chakra-ui/theme-tools" "1.2.2"
+    "@chakra-ui/utils" "1.8.3"
+
+"@chakra-ui/toast@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.3.2.tgz#cd2a606e1ac218750d5f415ef9c5343bb26a9b09"
+  integrity sha512-uREAV+UoPvbTktQXgGhaExOX4RIKAlj54K9yOojO2FOBDCywtq0TdlI4eMk/dZvlz2SIuTWveK/C4CHBBbcd4Q==
+  dependencies:
+    "@chakra-ui/alert" "1.2.8"
+    "@chakra-ui/close-button" "1.1.12"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/theme" "1.10.4"
+    "@chakra-ui/transition" "1.3.6"
+    "@chakra-ui/utils" "1.8.3"
     "@reach/alert" "0.13.2"
 
-"@chakra-ui/tooltip@1.3.14":
-  version "1.3.14"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.3.14.tgz#10c54a81ad810b16f442e6bfc129561beb9eb63a"
-  integrity sha512-P7npmVnCcGdTxwbf8lIHcsvpPdLpQLgyOcdEykJd6iSEb33SquVK2RULrktawn/NqbAohulUrvVoIHDhY9j92A==
+"@chakra-ui/tooltip@1.3.12":
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.3.12.tgz#1e6212a989c88ab571e36bb0e97a3d8e0fb6385c"
+  integrity sha512-zF4pWU//9YSIR3D9cljO+BNlYettKXqgVermTg8z7KvKMmgH+Ni99OA7aWQ6g3vii9LzJryi5kUdxfApoLCm9Q==
   dependencies:
-    "@chakra-ui/hooks" "1.6.2"
-    "@chakra-ui/popper" "2.3.1"
-    "@chakra-ui/portal" "1.2.11"
+    "@chakra-ui/hooks" "1.6.1"
+    "@chakra-ui/popper" "2.3.0"
+    "@chakra-ui/portal" "1.2.10"
     "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.4"
-    "@chakra-ui/visually-hidden" "1.0.16"
+    "@chakra-ui/utils" "1.8.3"
+    "@chakra-ui/visually-hidden" "1.0.15"
 
-"@chakra-ui/transition@1.3.8":
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.3.8.tgz#fd022eb7d190b5afd2f9013b14a1e074dcb6a0b1"
-  integrity sha512-YvcHkazYUIBaew5dfrts9Wp6/LPhHgbJoRYrKHBcfsDU+a63g/HoN4SCB19B46+pV3L6Fg4VPnOIED7KL7uoXg==
+"@chakra-ui/transition@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.3.6.tgz#c577c4a5a4d3a42c057e966ce85881310c715424"
+  integrity sha512-P6H88iHWwElGpqrH3RoEhWTZToFw3ZQx2XyJhVUHNroavkxQ48wyRcoFIQ/btKAInQ+5xyyKISRLZlvAuy6ONg==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
+
+"@chakra-ui/utils@1.8.3":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.8.3.tgz#4eb6da7d772e483376ca47afeaf54cd453432340"
+  integrity sha512-v184c2TYwQYBEcDI/9C1DjN668jZVTJeb/DPtucAjEHNi4T0py3tjGDbUd05LoNoZ64uijtWYanfrr6Abe4m1Q==
+  dependencies:
+    "@types/lodash.mergewith" "4.6.6"
+    css-box-model "1.2.1"
+    framesync "5.3.0"
+    lodash.mergewith "4.6.2"
 
 "@chakra-ui/utils@1.8.4", "@chakra-ui/utils@^1.7.0":
   version "1.8.4"
@@ -1759,12 +1790,12 @@
     framesync "5.3.0"
     lodash.mergewith "4.6.2"
 
-"@chakra-ui/visually-hidden@1.0.16":
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.0.16.tgz#7cd3299bbedc4c924be699a2a1a323fa91377c48"
-  integrity sha512-UQfSepguq/A0OzhW6tzBspLim8nMlG4G1pFeQRyuGAqJnoh1fCk749jcv32+FDBaeI60JGMCap6LcYgarxpt3A==
+"@chakra-ui/visually-hidden@1.0.15":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.0.15.tgz#85270aca0e49d4dd21de9088e4eb6f07caf1e9ff"
+  integrity sha512-/qGI47YamrgazFt9KS4YxIt5U2/RT6jxdjHj1Tn3D2clivB1n+H+v5fQC9xFfjm7ul0QZwEhBrYhynqr5ybZkg==
   dependencies:
-    "@chakra-ui/utils" "1.8.4"
+    "@chakra-ui/utils" "1.8.3"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
The latest version of chakra-ui breaks any configuration for color mode in chakra and always forces the system theme.

Our dependency upgrade workflow introduced this version and has caused visual issues for multiple users. Pinning the version should solve this for the time being until chakra-ui fixes the issue on their end

Here's a link to the @chakra-ui issue: https://github.com/chakra-ui/chakra-ui/issues/4987