### PR TITLE
feat: support preload script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 
 <head>
+  <script src="%PUBLIC_URL%/preload.js"></script>
+
   <meta charset="utf-8" />
   <meta name="description"
     content="Construct Hub helps developers find open-source construct libraries for use with AWS CDK, CDK8s, CDKTf and other construct-based tools." />
@@ -14,9 +16,6 @@
   <meta name="theme-color" content="#ffffff">
 
   <title>Construct Hub</title>
-
-  <script>var AWSMA = { config: { customPageview: true } }</script>
-  <script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
 
 </head>
 

--- a/scripts/proxy-server.js
+++ b/scripts/proxy-server.js
@@ -12,11 +12,13 @@ const port = process.env.PORT || 3000;
 
 const buildDir = path.join(__dirname, "..", "build");
 
+const PROXY_FILES = [".json", ".md", "preload.js"];
+
 app.use(express.static(buildDir));
 
 app.use(
   proxy(proxyUrl, {
-    filter: (req) => req.url.includes(".json") || req.url.includes(".md"),
+    filter: (req) => PROXY_FILES.some((file) => req.url.includes(file)),
   })
 );
 


### PR DESCRIPTION
This pull request updates the webapp index.html to point to the new `preload.js` file rather than hard-coding the scripts in our public library. This will allow Construct Hub operators to define and use their own preload scripts, which can serve as an entry point for monitoring or analytics.

### Testing (localhost)

1. `git fetch && git checkout feat/preload-script`
2. `yarn && yarn dev`
3. Open the network tab, verify that `preload.js` loads and that analytic calls are made by filtering `b/ss`