### PR TITLE
fix: visiting /api renders empty page

### DIFF
--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -1,6 +1,12 @@
 import { Box, Flex, Grid } from "@chakra-ui/react";
 import { FunctionComponent, useEffect } from "react";
-import { Route, Switch, useRouteMatch, useLocation } from "react-router-dom";
+import {
+  Route,
+  Switch,
+  useRouteMatch,
+  useLocation,
+  Redirect,
+} from "react-router-dom";
 import { NavTree } from "../../components/NavTree";
 import { ChooseSubmodule } from "./ChooseSubmodule";
 import { PackageReadme } from "./PackageReadme";
@@ -38,7 +44,7 @@ export const PackageDocs: FunctionComponent = () => {
   const { path } = useRouteMatch();
   const { menuItems } = usePackageState();
 
-  const { hash, pathname } = useLocation();
+  const { hash, pathname, search } = useLocation();
 
   useEffect(() => {
     if (hash) {
@@ -90,6 +96,11 @@ export const PackageDocs: FunctionComponent = () => {
         }}
       >
         <Switch>
+          <Redirect
+            exact
+            from={`${path}/${API_URL_RESOURCE}`}
+            to={{ pathname: path, search }}
+          />
           <Route exact path={path}>
             <PackageReadme />
           </Route>


### PR DESCRIPTION
Currently, visiting a page like https://constructs.dev/packages/@aws-cdk/aws-s3/v/1.132.0/api displays a page with no content (fortunately there is still a sidebar you can navigate to).

Since we do not have anything to show for this URL right now, we should just redirect the user to the root docs page.