### PR TITLE
fix(shortbread): cookie consent not showing on Safari, Chrome (#776)

### DIFF
--- a/src/components/CDKType/CDKType.tsx
+++ b/src/components/CDKType/CDKType.tsx
@@ -61,7 +61,7 @@ const badgeColorMap = {
 };
 
 export const CDKTypeBadge = forwardRef<CDKTypeBadgeProps, "span">(
-  ({ name, majorVersion, ...badgeProps }) => {
+  ({ name, majorVersion, ...badgeProps }, ref) => {
     if (!name) return null;
 
     const bg = badgeColorMap[name];
@@ -76,6 +76,7 @@ export const CDKTypeBadge = forwardRef<CDKTypeBadgeProps, "span">(
         h="1.5rem"
         maxW="5.5rem"
         px={1.5}
+        ref={ref}
         textTransform="none"
         {...badgeProps}
       >

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -26,14 +26,23 @@ export const Page: FunctionComponent<PageProps> = ({
   const { suffix = true, title, description } = meta;
   const formattedTitle = suffix ? `${title} - Construct Hub` : title;
 
+  // Should be the same as the "real" CSP, except most things come from HTTP
+  // instead of HTTPS (because it is protocol-relative, and the dev site is
+  // served over plain HTTP).
+  const csp = [
+    "default-src 'self' 'unsafe-inline' http://*.awsstatic.com;",
+    "connect-src 'self' https://*.shortbread.aws.dev http://*.shortbread.aws.dev http://a0.awsstatic.com/ http://amazonwebservices.d2.sc.omtrdc.net http://aws.demdex.net http://dpm.demdex.net http://cm.everesttech.net;",
+    "frame-src http://aws.demdex.net http://dpm.demdex.net;",
+    "img-src 'self' https://* http://a0.awsstatic.com/ http://amazonwebservices.d2.sc.omtrdc.net http://aws.demdex.net http://dpm.demdex.net http://cm.everesttech.net;",
+    "object-src 'none';",
+    "style-src 'self' 'unsafe-inline';",
+  ].join(" ");
+
   return (
     <>
       <Helmet>
         {process.env.NODE_ENV === "development" && (
-          <meta
-            content="default-src 'self' 'unsafe-inline' https://*.awsstatic.com https://amazonwebservices.d2.sc.omtrdc.net; connect-src 'self' https://*.shortbread.aws.dev ws://localhost:3000 https://*.awsstatic.com https://amazonwebservices.d2.sc.omtrdc.net; frame-src 'none'; img-src 'self' https://* http://*.omtrdc.net; object-src 'none'; style-src 'self' 'unsafe-inline';"
-            httpEquiv="Content-Security-Policy"
-          />
+          <meta content={csp} httpEquiv="Content-Security-Policy" />
         )}
 
         <meta content="width=device-width, initial-scale=1" name="viewport" />

--- a/src/lib/shortbread/shortbread.ts
+++ b/src/lib/shortbread/shortbread.ts
@@ -40,26 +40,15 @@ let instance: Shortbread | undefined;
  * Call to initialize the shortbread instance. Must be called before all other methods
  */
 export const initialize = async () => {
-  return new Promise<void>((resolve, reject) => {
-    // Wait until page has loaded first
-    window.addEventListener("load", async () => {
-      try {
-        const options: ShortbreadOptions = {
-          domain: window.location.hostname,
-          language: navigator.language,
-          __storeWriter: getLocalStoreWriter(),
-        };
+  const options: ShortbreadOptions = {
+    domain: window.location.hostname,
+    language: navigator.language,
+    __storeWriter: getLocalStoreWriter(),
+  };
 
-        // Import the shortbread source
-        const { AWSCShortbread } = await import("./source");
-        instance = AWSCShortbread(options);
-
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-  });
+  // Import the shortbread source
+  const { AWSCShortbread } = await import("./source");
+  instance = AWSCShortbread(options);
 };
 
 // Shortbread wrappers


### PR DESCRIPTION

The ShortBread initializatio code is registered in a `window.load` event
handler, however it appears that event has already fired in WebKit-like
browsers when the event handler is added.

Just initialize ShortBread in-band instead, so it always shows.

Additionally - adjusted to dev-mode CSP to match the production site's
with the required adjustments (dev-mode is served over HTTP, and so most
of the sources are also HTTP instead of HTTPS like on production).

Also, fixed a React warning pertaining to a `forwardRef` use.
