### PR TITLE
chore: update TOC to be fixed width

### DIFF
--- a/src/components/NavTree/NavTree.tsx
+++ b/src/components/NavTree/NavTree.tsx
@@ -58,6 +58,7 @@ const NavItemWrapper: FunctionComponent<NavItemWrapperProps> = ({
     marginLeft: showToggle ? 0 : 1,
     fontWeight: showToggle ? "bold" : undefined,
     textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as any,
     w: "100%",
   };
 

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -67,7 +67,7 @@ export const PackageDocs: FunctionComponent = () => {
     <Grid
       columnGap={4}
       h="full"
-      templateColumns={{ base: "1fr", md: "20rem 3fr" }}
+      templateColumns={{ base: "1fr", md: "minmax(20rem, 1fr) 3fr" }}
       width="100%"
     >
       <Flex

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -67,7 +67,7 @@ export const PackageDocs: FunctionComponent = () => {
     <Grid
       columnGap={4}
       h="full"
-      templateColumns={{ base: "1fr", md: "1fr 3fr" }}
+      templateColumns={{ base: "1fr", md: "20rem 3fr" }}
       width="100%"
     >
       <Flex


### PR DESCRIPTION
Updates the table of contents so that it always has the same width on desktop viewports, as it can seem overly large or overly squished on certain screen resolutions.

Also updates the table of contents to display ellipses when titles get too long -- the CSS for ellipses was already there, but the text was still wrapping since the `white-space` property wasn't set to `nowrap`.

<img width="454" alt="Screen Shot 2022-01-27 at 4 16 08 PM" src="https://user-images.githubusercontent.com/5008987/151464908-4bae34e4-9676-4b11-a76f-68cdb14d4d68.png">
