### PR TITLE
fix: package page scrolls to top on focus

### DIFF
--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -61,7 +61,7 @@ export const PackageDocs: FunctionComponent = () => {
     } else {
       window.scrollTo(0, 0);
     }
-  });
+  }, [hash, pathname]);
 
   return (
     <Grid


### PR DESCRIPTION
Fixes https://github.com/cdklabs/construct-hub/issues/718

### Description

When switching tabs or windows on a package page, the page scrolls back to top when it takes focus.

#### Expected behavior and testing steps

1. User scrolls down package docs
2. User switches tabs / window
3. User returns to package docs, scroll state should persist.

#### Observed behavior

Verifiable here - https://constructs.dev

1. User scrolls down package docs
2. User switches tabs / window
3. User returns to package docs, scroll state resets to top of page.