### PR TITLE
chore: update home page categories, fixes tag click bug

### DIFF
--- a/src/components/PackageCard/Tags.tsx
+++ b/src/components/PackageCard/Tags.tsx
@@ -16,13 +16,11 @@ export const Tags: FunctionComponent = () => {
 
   return (
     <>
-      {tags
-        .slice(0, 10)
-        .map(({ id, isKeyword, keyword: { label, color } = {} }) => (
-          <PackageTag isKeyword={isKeyword} key={id} value={id} variant={color}>
-            {label}
-          </PackageTag>
-        ))}
+      {tags.slice(0, 10).map(({ id, keyword: { label, color } = {} }) => (
+        <PackageTag key={id} value={id} variant={color}>
+          {label}
+        </PackageTag>
+      ))}
     </>
   );
 };

--- a/src/components/PackageTag/PackageTag.tsx
+++ b/src/components/PackageTag/PackageTag.tsx
@@ -4,7 +4,6 @@ import { getSearchPath } from "../../util/url";
 import { NavLink } from "../NavLink";
 
 export interface PackageTagProps extends TagProps {
-  isKeyword?: boolean;
   value: string;
   label?: string;
   zIndex?: string | number;
@@ -12,18 +11,15 @@ export interface PackageTagProps extends TagProps {
 
 export const PackageTag: FunctionComponent<PackageTagProps> = ({
   children,
-  isKeyword = false,
   value,
   label = value,
   zIndex,
   ...tagProps
 }) => {
-  const prop = isKeyword ? "keywords" : "tags";
-
   return (
     <NavLink
       aria-label={`Tag: ${label}`}
-      to={getSearchPath({ [prop]: [value] })}
+      to={getSearchPath({ keywords: [value] })}
       zIndex={zIndex}
     >
       <Tag

--- a/src/util/package.test.ts
+++ b/src/util/package.test.ts
@@ -65,14 +65,12 @@ describe("mapPackageKeywords", () => {
       Array [
         Object {
           "id": "Keyword 1",
-          "isKeyword": true,
           "keyword": Object {
             "label": "Keyword 1",
           },
         },
         Object {
           "id": "Keyword 2",
-          "isKeyword": true,
           "keyword": Object {
             "label": "Keyword 2",
           },
@@ -105,16 +103,14 @@ describe("mapPackageTags", () => {
     expect(mapPackageTags(PACKAGE_TAGS)).toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "tag1",
-          "isKeyword": false,
+          "id": "Tag 1",
           "keyword": Object {
             "color": "red",
             "label": "Tag 1",
           },
         },
         Object {
-          "id": "tag2",
-          "isKeyword": false,
+          "id": "Tag 2",
           "keyword": Object {
             "label": "Tag 2",
           },
@@ -150,30 +146,26 @@ describe("tagObjectsFrom", () => {
     ).toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "tag1",
-          "isKeyword": false,
+          "id": "Tag 1",
           "keyword": Object {
             "color": "red",
             "label": "Tag 1",
           },
         },
         Object {
-          "id": "tag2",
-          "isKeyword": false,
+          "id": "Tag 2",
           "keyword": Object {
             "label": "Tag 2",
           },
         },
         Object {
           "id": "Keyword 1",
-          "isKeyword": true,
           "keyword": Object {
             "label": "Keyword 1",
           },
         },
         Object {
           "id": "Keyword 2",
-          "isKeyword": true,
           "keyword": Object {
             "label": "Keyword 2",
           },
@@ -187,16 +179,14 @@ describe("tagObjectsFrom", () => {
       .toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "tag1",
-          "isKeyword": false,
+          "id": "Tag 1",
           "keyword": Object {
             "color": "red",
             "label": "Tag 1",
           },
         },
         Object {
-          "id": "tag2",
-          "isKeyword": false,
+          "id": "Tag 2",
           "keyword": Object {
             "label": "Tag 2",
           },
@@ -210,14 +200,12 @@ describe("tagObjectsFrom", () => {
       Array [
         Object {
           "id": "Keyword 1",
-          "isKeyword": true,
           "keyword": Object {
             "label": "Keyword 1",
           },
         },
         Object {
           "id": "Keyword 2",
-          "isKeyword": true,
           "keyword": Object {
             "label": "Keyword 2",
           },
@@ -232,8 +220,7 @@ describe("tagObjectsFrom", () => {
     ).toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "tag1",
-          "isKeyword": false,
+          "id": "Tag 1",
           "keyword": Object {
             "color": "red",
             "label": "Tag 1",
@@ -241,7 +228,6 @@ describe("tagObjectsFrom", () => {
         },
         Object {
           "id": "Keyword 1",
-          "isKeyword": true,
           "keyword": Object {
             "label": "Keyword 1",
           },
@@ -255,8 +241,7 @@ describe("tagObjectsFrom", () => {
       .toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "tag1",
-          "isKeyword": false,
+          "id": "Tag 1",
           "keyword": Object {
             "color": "red",
             "label": "Tag 1",

--- a/src/util/package.ts
+++ b/src/util/package.ts
@@ -1,9 +1,7 @@
 import { PackageHighlight, PackageTagConfig } from "../api/config";
 import { KEYWORD_IGNORE_LIST } from "../constants/keywords";
 
-export interface TagObject extends PackageTagConfig {
-  isKeyword?: boolean;
-}
+export interface TagObject extends PackageTagConfig {}
 
 /**
  * Reduces package tags to only return highlight tags
@@ -35,7 +33,7 @@ export const mapPackageTags = (
     })
     .map((tag) => ({
       ...tag,
-      isKeyword: false,
+      id: tag.keyword?.label!,
     }));
 };
 
@@ -49,7 +47,6 @@ export const mapPackageKeywords = (keywords?: string[]): TagObject[] => {
     .filter((label) => Boolean(label) && !KEYWORD_IGNORE_LIST.has(label))
     .map((label) => ({
       id: label,
-      isKeyword: true,
       keyword: {
         label,
       },

--- a/src/views/Home/Categories.tsx
+++ b/src/views/Home/Categories.tsx
@@ -11,14 +11,24 @@ import testIds from "./testIds";
  * Categories used if config does not have specific categories
  */
 const DEFAULT_CATEGORIES: Category[] = [
-  { title: "Monitoring", url: getSearchPath({ query: "monitoring" }) },
-  { title: "Kubernetes", url: getSearchPath({ query: "kubernetes" }) },
-  { title: "Serverless", url: getSearchPath({ query: "serverless" }) },
-  { title: "Databases", url: getSearchPath({ query: "databases" }) },
-  { title: "Utilities", url: getSearchPath({ query: "utilities" }) },
-  { title: "Deployment", url: getSearchPath({ query: "deployment" }) },
-  { title: "Websites", url: getSearchPath({ query: "web" }) },
-  { title: "Security", url: getSearchPath({ query: "security" }) },
+  { title: "Monitoring", url: getSearchPath({ keywords: ["monitoring"] }) },
+  { title: "Containers", url: getSearchPath({ keywords: ["containers"] }) },
+  { title: "Serverless", url: getSearchPath({ keywords: ["serverless"] }) },
+  { title: "Databases", url: getSearchPath({ keywords: ["databases"] }) },
+  { title: "Utilities", url: getSearchPath({ keywords: ["utilities"] }) },
+  { title: "Deployment", url: getSearchPath({ keywords: ["deployment"] }) },
+  { title: "Websites", url: getSearchPath({ keywords: ["web"] }) },
+  { title: "Security", url: getSearchPath({ keywords: ["security"] }) },
+  { title: "Compliance", url: getSearchPath({ keywords: ["compliance"] }) },
+  { title: "Network", url: getSearchPath({ keywords: ["network"] }) },
+  {
+    title: "Artificial Intelligence (AI)",
+    url: getSearchPath({ keywords: ["artificial intelligence (ai)"] }),
+  },
+  {
+    title: "Cloud Services Integrations",
+    url: getSearchPath({ keywords: ["cloud services integrations"] }),
+  },
 ];
 
 export const Categories: FunctionComponent = () => {

--- a/src/views/Package/PackageHeader/Heading.tsx
+++ b/src/views/Package/PackageHeader/Heading.tsx
@@ -71,8 +71,8 @@ export const Heading: FunctionComponent<HeadingProps> = ({
         wrap="wrap"
       >
         <CDKTypeBadge {...cdkTypeProps} />
-        {tags.map(({ id, isKeyword, keyword: { label, color } = {} }) => (
-          <PackageTag isKeyword={isKeyword} key={id} value={id} variant={color}>
+        {tags.map(({ id, keyword: { label, color } = {} }) => (
+          <PackageTag key={id} value={id} variant={color}>
             {label}
           </PackageTag>
         ))}

--- a/src/views/SearchRedesign/KeywordsFilter.tsx
+++ b/src/views/SearchRedesign/KeywordsFilter.tsx
@@ -21,6 +21,7 @@ export const KeywordsFilter: FunctionComponent = () => {
       .sort(([, count1], [, count2]) => {
         return count1 < count2 ? 1 : -1;
       })
+      .filter(([keyword]) => !keywords.includes(keyword))
       .map(([keyword]) => ({
         display: keyword,
         value: keyword,


### PR DESCRIPTION
Fixes #718 

Updates the home page categories. Also fixes a bug where clicking on tags on cards would apply a filter with no way to remove the filter. 