### PR TITLE
chore: filter ux adjustments

### DIFF
--- a/src/theme/components/Checkbox.ts
+++ b/src/theme/components/Checkbox.ts
@@ -1,0 +1,109 @@
+import { checkboxAnatomy as parts } from "@chakra-ui/anatomy";
+import {
+  mode,
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+  SystemStyleObject,
+} from "@chakra-ui/theme-tools";
+
+const baseStyleControl: SystemStyleFunction = (props) => {
+  const { colorScheme: c } = props;
+
+  return {
+    w: "100%",
+    transitionProperty: "box-shadow",
+    transitionDuration: "normal",
+    border: "2px solid",
+    borderRadius: "sm",
+    borderColor: "inherit",
+    color: "white",
+
+    _checked: {
+      bg: mode(`${c}.500`, `${c}.200`)(props),
+      borderColor: mode(`${c}.500`, `${c}.200`)(props),
+      color: mode("white", "gray.900")(props),
+
+      _hover: {
+        bg: mode(`${c}.600`, `${c}.300`)(props),
+        borderColor: mode(`${c}.600`, `${c}.300`)(props),
+      },
+
+      _disabled: {
+        borderColor: mode("gray.200", "transparent")(props),
+        bg: mode("gray.200", "whiteAlpha.300")(props),
+        color: mode("gray.500", "whiteAlpha.500")(props),
+      },
+    },
+
+    _indeterminate: {
+      bg: mode(`${c}.500`, `${c}.200`)(props),
+      borderColor: mode(`${c}.500`, `${c}.200`)(props),
+      color: mode("white", "gray.900")(props),
+    },
+
+    _disabled: {
+      bg: mode("gray.100", "whiteAlpha.100")(props),
+      borderColor: mode("gray.100", "transparent")(props),
+    },
+
+    _focus: {
+      boxShadow: "outline",
+    },
+
+    _invalid: {
+      borderColor: mode("red.500", "red.300")(props),
+    },
+  };
+};
+
+const baseStyleLabel: SystemStyleObject = {
+  userSelect: "none",
+  _disabled: { opacity: 0.4 },
+};
+
+const baseStyleIcon: SystemStyleObject = {
+  transitionProperty: "transform",
+  transitionDuration: "normal",
+};
+
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+  icon: baseStyleIcon,
+  control: baseStyleControl(props),
+  label: baseStyleLabel,
+});
+
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
+  sm: {
+    control: { h: 3, w: 3 },
+    label: { fontSize: "sm" },
+    icon: { fontSize: "0.45rem" },
+  },
+  base: {
+    control: { h: 3.5, w: 3.5 },
+    label: { fontSize: "md" },
+    icon: { fontSize: "0.5rem" },
+  },
+  md: {
+    control: { w: 4, h: 4 },
+    label: { fontSize: "md" },
+    icon: { fontSize: "0.625rem" },
+  },
+  lg: {
+    control: { w: 5, h: 5 },
+    label: { fontSize: "lg" },
+    icon: { fontSize: "0.625rem" },
+  },
+};
+
+const defaultProps = {
+  size: "base",
+  colorScheme: "blue",
+};
+
+export const Checkbox = {
+  parts: parts.keys,
+  baseStyle,
+  sizes,
+  defaultProps,
+};

--- a/src/theme/components/Checkbox.ts
+++ b/src/theme/components/Checkbox.ts
@@ -81,7 +81,7 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   },
   base: {
     control: { h: 3.5, w: 3.5 },
-    label: { fontSize: "md" },
+    label: { fontSize: "sm" },
     icon: { fontSize: "0.5rem" },
   },
   md: {

--- a/src/theme/components/Radio.ts
+++ b/src/theme/components/Radio.ts
@@ -12,12 +12,16 @@ const baseStyleControl: SystemStyleFunction = (props) => {
   return {
     ...control,
     borderRadius: "full",
+    pos: "relative",
     _checked: {
       ...control._checked,
       _before: {
         content: `""`,
         display: "inline-block",
-        pos: "relative",
+        pos: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
         w: "50%",
         h: "50%",
         borderRadius: "50%",
@@ -39,7 +43,7 @@ const sizes: Record<string, PartsStyleObject<typeof parts>> = {
   },
   base: {
     control: { h: 3.5, w: 3.5 },
-    label: { fontSize: "md" },
+    label: { fontSize: "sm" },
   },
   md: {
     control: { h: 4, w: 4 },

--- a/src/theme/components/Radio.ts
+++ b/src/theme/components/Radio.ts
@@ -1,0 +1,64 @@
+import { radioAnatomy as parts } from "@chakra-ui/anatomy";
+import {
+  PartsStyleFunction,
+  PartsStyleObject,
+  SystemStyleFunction,
+} from "@chakra-ui/theme-tools";
+import { Checkbox } from "./Checkbox";
+
+const baseStyleControl: SystemStyleFunction = (props) => {
+  const { control = {} } = Checkbox.baseStyle(props) as any;
+
+  return {
+    ...control,
+    borderRadius: "full",
+    _checked: {
+      ...control._checked,
+      _before: {
+        content: `""`,
+        display: "inline-block",
+        pos: "relative",
+        w: "50%",
+        h: "50%",
+        borderRadius: "50%",
+        bg: "currentColor",
+      },
+    },
+  };
+};
+
+const baseStyle: PartsStyleFunction<typeof parts> = (props) => ({
+  label: Checkbox.baseStyle(props).label,
+  control: baseStyleControl(props),
+});
+
+const sizes: Record<string, PartsStyleObject<typeof parts>> = {
+  sm: {
+    control: { h: 3, w: 3 },
+    label: { fontSize: "sm" },
+  },
+  base: {
+    control: { h: 3.5, w: 3.5 },
+    label: { fontSize: "md" },
+  },
+  md: {
+    control: { h: 4, w: 4 },
+    label: { fontSize: "md" },
+  },
+  lg: {
+    control: { h: 5, w: 5 },
+    label: { fontSize: "lg" },
+  },
+};
+
+const defaultProps = {
+  size: "base",
+  colorScheme: "blue",
+};
+
+export const Radio = {
+  parts: parts.keys,
+  baseStyle,
+  sizes,
+  defaultProps,
+};

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,7 +1,9 @@
 import { theme } from "@chakra-ui/react";
 import { PackageTagConfig } from "../../api/config";
+import { Checkbox } from "./Checkbox";
 import { Code } from "./Code";
 import { Divider } from "./Divider";
+import { Radio } from "./Radio";
 import { makeTag } from "./Tag";
 
 interface ComponentsConfig {
@@ -11,8 +13,10 @@ interface ComponentsConfig {
 export const makeComponents = (config: ComponentsConfig) => {
   return {
     ...theme.components,
+    Checkbox,
     Code,
     Divider,
+    Radio,
     Tag: makeTag(config.Tag),
   };
 };

--- a/src/views/SearchRedesign/CheckboxFilter.tsx
+++ b/src/views/SearchRedesign/CheckboxFilter.tsx
@@ -28,7 +28,7 @@ export const CheckboxFilter: FunctionComponent<CheckboxFilterProps> = ({
   };
 
   return (
-    <Stack data-testid={dataTestid} spacing={2}>
+    <Stack data-testid={dataTestid} spacing={1}>
       <FilterHeading hint={hint} name={name} />
       {options.map(({ disabledHint, display, isDisabled, value }) => (
         <Checkbox

--- a/src/views/SearchRedesign/CheckboxFilter.tsx
+++ b/src/views/SearchRedesign/CheckboxFilter.tsx
@@ -47,7 +47,6 @@ export const CheckboxFilter: FunctionComponent<CheckboxFilterProps> = ({
               color="gray.600"
               data-testid={testIds.filterItem}
               data-value={value}
-              fontSize="sm"
               isTruncated
             >
               {display}

--- a/src/views/SearchRedesign/FilterHeading.tsx
+++ b/src/views/SearchRedesign/FilterHeading.tsx
@@ -4,7 +4,6 @@ import {
   Heading,
   Text,
   Popover,
-  // IconButton,
   PopoverTrigger,
   PopoverBody,
   PopoverArrow,

--- a/src/views/SearchRedesign/FilterHeading.tsx
+++ b/src/views/SearchRedesign/FilterHeading.tsx
@@ -4,7 +4,7 @@ import {
   Heading,
   Text,
   Popover,
-  IconButton,
+  // IconButton,
   PopoverTrigger,
   PopoverBody,
   PopoverArrow,
@@ -22,22 +22,16 @@ export const FilterHeading: FunctionComponent<FilterHeadingProps> = ({
   hint,
 }) => {
   return (
-    <Flex align="center">
+    <Flex align="center" mb={1}>
       <Heading as="h4" size="sm" w="max-content">
         {name}
       </Heading>
       {hint ? (
         <Popover colorScheme="dark" placement="right" strategy="fixed">
           <PopoverTrigger>
-            <IconButton
-              aria-label={`Hint: ${name}`}
-              icon={<QuestionIcon h={4} w={4} />}
-              ml={2}
-              px={0}
-              py={0}
-              size="sm"
-              variant="ghost"
-            />
+            <Flex aria-label={`Hint: ${name}`} as="button" ml={2}>
+              <QuestionIcon h={3.5} w={3.5} />
+            </Flex>
           </PopoverTrigger>
           <PopoverContent
             bg="gray.700"

--- a/src/views/SearchRedesign/FilterPanel.tsx
+++ b/src/views/SearchRedesign/FilterPanel.tsx
@@ -30,7 +30,7 @@ export const FilterPanel: FunctionComponent<FilterPanelProps> = () => {
       top={TOP_OFFSET}
       zIndex="docked"
     >
-      <Stack color="blue.800" h="max-content" spacing={6} top={4}>
+      <Stack color="blue.800" h="max-content" spacing={4} top={4}>
         <Heading as="h3" size="sm">
           Filters
         </Heading>

--- a/src/views/SearchRedesign/RadioFilter.tsx
+++ b/src/views/SearchRedesign/RadioFilter.tsx
@@ -22,7 +22,7 @@ export const RadioFilter: FunctionComponent<RadioFilterProps> = ({
   hint,
 }) => {
   return (
-    <Stack data-testid={dataTestid} spacing={2}>
+    <Stack data-testid={dataTestid} spacing={1}>
       <FilterHeading hint={hint} name={name} />
       <RadioGroup onChange={onValueChange} value={checkedValue}>
         <Stack>

--- a/src/views/SearchRedesign/RadioFilter.tsx
+++ b/src/views/SearchRedesign/RadioFilter.tsx
@@ -25,14 +25,13 @@ export const RadioFilter: FunctionComponent<RadioFilterProps> = ({
     <Stack data-testid={dataTestid} spacing={1}>
       <FilterHeading hint={hint} name={name} />
       <RadioGroup onChange={onValueChange} value={checkedValue}>
-        <Stack>
+        <Stack spacing={1}>
           {options.map(({ display, value }) => (
             <Radio key={value} value={value}>
               <Text
                 color="gray.600"
                 data-testid={testIds.filterItem}
                 data-value={value}
-                fontSize="sm"
                 isTruncated
               >
                 {display}


### PR DESCRIPTION
Implements the following changes:
- Ensure all spaces between filter groups = 16px
- Ensure all spaces between filter label and filter values = 8px
- reduce radio buttons and checkboxes to have size 14x14px
- space between radio buttons and checkboxes = 4px
- Modify question mark icon size from 16x16 to 14x14
- Reduce spacing between tooltip icon and label to 6px