### PR TITLE
chore: bump node version in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.20.0
+          node-version: 12.22.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.20.0
+          node-version: 12.22.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.20.0
+          node-version: 12.22.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -27,7 +27,7 @@ const project = new web.ReactTypeScriptProject({
   },
 
   minNodeVersion: "12.20.0",
-  workflowNodeVersion: '12.22.0',
+  workflowNodeVersion: "12.22.0",
 
   eslint: true,
   eslintOptions: {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -27,6 +27,7 @@ const project = new web.ReactTypeScriptProject({
   },
 
   minNodeVersion: "12.20.0",
+  workflowNodeVersion: '12.22.0',
 
   eslint: true,
   eslintOptions: {


### PR DESCRIPTION
The current node version we are using the workflows is causing the upgrade workflow to [fail](https://github.com/cdklabs/construct-hub-webapp/runs/4629550219?check_suite_focus=true):

```console
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
child_process.js:674
    throw err;
    ^

Error: Command failed: yarn install --check-files
error @typescript-eslint/eslint-plugin@5.8.0: The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.17.0 || >=16.0.0". Got "12.20.0"
error Found incompatible module.
```

This corresponds to our configuration in [construct-hub](https://github.com/cdklabs/construct-hub/blob/main/.projenrc.js#L87).