### PR TITLE
fix: support nav items which do not start with letters, reimplement active nav item state

### DIFF
--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -68,7 +68,7 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
         size={size}
       >
         <NavLink
-          data-heading-id={id}
+          data-heading-id={`#${id}`}
           data-heading-level={level}
           data-heading-title={title}
           id={id}

--- a/src/components/NavTree/NavTree.tsx
+++ b/src/components/NavTree/NavTree.tsx
@@ -1,6 +1,7 @@
 import { ChevronDownIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import { Box, Flex, IconButton, Text, useDisclosure } from "@chakra-ui/react";
 import { FunctionComponent, useMemo, ReactNode } from "react";
+import { useLocation } from "react-router-dom";
 import { NavLink } from "../NavLink";
 
 export interface NavItemConfig {
@@ -68,9 +69,13 @@ export const NavItem: FunctionComponent<NavItemProps> = ({
   level,
   onOpen,
 }) => {
-  const linkIsActive = false;
   const defaultIsOpen = level < 2; // only show first two levels by default
   const disclosure = useDisclosure({ onOpen, defaultIsOpen });
+  const { hash, pathname } = useLocation();
+  const pathUrl = new URL(path ?? "", window.origin);
+  const linkIsActive = path?.includes("/api/")
+    ? pathUrl.pathname === pathname
+    : pathUrl.hash && hash && pathUrl.hash === hash;
 
   const showToggle = (children?.length ?? 0) > 0;
   const showChildren = disclosure.isOpen && showToggle;

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -48,7 +48,10 @@ export const PackageDocs: FunctionComponent = () => {
 
   useEffect(() => {
     if (hash) {
-      const target = document.querySelector(`${hash}`) as HTMLElement;
+      const target = document.querySelector(
+        `[data-heading-id="${hash}"]`
+      ) as HTMLElement;
+
       target?.scrollIntoView(true);
     } else if (isApiPath(pathname)) {
       const target = document.getElementById(DOCS_ROOT_ID) as HTMLElement;


### PR DESCRIPTION
Fixes #736 

Since we cannot guarantee that markdown headers will start with a letter, we can't query select markdown headings by their id. Instead, we can use the `data-heading-id` attribute and maintain the same functionality while preventing an error from querying invalid id's.

Additionally, this work fixes the Nav Item active states so that the active nav item will be colored blue - which was prior behavior to the markdown rendering changes from @MrArnoldPalmer

To test this work, I had to download a markdown response for a package, and copy it to my public folder with the corresponding request path (`localhost:3000/data/foo/v123/docs-typescript.md` => `public/data/foo/v123/docs-typescript.md`). This allowed me to modify the markdown headings freely for testing as the original library with this issue no longer has numbered headings.

<img width="1603" alt="Screen Shot 2021-12-01 at 11 09 32 AM" src="https://user-images.githubusercontent.com/8749859/144298441-02b24e15-9c79-4577-94b8-403026ed5b4d.png">

