### PR TITLE
feat: readme ui tweaks

### DIFF
--- a/src/views/Package/util.test.ts
+++ b/src/views/Package/util.test.ts
@@ -115,25 +115,17 @@ describe("parseMarkdownStructure", () => {
         path: baseHashPath,
         children: [
           {
-            level: 1,
-            id: "title-1",
-            title: "Title 1",
-            path: `${baseHashPath}#title-1`,
+            level: 2,
+            id: "title-2",
+            title: "Title 2",
+            path: `${baseHashPath}#title-2`,
             children: [
               {
-                level: 2,
-                id: "title-2",
-                title: "Title 2",
-                path: `${baseHashPath}#title-2`,
-                children: [
-                  {
-                    level: 3,
-                    id: "title-3",
-                    title: "Title 3",
-                    path: `${baseHashPath}#title-3`,
-                    children: [],
-                  },
-                ],
+                level: 3,
+                id: "title-3",
+                title: "Title 3",
+                path: `${baseHashPath}#title-3`,
+                children: [],
               },
             ],
           },


### PR DESCRIPTION
1. Remove trailing ":" or "." from navigation bar titles.
2. If the README nav tree has a single root, collapse it into the "Readme" item to reduce redundant nesting.

Before:

![Screen Shot 2021-11-18 at 14 45 58](https://user-images.githubusercontent.com/598796/142417861-ed0e3328-ba49-42c0-9992-4516da001577.png)



After:
![Screen Shot 2021-11-18 at 14 46 52](https://user-images.githubusercontent.com/598796/142417998-c73501e7-75ba-485f-a510-fbecb17d75ff.png)


