### PR TITLE
fix: search icon is not clickable

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -7,6 +7,7 @@ import {
   InputRightElement,
   useDisclosure,
   Button,
+  IconButton,
 } from "@chakra-ui/react";
 import {
   useContext,
@@ -161,7 +162,13 @@ export const SearchBar: FunctionComponent<SearchBarProps> = ({
             </InputRightElement>
           ) : (
             <InputRightElement>
-              <SearchIcon data-testid={testIds.searchIcon} />
+              <IconButton
+                aria-label="Run search"
+                data-testid={testIds.searchIcon}
+                icon={<SearchIcon />}
+                type="submit"
+                variant="ghost"
+              ></IconButton>
             </InputRightElement>
           )}
         </InputGroup>


### PR DESCRIPTION
Fixes the search icon on the search results page and on the header of package pages to be clickable.