### PR TITLE
fix: Persist api reference on version change

### DIFF
--- a/src/util/url.test.ts
+++ b/src/util/url.test.ts
@@ -86,17 +86,47 @@ describe("getSearchPath", () => {
 
 describe("getPackagePath", () => {
   it("creates a valid package url", () => {
-    const pkg = {
+    const basePkg = {
       name: "@example/construct",
       version: "1.0.0",
-      submodule: "foo",
-      language: Language.Go,
     };
 
-    const result = getPackagePath(pkg);
+    const basePath = getPackagePath(basePkg);
 
-    expect(result).toMatchInlineSnapshot(
-      `"/packages/@example/construct/v/1.0.0?submodule=foo&lang=golang"`
+    expect(basePath).toMatchInlineSnapshot(
+      `"/packages/@example/construct/v/1.0.0"`
+    );
+
+    const pathWithSubmodule = getPackagePath({ ...basePkg, submodule: "foo" });
+
+    expect(pathWithSubmodule).toMatchInlineSnapshot(
+      `"/packages/@example/construct/v/1.0.0?submodule=foo"`
+    );
+
+    const pathWithLanguage = getPackagePath({
+      ...basePkg,
+      language: Language.Go,
+    });
+
+    expect(pathWithLanguage).toMatchInlineSnapshot(
+      `"/packages/@example/construct/v/1.0.0?lang=golang"`
+    );
+
+    const pathWithApiRef = getPackagePath({ ...basePkg, api: "bar" });
+
+    expect(pathWithApiRef).toMatchInlineSnapshot(
+      `"/packages/@example/construct/v/1.0.0/api/bar"`
+    );
+
+    const pathWithAllParams = getPackagePath({
+      ...basePkg,
+      submodule: "foo",
+      api: "bar",
+      language: Language.Go,
+    });
+
+    expect(pathWithAllParams).toMatchInlineSnapshot(
+      `"/packages/@example/construct/v/1.0.0/api/bar?submodule=foo&lang=golang"`
     );
   });
 });

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -100,13 +100,18 @@ export const getPackagePath = ({
   version,
   language,
   submodule,
+  api,
 }: {
+  api?: string;
   name: string;
   version: string;
   language?: Language;
   submodule?: string;
-}) =>
-  createURL(`${ROUTES.PACKAGES}/${name}/v/${version}`, {
+}) => {
+  const apiSegment = api ? `/api/${api}` : "";
+
+  return createURL(`${ROUTES.PACKAGES}/${name}/v/${version}${apiSegment}`, {
     [QUERY_PARAMS.SUBMODULE]: submodule,
     [QUERY_PARAMS.LANGUAGE]: language,
   });
+};

--- a/src/views/Package/PackageHeader/SelectVersion.tsx
+++ b/src/views/Package/PackageHeader/SelectVersion.tsx
@@ -19,7 +19,7 @@ export const SelectVersion: FunctionComponent = () => {
   const pkgName = scope ? `${scope}/${name}` : name;
 
   const searchAPI = useSearchContext()!;
-  const { push } = useHistory();
+  const { push, location } = useHistory();
 
   const packages = searchAPI.findByName(pkgName);
 
@@ -39,13 +39,27 @@ export const SelectVersion: FunctionComponent = () => {
   const onChangeVersion: React.ChangeEventHandler<HTMLSelectElement> = (
     evt
   ) => {
-    push(
-      getPackagePath({
-        name: pkgName,
-        version: evt.target.value,
-        language,
-      })
-    );
+    const { pathname, hash } = location;
+
+    // Need to include the api reference segment to persist the docs across version changes
+    let api = "";
+
+    if (pathname.includes("/api/")) {
+      // "packages/foo/v/1.2.3/api/bar" => ["packages/foo/v/1.2.3", "bar"]
+      [, api] = pathname.split("/api/");
+    }
+
+    const url = getPackagePath({
+      name: pkgName,
+      version: evt.target.value,
+      language,
+      api,
+    });
+
+    // Persist the hash if present
+    const urlWithHash = [url, hash].join("");
+
+    push(urlWithHash);
   };
 
   return (


### PR DESCRIPTION
Fixes #869 

### Description

When changing package versions, the page should persist the current readme segment or api reference page

#### Expected behavior and testing

1. User selects an api reference page
2. User changes package version
3. Api reference page should remain, version should update

#### Observed behavior

1. User selects an api reference page
2. User changes package version
3. Version updates but the page reverts to showing the readme