### PR TITLE
feat: add random package route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ const FAQ = lazy(() => import("./views/FAQ"));
 const Home = lazy(() => import("./views/Home"));
 const NotFound = lazy(() => import("./views/NotFound"));
 const Packages = lazy(() => import("./views/Packages"));
+const Random = lazy(() => import("./views/Random"));
 const Search = lazy(() => import("./views/Search"));
 const SiteTerms = lazy(() => import("./views/SiteTerms"));
 
@@ -33,6 +34,7 @@ export const App: FunctionComponent = () => {
         <LazyRoute component={SiteTerms} exact path={ROUTES.SITE_TERMS} />
         <LazyRoute component={Packages} path={ROUTES.PACKAGES} />
         <LazyRoute component={Search} exact path={ROUTES.SEARCH} />
+        <LazyRoute component={Random} exact path={ROUTES.RANDOM} />
         <LazyRoute component={NotFound} path="*" />
       </Switch>
       <Footer />

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -28,7 +28,8 @@ export const ROUTES = {
   PACKAGES: "/packages",
   SEARCH: "/search",
   SITE_TERMS: "/terms",
-};
+  RANDOM: "/random",
+} as const;
 
 type QueryParams = typeof QUERY_PARAMS;
 

--- a/src/views/Random/Random.tsx
+++ b/src/views/Random/Random.tsx
@@ -1,0 +1,32 @@
+import { Center, Spinner } from "@chakra-ui/react";
+import type { FunctionComponent } from "react";
+import { Redirect } from "react-router-dom";
+import type { CatalogPackage, Packages } from "../../api/package/packages";
+import { useCatalog } from "../../hooks/useCatalog";
+import { getPackagePath } from "../../util/url";
+
+const getRandomPkg = (catalog: Packages): CatalogPackage => {
+  const packages = catalog.packages;
+  const idx = Math.floor(Math.random() * packages.length);
+  return packages[idx];
+};
+
+export const Random: FunctionComponent = () => {
+  const catalog = useCatalog();
+
+  if (catalog.isLoading || !catalog.data) {
+    return (
+      <Center minH="16rem">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
+
+  const pkg = getRandomPkg(catalog.data);
+  const url = getPackagePath({
+    name: pkg.name,
+    version: pkg.version,
+  });
+
+  return <Redirect to={url} />;
+};

--- a/src/views/Random/index.ts
+++ b/src/views/Random/index.ts
@@ -1,0 +1,1 @@
+export { Random as default } from "./Random";


### PR DESCRIPTION
Visit constructs.dev/random (or your-construct-hub.com/random) to get taken to a random construct.

This is something I thought would be useful for testing purposes so that I can easily visit a random package to see how the API reference looks, whether tags are appearing properly, etc. By contrast if I find packages through search, I tend to be biased towards packages that are recently published, or are ranked highest/lowest in downloads, or come at the beginning/end of the alphabet, etc.

For now this is just an easter egg basically, but I'm totally open to adding it to the UI. 🙂 