### PR TITLE
chore: change construct-hub trigger to `dev`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - name: Trigger upgrade workflow
         run: gh api -X POST
-          /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches
-          --field ref="main"
+          /repos/cdklabs/construct-hub/actions/workflows/upgrade-dev.yml/dispatches
+          --field ref="dev"
         env:
           GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -265,7 +265,7 @@ project.release.addJobs({
     steps: [
       {
         name: "Trigger upgrade workflow",
-        run: 'gh api -X POST /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches --field ref="main"',
+        run: 'gh api -X POST /repos/cdklabs/construct-hub/actions/workflows/upgrade-dev.yml/dispatches --field ref="dev"',
         env: {
           GITHUB_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
         },


### PR DESCRIPTION
Cherry-pick of https://github.com/cdklabs/construct-hub-webapp/pull/753 to `main`