### PR TITLE
chore: improve assembly type safety

### DIFF
--- a/src/api/package/assembly.ts
+++ b/src/api/package/assembly.ts
@@ -27,8 +27,5 @@ export const fetchAssembly = async (
       `Failed fetching assembly for ${assemblyPath}: ${response.statusText}`
     );
   }
-  const json = (await response.json()) as spec.Assembly;
-  delete json.types;
-  delete json.readme;
-  return json;
+  return response.json();
 };

--- a/src/api/package/assembly.ts
+++ b/src/api/package/assembly.ts
@@ -2,6 +2,14 @@ import * as spec from "@jsii/spec";
 import { API_PATHS } from "../../constants/url";
 import { getAssetsPath } from "./util";
 
+// These fields are removed from assembly.json during processing to save space,
+// and we don't need them here in the client.
+// See https://github.com/cdklabs/construct-hub/pull/567
+export type SlimAssembly = Omit<
+  spec.Assembly,
+  "types" | "readme" | "dependencyClosure"
+>;
+
 /**
  * Fetch assembly of a specific package from the backend.
  */
@@ -9,7 +17,7 @@ export const fetchAssembly = async (
   name: string,
   version: string,
   scope?: string
-): Promise<spec.Assembly> => {
+): Promise<SlimAssembly> => {
   const assemblyPath = `${getAssetsPath(name, version, scope)}${
     API_PATHS.ASSEMBLY_SUFFIX
   }`;
@@ -19,5 +27,8 @@ export const fetchAssembly = async (
       `Failed fetching assembly for ${assemblyPath}: ${response.statusText}`
     );
   }
-  return response.json();
+  const json = (await response.json()) as spec.Assembly;
+  delete json.types;
+  delete json.readme;
+  return json;
 };


### PR DESCRIPTION
Since backend now trims down some fields in `assembly.json`, it would be wise to reflect that in the downstream types so that client code won't accidentally use these fields in the future.

