### PR TITLE
fix: api ref nav behaves differently from readme

### DIFF
--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -46,7 +46,6 @@ export const PackageDocs: FunctionComponent = () => {
       target?.scrollIntoView(true);
     } else if (isApiPath(pathname)) {
       const target = document.getElementById(DOCS_ROOT_ID) as HTMLElement;
-      console.log(target);
       target?.scrollIntoView(true);
     } else {
       window.scrollTo(0, 0);

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -10,6 +10,7 @@ import { PackageTypeDocs } from "./PackageTypeDocs";
 // We want the nav to be sticky, but it should account for the sticky heading as well, which is 72px
 const TOP_OFFSET = "4.5rem";
 const DOCS_ROOT_ID = "apidocs_header";
+const API_URL_RESOURCE = "api";
 
 const SubmoduleSelector: FunctionComponent = () => {
   const {
@@ -30,7 +31,7 @@ const SubmoduleSelector: FunctionComponent = () => {
 
 const isApiPath = (path: string) => {
   const parts = path.split("/");
-  return parts[parts.length - 2] === "api";
+  return parts[parts.length - 2] === API_URL_RESOURCE;
 };
 
 export const PackageDocs: FunctionComponent = () => {
@@ -93,7 +94,7 @@ export const PackageDocs: FunctionComponent = () => {
           <Route exact path={path}>
             <PackageReadme />
           </Route>
-          <Route exact path={`${path}/api/:typeId`}>
+          <Route exact path={`${path}/${API_URL_RESOURCE}/:typeId`}>
             <PackageTypeDocs rootId={DOCS_ROOT_ID} />
           </Route>
         </Switch>

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -9,6 +9,7 @@ import { PackageTypeDocs } from "./PackageTypeDocs";
 
 // We want the nav to be sticky, but it should account for the sticky heading as well, which is 72px
 const TOP_OFFSET = "4.5rem";
+const DOCS_ROOT_ID = "apidocs_header";
 
 const SubmoduleSelector: FunctionComponent = () => {
   const {
@@ -26,14 +27,25 @@ const SubmoduleSelector: FunctionComponent = () => {
     </Flex>
   ) : null;
 };
+
+const isApiPath = (path: string) => {
+  const parts = path.split("/");
+  return parts[parts.length - 2] === "api";
+};
+
 export const PackageDocs: FunctionComponent = () => {
   const { path } = useRouteMatch();
   const { menuItems } = usePackageState();
 
-  const { hash } = useLocation();
+  const { hash, pathname } = useLocation();
+
   useEffect(() => {
     if (hash) {
       const target = document.querySelector(`${hash}`) as HTMLElement;
+      target?.scrollIntoView(true);
+    } else if (isApiPath(pathname)) {
+      const target = document.getElementById(DOCS_ROOT_ID) as HTMLElement;
+      console.log(target);
       target?.scrollIntoView(true);
     } else {
       window.scrollTo(0, 0);
@@ -82,7 +94,7 @@ export const PackageDocs: FunctionComponent = () => {
             <PackageReadme />
           </Route>
           <Route exact path={`${path}/api/:typeId`}>
-            <PackageTypeDocs />
+            <PackageTypeDocs rootId={DOCS_ROOT_ID} />
           </Route>
         </Switch>
       </Box>

--- a/src/views/Package/PackageTypeDocs.tsx
+++ b/src/views/Package/PackageTypeDocs.tsx
@@ -1,6 +1,6 @@
 import { Heading } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
-import { useParams } from "react-router-dom";
+import { NavLink, useLocation, useParams } from "react-router-dom";
 import { Markdown } from "../../components/Markdown";
 import { PackageDocsError } from "./PackageDocsError";
 import { usePackageState } from "./PackageState";
@@ -15,7 +15,10 @@ const usePackageTypeDocs = () => {
   return;
 };
 
-export const PackageTypeDocs: FunctionComponent = () => {
+export const PackageTypeDocs: FunctionComponent<{ rootId: string }> = ({
+  rootId,
+}) => {
+  const { pathname, hash, search } = useLocation();
   const {
     isLoadingDocs,
     assembly: { data: assembly },
@@ -28,11 +31,13 @@ export const PackageTypeDocs: FunctionComponent = () => {
     return <PackageDocsError />;
   }
   const { title, content } = docs;
-
+  const url = `${pathname}${search}#${hash}`;
   return (
     <>
       <Heading as="h2" p={8} size="2xl">
-        {title}
+        <NavLink id={rootId} to={url}>
+          {title}
+        </NavLink>
       </Heading>
       <Markdown repository={assembly.repository}>{content}</Markdown>
     </>


### PR DESCRIPTION
When clicking on a nav item from readme, it will scroll the view so that this item is at the top (which implies that the package header is not displayed). When clicking on an API reference item, it will scroll to 0 (which implies that package header is displayed). This results in an inconsistent exprience.

To solve this, we added an `id` to the API doc header and scroll it to view if the URL is an `/api` URL.

Additionally, we also made this header a link, so that it will behave like README headers (which are links to themselves).