### PR TITLE
fix: adds focus outlines to usecase buttons and search bar

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -133,6 +133,8 @@ export const SearchBar: FunctionComponent<SearchBarProps> = ({
             _focus={{
               boxShadow: "base",
               borderColor: "inherit", // To avoid taking @chakra's border color on focus
+              outlineColor: "blue.500",
+              outlineOffset: 0,
             }}
             bg="white"
             boxShadow={disclosure.isOpen ? "base" : "none"}
@@ -140,6 +142,7 @@ export const SearchBar: FunctionComponent<SearchBarProps> = ({
             onChange={onChange ?? searchAPI.onQueryChange}
             onFocus={disclosure.onOpen}
             placeholder={placeholder}
+            pr={hasButton ? "9rem" : undefined}
             ref={inputRef}
             value={value ?? searchAPI.query}
             {...inputProps}
@@ -148,15 +151,17 @@ export const SearchBar: FunctionComponent<SearchBarProps> = ({
           {hasButton ? (
             <InputRightElement
               display={{ base: "none", md: "initial" }}
-              w="9rem"
+              w="auto"
             >
               <Button
                 borderLeftRadius="0"
                 colorScheme="blue"
                 data-testid={testIds.searchButton}
+                fontSize="0.875rem"
                 type="submit"
+                w="9rem"
               >
-                Find Constructs
+                Find constructs
               </Button>
             </InputRightElement>
           ) : (

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -130,15 +130,10 @@ export const SearchBar: FunctionComponent<SearchBarProps> = ({
           )}
 
           <Input
-            _focus={{
-              boxShadow: "base",
-              borderColor: "inherit", // To avoid taking @chakra's border color on focus
-              outlineColor: "blue.500",
-              outlineOffset: 0,
-            }}
             bg="white"
             boxShadow={disclosure.isOpen ? "base" : "none"}
             data-testid={testIds.input}
+            focusBorderColor="blue.500"
             onChange={onChange ?? searchAPI.onQueryChange}
             onFocus={disclosure.onOpen}
             placeholder={placeholder}

--- a/src/views/Home/Categories.tsx
+++ b/src/views/Home/Categories.tsx
@@ -1,4 +1,12 @@
-import { Flex, Heading, Text, Button, Wrap, WrapItem } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  Heading,
+  Text,
+  Button,
+  Wrap,
+  WrapItem,
+} from "@chakra-ui/react";
 import type { FunctionComponent } from "react";
 import { Category } from "../../api/config";
 import { NavLink } from "../../components/NavLink";
@@ -67,17 +75,18 @@ export const Categories: FunctionComponent = () => {
       <Wrap>
         {categories.map((category) => (
           <WrapItem key={category.title}>
-            <Button
-              _hover={{ backgroundColor: "white" }}
-              as={NavLink}
-              color="blue.800"
-              colorScheme="gray"
-              size="md"
-              style={{ boxShadow: "0px 4px 4px rgba(73, 73, 73, 0.63)" }}
-              to={category.url}
-            >
-              {category.title}
-            </Button>
+            <NavLink to={category.url}>
+              <Button
+                _hover={{ backgroundColor: "white" }}
+                as={Box}
+                boxShadow="0px 4px 4px rgba(73, 73, 73, 0.63)"
+                color="blue.800"
+                colorScheme="gray"
+                size="md"
+              >
+                {category.title}
+              </Button>
+            </NavLink>
           </WrapItem>
         ))}
       </Wrap>


### PR DESCRIPTION
Fixes #796 

Adds outlines to use case buttons and search bar

<img width="422" alt="Screen Shot 2021-11-30 at 2 11 12 PM" src="https://user-images.githubusercontent.com/8749859/144136386-03962440-d176-4937-97b0-72b00bb422e0.png">
<img width="337" alt="Screen Shot 2021-11-30 at 10 51 44 AM" src="https://user-images.githubusercontent.com/8749859/144136393-63be7d37-ec53-4697-a322-dff3e875d558.png">
