### PR TITLE
feat: show dependency versions

### DIFF
--- a/src/views/Package/DependenciesList.tsx
+++ b/src/views/Package/DependenciesList.tsx
@@ -38,7 +38,7 @@ export const DependenciesList: FunctionComponent = () => {
           p={2}
           to={getPackagePath({ name, version: sanitizeVersion(version) })}
         >
-          {name}
+          {name} - {version}
         </NavLink>
       ))}
     </Stack>

--- a/src/views/Package/PackageHeader/Heading.tsx
+++ b/src/views/Package/PackageHeader/Heading.tsx
@@ -67,7 +67,7 @@ export const Heading: FunctionComponent<HeadingProps> = ({
         >
           {name}
         </ChakraHeading>
-        <Box as="span" color="blue.500" flex={1} fontSize="sm" ml={4}>
+        <Box as="span" flex={1} fontSize="sm" ml={4}>
           {version}
         </Box>
       </Flex>


### PR DESCRIPTION
Fixes #638

Displays dependency versions in the same manner as we did previously within the dropdown. Also recolors the package version from a blue (commonly used in links) to prevent confusion