### PR TITLE
feat: add tags to search indexing

### DIFF
--- a/src/api/catalog-search/__snapshots__/catalog-search.test.ts.snap
+++ b/src/api/catalog-search/__snapshots__/catalog-search.test.ts.snap
@@ -97,8 +97,8 @@ Array [
 
 exports[`CatalogSearchAPI Snapshots Returns consistent query results 1`] = `
 Array [
-  "@aws-cdk/aws-lambda-nodejs@1.125.0",
   "aws-lambda-golang@0.1.1",
+  "@aws-cdk/aws-lambda-nodejs@1.125.0",
   "@aws-cdk/aws-lambda-destinations@1.125.0",
   "nodejsfunction-plus@0.0.1",
   "cdk-elasticache-monitor@0.0.13",

--- a/src/api/catalog-search/catalog-search.ts
+++ b/src/api/catalog-search/catalog-search.ts
@@ -36,6 +36,10 @@ const INDEX_FIELDS = {
     name: "scope",
     boost: 5,
   },
+  TAG_NAMES: {
+    name: "tagNames",
+    boost: 2,
+  },
 } as const;
 
 export interface ExtendedCatalogPackage extends CatalogPackage {
@@ -44,6 +48,7 @@ export interface ExtendedCatalogPackage extends CatalogPackage {
   downloads: number;
   id: string;
   packageName?: string;
+  tagNames: string[];
   scope?: string;
 }
 
@@ -109,18 +114,42 @@ export class CatalogSearchAPI {
         (pkg) => !pkg.keywords?.includes("construct-hub/hide-from-search")
       )
       .reduce((map, pkg) => {
-        const { name, version } = pkg;
+        const { author, name, version } = pkg;
         const id = [name, version].join("@");
 
         const downloads = stats.packages[name]?.downloads?.npm ?? 0;
+        let [scope, packageName] = name.split("/");
 
+        if (!packageName) {
+          packageName = scope;
+        }
+
+        let authorName: string | undefined;
+        let authorEmail: string | undefined;
+
+        if (typeof author === "string") {
+          authorName = author;
+        } else {
+          if (author?.name) {
+            authorName = author.name;
+          }
+
+          if (author?.email) {
+            authorEmail = author.email;
+          }
+        }
         map.set(id, {
           ...pkg,
+          authorName,
+          authorEmail,
           keywords: pkg.keywords?.filter(
             (keyword) => !KEYWORD_IGNORE_LIST.has(keyword)
           ),
           downloads,
           id,
+          packageName,
+          scope,
+          tagNames: (pkg.metadata.packageTags ?? []).map((t) => t.id),
         });
 
         return map;
@@ -141,29 +170,6 @@ export class CatalogSearchAPI {
       }
 
       [...catalogMap.values()].forEach((pkg) => {
-        const { author, name } = pkg;
-
-        const [scope, packageName] = name.split("/");
-
-        if (packageName) {
-          pkg.scope = scope;
-          pkg.packageName = packageName;
-        } else {
-          pkg.packageName = scope;
-        }
-
-        if (typeof author === "string") {
-          pkg.authorName = author;
-        } else {
-          if (author?.name) {
-            pkg.authorName = author.name;
-          }
-
-          if (author?.email) {
-            pkg.authorEmail = author.email;
-          }
-        }
-
         this.add(pkg);
       });
     });

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -76,7 +76,7 @@ export const SearchBar: FunctionComponent<SearchBarProps> = ({
   const catalog = useCatalog();
 
   const roundedCatalogLength =
-    Math.round((catalog?.data?.packages?.length ?? 0) / 100) * 100;
+    Math.floor((catalog?.data?.packages?.length ?? 0) / 100) * 100;
 
   const placeholder = `Search ${
     roundedCatalogLength > 0 ? `${roundedCatalogLength}+ ` : ""

--- a/src/views/SearchRedesign/SearchResults.tsx
+++ b/src/views/SearchRedesign/SearchResults.tsx
@@ -95,7 +95,10 @@ export const SearchResults: FunctionComponent = () => {
         <SearchBar
           bg="white"
           onChange={searchAPI.onQueryChange}
-          onSubmit={searchAPI.onSubmit}
+          onSubmit={(e) => {
+            searchAPI.setSort(undefined);
+            searchAPI.onSubmit(e);
+          }}
           value={searchAPI.query}
         />
 


### PR DESCRIPTION
Fixes #666 

Adds tags to search indexing. Also updates the catalog estimate in the search placeholder to round down, and resets sorting to relevance when a user types a new input