### PR TITLE
fix: mobile filters dont account for address bar in calculated height

### DIFF
--- a/src/views/SearchRedesign/SortAndFilterDrawer.tsx
+++ b/src/views/SearchRedesign/SortAndFilterDrawer.tsx
@@ -36,8 +36,8 @@ export const SortAndFilterDrawer: FunctionComponent = () => {
       <Drawer {...drawer} placement="bottom">
         <DrawerOverlay />
 
-        <DrawerContent color="blue.800">
-          <DrawerHeader>Sorting and Filters</DrawerHeader>
+        <DrawerContent color="blue.800" maxH="full">
+          <DrawerHeader borderBottom="base">Sorting and Filters</DrawerHeader>
 
           <DrawerCloseButton />
 


### PR DESCRIPTION
Fixes #720 

I think every web developer has had to fix this issue in some way before. Mobile browsers don't include the address bar height as part of their `vh` calculation (for justifiable reasons) which can cause some annoying issues for applications that use `vh` units. Fortunately, we can solve this issue by setting a max height of 100% on the filter drawer that will prevent the close button from being hidden under the address bar