### PR TITLE
chore: trigger ch main upgrade on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - name: Trigger upgrade workflow
         run: gh api -X POST
-          /repos/cdklabs/construct-hub/actions/workflows/upgrade-dev.yml/dispatches
-          --field ref="dev"
+          /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches
+          --field ref="main"
         env:
           GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -267,7 +267,7 @@ project.release.addJobs({
     steps: [
       {
         name: "Trigger upgrade workflow",
-        run: 'gh api -X POST /repos/cdklabs/construct-hub/actions/workflows/upgrade-dev.yml/dispatches --field ref="dev"',
+        run: 'gh api -X POST /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches --field ref="main"',
         env: {
           GITHUB_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
         },


### PR DESCRIPTION
Now that CH `main` upgrade workflow [only upgrades the webapp](https://github.com/cdklabs/construct-hub/pull/607), its ok for a webapp release to trigger it.