### PR TITLE
feat: minimal home page

### DIFF
--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -110,7 +110,7 @@ describe("Home (Redesign / WIP)", () => {
 
   describe("Featured Section", () => {
     it("has a header and 4 cards", () => {
-      cy.visit("/");
+      cy.visit("/?ff-fullSite");
       cy.getByDataTest(home.featuredContainer)
         .should("be.visible")
         .within(() => {
@@ -127,7 +127,7 @@ describe("Home (Redesign / WIP)", () => {
     });
 
     it("shows recently updated if no content is featured", () => {
-      cy.visitWithConfig("/", {
+      cy.visitWithConfig("/?ff-fullSite", {
         featuredPackages: undefined,
       });
 
@@ -171,7 +171,7 @@ describe("Home (Redesign / WIP)", () => {
         ],
       };
 
-      cy.visitWithConfig("/", {
+      cy.visitWithConfig("/?ff-fullSite", {
         featuredPackages,
       });
 
@@ -193,6 +193,8 @@ describe("Home (Redesign / WIP)", () => {
 
   describe("CDK Type Section", () => {
     it("has heading, description, 3 tabs, 4 cards, and a see all button", () => {
+      cy.visit("/?ff-fullSite");
+
       cy.getByDataTest(home.cdkTypeSection).within(() => {
         cy.getByDataTest(home.cdkTypeSectionHeading).should("be.visible");
         cy.getByDataTest(home.cdkTypeSectionDescription).should("be.visible");
@@ -213,6 +215,8 @@ describe("Home (Redesign / WIP)", () => {
     });
 
     it("reveals different cards for respective tabs", () => {
+      cy.visit("/?ff-fullSite");
+
       cy.getByDataTest(home.cdkTypeSection).within(() => {
         cy.getByDataTest(home.cdkTypeTab).each((tab, index) => {
           const tabName: string = ["Community", "AWS", "HashiCorp"][index];
@@ -230,7 +234,10 @@ describe("Home (Redesign / WIP)", () => {
         });
       });
     });
+
     it("has a see all button which opens the correct search url", () => {
+      cy.visit("/?ff-fullSite");
+
       const testSeeAll = (tagName: string, index: number) => {
         cy.getByDataTest(home.cdkTypeTab).eq(index).click();
 

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -77,7 +77,10 @@ export interface FeaturedPackagesDetail {
   readonly comment?: string;
 }
 
-export interface FeatureFlags {}
+export interface FeatureFlags {
+  fullSite?: boolean;
+  searchRedesign?: boolean;
+}
 
 export interface Config {
   featureFlags?: FeatureFlags;

--- a/src/components/DevPreviewBanner/DevPreviewBanner.tsx
+++ b/src/components/DevPreviewBanner/DevPreviewBanner.tsx
@@ -8,18 +8,25 @@ import {
 } from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 import { CONSTRUCT_HUB_REPO_URL } from "../../constants/links";
+import { useConfig } from "../../contexts/Config";
 import { Card } from "../Card";
 import { ExternalLink } from "../ExternalLink";
 
 const STORAGE_KEY = "showing-dev-preview-banner";
 
 export const DevPreviewBanner: FunctionComponent = () => {
+  const { data: config } = useConfig();
   const { isOpen, onClose } = useDisclosure({
     defaultIsOpen: JSON.parse(
       window.sessionStorage.getItem(STORAGE_KEY) ?? "true"
     ),
     onClose: () => window.sessionStorage.setItem(STORAGE_KEY, "false"),
   });
+
+  // we keep the box because otherwise layout breaks
+  if (config?.featureFlags?.fullSite) {
+    return <Box h="max-content" />;
+  }
 
   return (
     <Box h="max-content">

--- a/src/contexts/Config/Config.tsx
+++ b/src/contexts/Config/Config.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useState,
 } from "react";
+import { useLocation } from "react-router-dom";
 import { fetchConfig, Config } from "../../api/config";
 import { useRequest, UseRequestResponse } from "../../hooks/useRequest";
 
@@ -19,6 +20,7 @@ const LOCAL_CONFIG = "construct-hub-config";
 export const useConfig = () => useContext(ConfigContext);
 
 export const ConfigProvider: FunctionComponent = ({ children }) => {
+  const { search } = useLocation();
   const [configData, setConfigData] = useState<Config | undefined>(() => {
     try {
       const stored = localStorage.getItem(LOCAL_CONFIG);
@@ -48,8 +50,24 @@ export const ConfigProvider: FunctionComponent = ({ children }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const config = configData ?? {};
+
+  // allow overriding feature flags using query params the query param name is
+  // `ff-<flagName>`, for example,
+  // `https://constructs.dev?ff-generalAvailability`.
+  const params = new URLSearchParams(search);
+  const flags: any = config.featureFlags ?? {};
+  config.featureFlags = flags;
+
+  for (const key of params.keys()) {
+    if (key.startsWith("ff-")) {
+      const flagName = key.slice(3);
+      flags[flagName] = true;
+    }
+  }
+
   return (
-    <ConfigContext.Provider value={{ ...configResponse, data: configData }}>
+    <ConfigContext.Provider value={{ ...configResponse, data: config }}>
       {children}
     </ConfigContext.Provider>
   );

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -2,6 +2,7 @@ import { Flex } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
 import { DevPreviewBanner } from "../../components/DevPreviewBanner";
 import { Page } from "../../components/Page";
+import { useConfig } from "../../contexts/Config";
 import { Categories } from "./Categories";
 import { CDKTypeTabs } from "./CDKTypeTabs";
 import { Featured } from "./Featured";
@@ -11,6 +12,8 @@ import { Info } from "./Info";
 import testIds from "./testIds";
 
 export const Home: FunctionComponent = () => {
+  const { data: config } = useConfig();
+  const fullSite = config?.featureFlags?.fullSite ?? false;
   return (
     <Page
       meta={{
@@ -32,11 +35,11 @@ export const Home: FunctionComponent = () => {
 
         <Info />
 
-        <Categories />
+        {fullSite ? <Categories /> : <></>}
 
-        <CDKTypeTabs />
+        {fullSite ? <CDKTypeTabs /> : <></>}
 
-        <Featured />
+        {fullSite ? <Featured /> : <></>}
       </GradientContainer>
     </Page>
   );


### PR DESCRIPTION
Remove a few sections from the home page for and introduce a feature flag `fullSite` which offers the full experience.

Also, now feature flags can be enabled using query params (e.g `?ff-fullSite`).

