### PR TITLE
fix: overflow on code blocks for safari

### DIFF
--- a/src/components/Code/MultiLineRenderer.tsx
+++ b/src/components/Code/MultiLineRenderer.tsx
@@ -24,7 +24,13 @@ export const MultiLineRenderer: FunctionComponent<RendererProps> = ({
       {tokens.map((line, i) => (
         <div key={i} {...getLineProps({ line, key: i })}>
           {line.map((token, key) => (
-            <span key={key} {...getTokenProps({ token, key })} />
+            <Box
+              as="span"
+              key={key}
+              // wordWrap is not supported as a style prop for some reason
+              sx={{ wordWrap: "normal" }}
+              {...getTokenProps({ token, key })}
+            />
           ))}
         </div>
       ))}


### PR DESCRIPTION
Fixes #746 

<img width="597" alt="Screen Shot 2021-12-01 at 9 12 52 AM" src="https://user-images.githubusercontent.com/8749859/144281460-ee6599c1-d03d-4bc0-a405-7ba43a5cef48.png">
