### PR TITLE
chore: trigger ch main on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - name: Trigger upgrade workflow
         run: gh api -X POST
-          /repos/cdklabs/construct-hub/actions/workflows/upgrade-dev.yml/dispatches
-          --field ref="dev"
+          /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches
+          --field ref="main"
         env:
           GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -265,7 +265,7 @@ project.release.addJobs({
     steps: [
       {
         name: "Trigger upgrade workflow",
-        run: 'gh api -X POST /repos/cdklabs/construct-hub/actions/workflows/upgrade-dev.yml/dispatches --field ref="dev"',
+        run: 'gh api -X POST /repos/cdklabs/construct-hub/actions/workflows/upgrade-main.yml/dispatches --field ref="main"',
         env: {
           GITHUB_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
         },

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This project is licensed under the Apache-2.0 License.
+


### PR DESCRIPTION
Cherry-pick https://github.com/cdklabs/construct-hub-webapp/pull/757 to `main`