### PR TITLE
chore: search label adjustments

### DIFF
--- a/src/views/SearchRedesign/SearchDetails.tsx
+++ b/src/views/SearchRedesign/SearchDetails.tsx
@@ -16,6 +16,26 @@ const Em: FunctionComponent = ({ children }) => (
   </Text>
 );
 
+const Count: FunctionComponent<{ first: number; count: number; last: number }> =
+  ({ first, count, last }) => {
+    if (!first && last >= count) {
+      return (
+        <>
+          <Em>{count}</Em> of <Em>{count}</Em>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Em>
+          {count ? first + 1 : count} - {last > count ? count : last}
+        </Em>{" "}
+        of <Em>{count}</Em>
+      </>
+    );
+  };
+
 export const SearchDetails: FunctionComponent<SearchDetailsProps> = ({
   limit,
   offset,
@@ -25,19 +45,25 @@ export const SearchDetails: FunctionComponent<SearchDetailsProps> = ({
 }) => {
   const first = limit * offset;
   const last = first + limit;
+  const hasResults = count > 0;
+
   return (
     <Text data-testid={testIds.searchDetails}>
-      Displaying{" "}
-      <Em>
-        {count ? first + 1 : count} - {last > count ? count : last}
-      </Em>{" "}
-      of <Em>{count}</Em> {filtered ? "search results" : "constructs"}
+      {hasResults ? (
+        <>
+          Displaying <Count count={count} first={first} last={last} />{" "}
+          {filtered ? "search results" : "constructs"}
+        </>
+      ) : (
+        <>{filtered ? "There were no search results" : "No constructs found"}</>
+      )}
       {query && (
         <>
           {" for "}
           <Em>{query}</Em>
         </>
       )}
+      .{!hasResults && filtered && <> Try a different term.</>}
     </Text>
   );
 };

--- a/src/views/SearchRedesign/SearchResults.tsx
+++ b/src/views/SearchRedesign/SearchResults.tsx
@@ -67,11 +67,15 @@ export const SearchResults: FunctionComponent = () => {
       isFirstRender.current = false;
     } else {
       // Trigger a history replace rather than push to avoid bloating browser history
-      window.scrollTo(0, 0);
       onSearch({ replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sort, languages, cdkType, cdkMajor, tags]);
+
+  // Scroll to top on page change
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [page]);
 
   return (
     <Page

--- a/src/views/SearchRedesign/SearchResults.tsx
+++ b/src/views/SearchRedesign/SearchResults.tsx
@@ -67,6 +67,7 @@ export const SearchResults: FunctionComponent = () => {
       isFirstRender.current = false;
     } else {
       // Trigger a history replace rather than push to avoid bloating browser history
+      window.scrollTo(0, 0);
       onSearch({ replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes #588 
Fixes #587 

Implements the following changes:
- When there is only a single page of results, display "Showing **x** of **x** results"
- Scroll to top when search results change
- When there are no results, display "There were no results for **X**. Try a different term."