### PR TITLE
fix: replace service worker with no-op worker

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -86,6 +86,9 @@
       "steps": [
         {
           "exec": "react-scripts build"
+        },
+        {
+          "spawn": "replace-worker"
         }
       ]
     },
@@ -233,6 +236,17 @@
         },
         {
           "exec": "git diff --ignore-space-at-eol --exit-code"
+        }
+      ]
+    },
+    "replace-worker": {
+      "name": "replace-worker",
+      "steps": [
+        {
+          "exec": "cp src/no-op-sw.js build/service-worker.js"
+        },
+        {
+          "exec": "rm build/service-worker.js.map"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -264,6 +264,12 @@ project.release.addJobs({
   },
 });
 
+// replace default service worker script with no-op worker
+const replaceWorker = project.addTask("replace-worker");
+replaceWorker.exec("cp src/no-op-sw.js build/service-worker.js");
+replaceWorker.exec("rm build/service-worker.js.map");
+project.compileTask.spawn(replaceWorker);
+
 project.synth();
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "publish:github": "npx projen publish:github",
     "publish:npm": "npx projen publish:npm",
     "release": "npx projen release",
+    "replace-worker": "npx projen replace-worker",
     "test": "npx projen test",
     "test:unit": "npx projen test:unit",
     "test:update": "npx projen test:update",

--- a/src/no-op-sw.js
+++ b/src/no-op-sw.js
@@ -1,0 +1,8 @@
+// A simple, no-op service worker that takes immediate control.
+
+self.addEventListener("install", () => {
+  // Skip over the "waiting" lifecycle state, to ensure that our
+  // new service worker is activated immediately, even if there's
+  // another tab open controlled by our older service worker code.
+  self.skipWaiting();
+});


### PR DESCRIPTION
In #571 we updated the default JavaScript code to try and unregister service workers. However, the same service-worker.js file is still being served at the root of the website, which may cause browsers that still have the old service worker installed to think there has been no changes to the service worker, so it may continue serving old cached content. A more proper fix as described by [this Stackoverflow post](https://stackoverflow.com/questions/33986976/how-can-i-remove-a-buggy-service-worker-or-implement-a-kill-switch/38980776) is to replace the service worker with a no-op worker that does not try serving any cached content.