### PR TITLE
feat: separate link from markdown heading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ jspm_packages/
 !/.eslintrc.json
 /build/
 !/react-app-env.d.ts
+/.vscode/
 cypress/videos/
 cypress/screenshots/
 !/.github/workflows/integ.yml

--- a/.npmignore
+++ b/.npmignore
@@ -12,12 +12,12 @@
 dist
 /tsconfig.json
 /.github/
-/.vscode/
 /.idea/
 /.projenrc.js
 tsconfig.tsbuildinfo
 /.eslintrc.json
 /build/
+/.vscode/
 !/build
 /public
 /build/config.json

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -93,6 +93,9 @@ const project = new web.ReactTypeScriptProject({
 // if test pass, we should be ok with this override, even though its a different major version.
 project.package.addField("resolutions", { "nth-check": "2.0.1" });
 
+project.gitignore.addPatterns("/.vscode/");
+project.npmignore.addPatterns("/.vscode/");
+
 (function addCypress() {
   project.addDevDeps("cypress");
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": true
-}

--- a/src/components/Markdown/Headings.tsx
+++ b/src/components/Markdown/Headings.tsx
@@ -1,4 +1,5 @@
-import { Heading, As } from "@chakra-ui/react";
+import { LinkIcon } from "@chakra-ui/icons";
+import { Flex, Heading, As } from "@chakra-ui/react";
 import { Children, FunctionComponent, ReactNode } from "react";
 import ReactDOMServer from "react-dom/server";
 import { sanitize } from "../../util/sanitize-anchor";
@@ -30,6 +31,30 @@ const stringContent = (node: ReactNode): string => {
     .trim();
 };
 
+const HeadingLink: FunctionComponent<{
+  id: string;
+  level: number;
+  title: string;
+}> = ({ id, level, title }) => (
+  <NavLink
+    _active={{ visibility: "initial" }}
+    _focus={{ visibility: "initial" }}
+    alignItems="center"
+    data-heading-id={`#${id}`}
+    data-heading-level={level}
+    data-heading-title={title}
+    display="flex"
+    id={id}
+    lineHeight={1}
+    opacity="hidden"
+    replace
+    to={`#${id}`}
+    visibility="hidden"
+  >
+    <LinkIcon boxSize={4} />
+  </NavLink>
+);
+
 export const Headings: FunctionComponent<HeadingResolverProps> = ({
   level,
   children,
@@ -52,32 +77,31 @@ export const Headings: FunctionComponent<HeadingResolverProps> = ({
   const id = dataElement?.dataset.headingId ?? sanitize(title);
 
   return (
-    <>
+    <Flex
+      _hover={{
+        "> a": {
+          visibility: "initial",
+        },
+      }}
+      align="stretch"
+      borderBottom="base"
+      justify="space-between"
+      mb={4}
+      mt={level >= 4 ? "1.5em" : 4}
+      px={level >= 4 ? 2 : undefined}
+      py={2}
+    >
       <Heading
         as={elem}
-        // backgroundColor={level === 5 ? "gray.50" : undefined}
-        borderBottom="base"
         color="textPrimary"
         level={level}
-        marginBottom={4}
-        marginTop={level >= 4 ? "1.5em" : 4}
-        paddingBottom={2}
-        paddingTop={2}
-        paddingX={level >= 4 ? 2 : undefined}
         size={size}
+        sx={{ "> code": { fontSize: "inherit" } }}
       >
-        <NavLink
-          data-heading-id={`#${id}`}
-          data-heading-level={level}
-          data-heading-title={title}
-          id={id}
-          replace
-          sx={{ "> code": { fontSize: "inherit" } }}
-          to={`#${id}`}
-        >
-          {children}
-        </NavLink>
+        {children}
       </Heading>
-    </>
+
+      <HeadingLink id={id} level={level} title={title} />
+    </Flex>
   );
 };

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -44,7 +44,7 @@ const isApiPath = (path: string) => {
 
 export const PackageDocs: FunctionComponent = () => {
   const { path } = useRouteMatch();
-  const { menuItems } = usePackageState();
+  const { menuItems, markdown } = usePackageState();
 
   const { hash, pathname, search } = useLocation();
 
@@ -61,7 +61,8 @@ export const PackageDocs: FunctionComponent = () => {
     } else {
       window.scrollTo(0, 0);
     }
-  }, [hash, pathname]);
+    // Subscribe to doc loading state so that we run this effect after docs load as well
+  }, [hash, pathname, markdown.isLoading]);
 
   return (
     <Grid


### PR DESCRIPTION
Fixes #867 

Separates the anchor element from the markdown heading to make it easier to copy headings.
When hovering the header line, the link icon will become visible. It will remain visible if clicked / focused

<img width="1722" alt="Screen Shot 2022-02-01 at 1 19 56 PM" src="https://user-images.githubusercontent.com/8749859/152053512-cb4cf16d-9ca0-4987-9125-845143e3de87.png">
