### PR TITLE
feat: show all keywords on package page

### DIFF
--- a/src/components/Code/Code.tsx
+++ b/src/components/Code/Code.tsx
@@ -29,7 +29,6 @@ export const Code: FunctionComponent<CodeProps> = ({
           borderRadius="md"
           boxShadow="base"
           className={props.className}
-          marginX={2}
           style={props.style}
           {...boxProps}
         >

--- a/src/components/Markdown/Code.tsx
+++ b/src/components/Markdown/Code.tsx
@@ -22,6 +22,7 @@ export const Code: FunctionComponent<CodeProps> = ({
         borderColor="gray.50"
         borderRadius="md"
         marginTop="md"
+        mx={2}
         px={2}
         py={0}
       >

--- a/src/views/Package/PackageHeader/HeaderContainer.tsx
+++ b/src/views/Package/PackageHeader/HeaderContainer.tsx
@@ -24,12 +24,12 @@ const lgGridAreas = makeGridAreas(
 export const HeaderContainer: FunctionComponent = ({ children }) => (
   <Grid
     columnGap={{ md: 6, lg: 10 }}
-    pt={{ base: 3, md: 6 }}
+    pt={{ base: 3, lg: 6 }}
     px={{ base: 5, md: 6, lg: 10 }}
-    rowGap={{ base: 4, md: 0 }}
-    templateAreas={{ base: baseGridAreas, md: lgGridAreas }}
-    templateColumns={{ base: "1fr", md: "1fr auto 15rem" }}
-    templateRows={{ md: "auto 1fr" }}
+    rowGap={{ base: 4, lg: 0 }}
+    templateAreas={{ base: baseGridAreas, lg: lgGridAreas }}
+    templateColumns={{ base: "1fr", lg: "1fr auto 15rem" }}
+    templateRows={{ lg: "auto 1fr" }}
   >
     {children}
   </Grid>

--- a/src/views/Package/PackageHeader/Heading.tsx
+++ b/src/views/Package/PackageHeader/Heading.tsx
@@ -89,18 +89,11 @@ export const Heading: FunctionComponent<HeadingProps> = ({
           fontWeight="semibold"
           {...cdkTypeProps}
         />
-        {tags
-          // .slice(0, 3)
-          .map(({ id, isKeyword, keyword: { label, color } = {} }) => (
-            <PackageTag
-              isKeyword={isKeyword}
-              key={id}
-              value={id}
-              variant={color}
-            >
-              {label}
-            </PackageTag>
-          ))}
+        {tags.map(({ id, isKeyword, keyword: { label, color } = {} }) => (
+          <PackageTag isKeyword={isKeyword} key={id} value={id} variant={color}>
+            {label}
+          </PackageTag>
+        ))}
       </Flex>
     </Stack>
   );

--- a/src/views/Package/PackageHeader/Heading.tsx
+++ b/src/views/Package/PackageHeader/Heading.tsx
@@ -74,7 +74,14 @@ export const Heading: FunctionComponent<HeadingProps> = ({
 
       <Text fontSize="1rem">{description}</Text>
 
-      <Stack align="center" direction="row" pt={3} spacing={2}>
+      <Flex
+        align="center"
+        direction="row"
+        pt={3}
+        // Chakra doesn't yet support css gap via style props
+        sx={{ gap: "0.5rem" }}
+        wrap="wrap"
+      >
         <CDKTypeIcon {...cdkTypeProps} />
         <CDKTypeText
           color="gray.700"
@@ -83,7 +90,7 @@ export const Heading: FunctionComponent<HeadingProps> = ({
           {...cdkTypeProps}
         />
         {tags
-          .slice(0, 3)
+          // .slice(0, 3)
           .map(({ id, isKeyword, keyword: { label, color } = {} }) => (
             <PackageTag
               isKeyword={isKeyword}
@@ -94,7 +101,7 @@ export const Heading: FunctionComponent<HeadingProps> = ({
               {label}
             </PackageTag>
           ))}
-      </Stack>
+      </Flex>
     </Stack>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/cdklabs/construct-hub/issues/538

We can now display more keywords on the package header! This is using flex gap which is supported on Firefox, Chrome, and Safari meaning we don't have to hack a solution when items wrap

<img width="1901" alt="Screen Shot 2021-11-12 at 2 18 18 PM" src="https://user-images.githubusercontent.com/8749859/141544393-30efa13a-c541-4813-a5ad-1cf38bf2ddf5.png">
<img width="681" alt="Screen Shot 2021-11-12 at 2 18 25 PM" src="https://user-images.githubusercontent.com/8749859/141544417-32d4c3a4-389c-43d9-88a5-c7f1d5141ee4.png">
