### PR TITLE
fix: CDK type tabs displaying no packages

### DIFF
--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -253,7 +253,7 @@ describe("Home (Redesign / WIP)", () => {
           );
       };
 
-      ["community", "aws-official", "hashicorp-official"].forEach(testSeeAll);
+      ["community", "aws-published", "hashicorp-published"].forEach(testSeeAll);
     });
   });
 });

--- a/src/views/Home/CDKTypeTabs.tsx
+++ b/src/views/Home/CDKTypeTabs.tsx
@@ -42,12 +42,12 @@ const tabs = {
   aws: {
     "data-event": HOME_ANALYTICS.PUBLISHER.eventName("AWS"),
     label: "AWS",
-    tag: "aws-official",
+    tag: "aws-published",
   },
   hashicorp: {
     "data-event": HOME_ANALYTICS.PUBLISHER.eventName("HashiCorp"),
     label: "HashiCorp",
-    tag: "hashicorp-official",
+    tag: "hashicorp-published",
   },
 };
 


### PR DESCRIPTION
Currently the CDK type tabs are showing no packages (or simply outdated packages) because of a change made in our backend to the CDK type tag IDs. This fixes the tag IDs so the correct packages are displayed.