### PR TITLE
feat: show keywords in search details

### DIFF
--- a/src/theme/components/Tag.ts
+++ b/src/theme/components/Tag.ts
@@ -43,6 +43,7 @@ export const makeTag = (config: PackageTagConfig[]) => {
     ...base,
     baseStyle: {
       container: {
+        border: "base",
         fontWeight: "normal",
       },
     },

--- a/src/views/SearchRedesign/SearchDetails.tsx
+++ b/src/views/SearchRedesign/SearchDetails.tsx
@@ -1,5 +1,6 @@
-import { Text } from "@chakra-ui/react";
+import { Flex, Text, Tag, TagLabel, TagCloseButton } from "@chakra-ui/react";
 import { FunctionComponent } from "react";
+import { useSearchState } from "./SearchState";
 import testIds from "./testIds";
 
 export interface SearchDetailsProps {
@@ -7,7 +8,6 @@ export interface SearchDetailsProps {
   offset: number;
   count: number;
   filtered: boolean;
-  query?: string;
 }
 
 const Em: FunctionComponent = ({ children }) => (
@@ -44,11 +44,20 @@ export const SearchDetails: FunctionComponent<SearchDetailsProps> = ({
   offset,
   count,
   filtered,
-  query,
 }) => {
+  const { query, searchAPI } = useSearchState();
+
+  const { keywords, setKeywords } = searchAPI;
   const first = limit * offset;
   const last = first + limit;
   const hasResults = count > 0;
+  const hasQuery = Boolean(query);
+  const hasKeywords = Boolean(keywords?.length);
+  const keywordTerm = (keywords?.length ?? 0) > 1 ? "keywords" : "keyword";
+
+  const getOnKeywordClick = (kw: string) => () => {
+    setKeywords((currentKeywords) => currentKeywords.filter((k) => k !== kw));
+  };
 
   return (
     <Text data-testid={testIds.searchDetails}>
@@ -60,13 +69,34 @@ export const SearchDetails: FunctionComponent<SearchDetailsProps> = ({
       ) : (
         <>{filtered ? "There were no search results" : "No constructs found"}</>
       )}
-      {query && (
+      {hasQuery && (
         <>
           {" for "}
           <Em>{query}</Em>
         </>
       )}
-      .{!hasResults && filtered && <> Try a different term.</>}
+      {hasKeywords && (
+        <>
+          {" with "}
+          {keywordTerm}{" "}
+          <Flex
+            align="center"
+            display="inline-flex"
+            maxW="full"
+            overflow="hidden"
+            sx={{ gap: "0.5rem" }}
+            wrap="wrap"
+          >
+            {keywords!.map((kw) => (
+              <Tag key={kw}>
+                <TagLabel>{kw}</TagLabel>
+                <TagCloseButton onClick={getOnKeywordClick(kw)} />
+              </Tag>
+            ))}
+          </Flex>
+        </>
+      )}
+      {!hasResults && filtered && <> Try a different term.</>}
     </Text>
   );
 };

--- a/src/views/SearchRedesign/SearchResults.tsx
+++ b/src/views/SearchRedesign/SearchResults.tsx
@@ -113,7 +113,6 @@ export const SearchResults: FunctionComponent = () => {
             filtered={!!query}
             limit={limit}
             offset={offset}
-            query={query}
           />
 
           <Box display={{ base: "none", md: "initial" }}>


### PR DESCRIPTION
Fixes #589 

This PR updates the search details to display active keywords inline, similar to how we do for the search query. The keywords displayed will also have a close icon which allows them to be quickly removed from the current filter set

Marking as draft to allow for UX review

<img width="1599" alt="Screen Shot 2021-12-01 at 11 38 48 AM" src="https://user-images.githubusercontent.com/8749859/144302514-4ef14b69-c8d3-42d7-af77-9691ff08d281.png">
<img width="1600" alt="Screen Shot 2021-12-01 at 11 39 18 AM" src="https://user-images.githubusercontent.com/8749859/144302515-c650a3ae-81c7-4bb8-bb57-11d7378ea2c7.png">
<img width="1600" alt="Screen Shot 2021-12-01 at 11 39 27 AM" src="https://user-images.githubusercontent.com/8749859/144302516-a8312933-35cf-4e5c-ba7b-64af833d581e.png">
<img width="1598" alt="Screen Shot 2021-12-01 at 11 39 37 AM" src="https://user-images.githubusercontent.com/8749859/144302518-c1b762ef-880f-471e-b1b7-53b8aefec0ee.png">
<img width="649" alt="Screen Shot 2021-12-01 at 11 40 01 AM" src="https://user-images.githubusercontent.com/8749859/144302520-b66433e7-c9ff-4784-97b9-c904b5dadde3.png">
