### PR TITLE
fix: nav items broken for submodules

### DIFF
--- a/src/views/Package/PackageState.tsx
+++ b/src/views/Package/PackageState.tsx
@@ -122,8 +122,9 @@ export const PackageStateProvider: FunctionComponent = ({ children }) => {
       name,
       version,
       language,
+      submodule,
     });
-  }, [markdownResponse.data, name, scope, version, language]);
+  }, [markdownResponse.data, name, scope, version, language, submodule]);
 
   // Handle missing JSON for assembly
   if (assemblyResponse.error) {

--- a/src/views/Package/util.test.ts
+++ b/src/views/Package/util.test.ts
@@ -190,4 +190,20 @@ describe("parseMarkdownStructure", () => {
       },
     ]);
   });
+
+  it("adds a submodule query parameter if needed", () => {
+    const result = parseMarkdownStructure(MARKDOWN_INPUT, {
+      ...packageData,
+      submodule: "my_submodule",
+    });
+
+    // filter out items without a path and make sure some items have paths.
+    const items = result.menuItems.filter((i) => i.path);
+    expect(items.length).toBeGreaterThan(0);
+
+    // verify that all urls include a ?submodule query.
+    for (const item of items) {
+      expect(item.path?.includes("&submodule=my_submodule")).toBeTruthy();
+    }
+  });
 });

--- a/src/views/Package/util.ts
+++ b/src/views/Package/util.ts
@@ -117,7 +117,7 @@ export const parseMarkdownStructure = (
     language: Language;
     name: string;
     version: string;
-    submodule: string;
+    submodule?: string;
   }
 ): { readme: string; apiReference: Types; menuItems: MenuItem[] } => {
   const nameSegment = scope ? `${scope}/${name}` : `${name}`;

--- a/src/views/Package/util.ts
+++ b/src/views/Package/util.ts
@@ -111,11 +111,22 @@ export const parseMarkdownStructure = (
     language,
     name,
     version,
-  }: { scope?: string; language: Language; name: string; version: string }
+    submodule,
+  }: {
+    scope?: string;
+    language: Language;
+    name: string;
+    version: string;
+    submodule: string;
+  }
 ): { readme: string; apiReference: Types; menuItems: MenuItem[] } => {
   const nameSegment = scope ? `${scope}/${name}` : `${name}`;
   const basePath = `/packages/${nameSegment}/v/${version}`;
-  const langQuery = `?${QUERY_PARAMS.LANGUAGE}=${language}`;
+  let query = `?${QUERY_PARAMS.LANGUAGE}=${language}`;
+  if (submodule) {
+    query += `&submodule=${submodule}`;
+  }
+
   const separator =
     '# API Reference <span data-heading-title="API Reference" data-heading-id="api-reference"></span>';
 
@@ -136,7 +147,7 @@ export const parseMarkdownStructure = (
   // Add back api reference title for use as menu item
   const apiReferenceParsed = [separator.trim(), ...(apiReferenceSplit ?? [])];
 
-  const baseReadmePath = `${basePath}${langQuery}`;
+  const baseReadmePath = `${basePath}${query}`;
   const readmeMenuItems = [
     {
       level: 1,
@@ -165,7 +176,7 @@ export const parseMarkdownStructure = (
   let menuItems: MenuItem[] = [...readmeMenuItems];
   const types: Types = {};
 
-  const getApiPath = (id: string) => `${basePath}/api/${id}${langQuery}`;
+  const getApiPath = (id: string) => `${basePath}/api/${id}${query}`;
   let prevType: { id: string; title: string };
   let prevLevel: number;
 


### PR DESCRIPTION
Add a `submodule=` query parameter if navigation item is within a submodule.

Fixes #692

