### PR TITLE
Feat/move readme subitems to right nav

### DIFF
--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -1,11 +1,5 @@
 import { Box, Flex, Grid } from "@chakra-ui/react";
-import type {
-  ClassSchema,
-  EnumSchema,
-  InterfaceSchema,
-  StructSchema,
-} from "jsii-docgen";
-import { FunctionComponent, useEffect, useMemo } from "react";
+import { FunctionComponent, useEffect } from "react";
 import {
   Route,
   Switch,
@@ -14,22 +8,19 @@ import {
   Redirect,
 } from "react-router-dom";
 import { NavTree } from "../../components/NavTree";
-import { QUERY_PARAMS } from "../../constants/url";
-import { useLanguage } from "../../hooks/useLanguage";
-import { useQueryParams } from "../../hooks/useQueryParams";
 import { ChooseSubmodule } from "./ChooseSubmodule";
-import { PACKAGE_ANALYTICS } from "./constants";
+import { API_URL_RESOURCE, PACKAGE_ANALYTICS } from "./constants";
 import { NavDrawer } from "./NavDrawer";
 import { PackageReadme } from "./PackageReadme";
 import { usePackageState } from "./PackageState";
 import { PackageTypeDocs } from "./PackageTypeDocs";
 import { StickyNavContainer } from "./StickyNavContainer";
-import { MenuItem } from "./util";
+import { useSectionItems } from "./useSectionItems";
+import { isApiPath } from "./util";
 
 // We want the nav to be sticky, but it should account for the sticky heading as well, which is 72px
 const TOP_OFFSET = "4.5rem";
 const DOCS_ROOT_ID = "apidocs_header";
-const API_URL_RESOURCE = "api";
 
 const SubmoduleSelector: FunctionComponent = () => {
   const {
@@ -46,164 +37,6 @@ const SubmoduleSelector: FunctionComponent = () => {
       <ChooseSubmodule />
     </Flex>
   ) : null;
-};
-
-const isApiPath = (path: string) => {
-  const parts = path.split("/");
-  return parts[parts.length - 2] === API_URL_RESOURCE;
-};
-
-/**
- * Generate the path of the API that should be linked to in the nav tree based
- * on the ID of the type or method or property etc.
- *
- * This method slices from the end of the ID rather than the beginning since the
- * number of segments at the beginning can vary -- for example, a class name
- * could be the second segment:
- *   @aws-cdk/aws-s3.Bucket
- * or the third segment:
- *   aws-cdk-lib.aws_s3.Bucket (within a jsii submodule)
- * or a fourth or later segment:
- *   aws-cdk-lib.aws_s3.CfnBucket.AbortIncompleteMultipartUploadProperty (class that is defined within another class / namespace)
- *
- * Instead we assume that the number of segments from the end is always the same
- * for the particular type of field, so for example a class method is always
- * of the form `(rest of path).ClassName.method`.
- *
- * @example
- * // getPathFromId("@aws-cdk/aws-s3.Bucket.Initializer.parameter.scope", 4")
- * // => { path: "Bucket", hash: "#Initializer.parameter.scope" }
- */
-const getPathHelper = (segments: number) => {
-  return (id: string): { path: string; hash: string } => {
-    const [path, ...rest] = id.split(".").slice(-segments);
-    return { path, hash: "#" + rest.join(".") };
-  };
-};
-
-/**
- * Map from fields of `jsii-docgen.Schema` to data needed to extract values and
- * render the right navigation sidebar. This is needed to make the information
- * in the JSON docs play well with the existing markdown docs, but this could be
- * refactored / dropped in the future.
- */
-const docsSectionsMap = {
-  initializer: {
-    header: "Initializer Props",
-    getValues: (e: ClassSchema) => e.initializer?.parameters ?? [],
-    // @aws-cdk/aws-s3.Bucket.Initializer.parameter.scope => Bucket#Initializer.parameter.scope
-    getPath: getPathHelper(4),
-  },
-  instanceMethods: {
-    header: "Instance Methods",
-    getValues: (e: ClassSchema | InterfaceSchema) => e.instanceMethods,
-    // @aws-cdk/aws-s3.Bucket.addCorsRule => Bucket#addCorsRule
-    getPath: getPathHelper(2),
-  },
-  staticMethods: {
-    header: "Static Methods",
-    getValues: (e: ClassSchema) => e.staticMethods,
-    // @aws-cdk/aws-s3.Bucket.fromBucketArn => Bucket#fromBucketArn
-    getPath: getPathHelper(2),
-  },
-  properties: {
-    header: "Properties",
-    getValues: (e: ClassSchema | StructSchema | InterfaceSchema) =>
-      e.properties,
-    // @aws-cdk/aws-s3.Bucket.property.bucketArn => Bucket#property.bucketArn
-    getPath: getPathHelper(3),
-  },
-  constants: {
-    header: "Constants",
-    getValues: (e: ClassSchema) => e.constants,
-    // @aws-cdk/aws-s3.CfnAccessPoint.property.CFN_RESOURCE_TYPE_NAME => CfnAccessPoint#property.CFN_RESOURCE_TYPE_NAME
-    getPath: getPathHelper(3),
-  },
-  members: {
-    header: "Enum Members",
-    getValues: (e: EnumSchema) => e.members,
-    // @aws-cdk/aws-s3.BucketAccessControl#PRIVATE => BucketAccessControl#PRIVATE
-    getPath: getPathHelper(2),
-  },
-};
-
-const schemaToSectionItems = (
-  type: ClassSchema | InterfaceSchema | StructSchema | EnumSchema,
-  language: string,
-  submodule?: string
-): MenuItem[] => {
-  const items: MenuItem[] = [];
-
-  for (const [schemaKey, props] of Object.entries(docsSectionsMap)) {
-    const { header, getValues, getPath } = props;
-    if (schemaKey in type) {
-      const parentItem: MenuItem = {
-        level: 1,
-        id: header,
-        title: header,
-        children: [],
-      };
-      // We aren't using a discriminated union, so the
-      // "if schemaKey in type" check doesn't give TypeScript enough
-      // information to infer this by itself.
-      const childItems: MenuItem[] = getValues(type as any).map((value) => {
-        const { path, hash } = getPath(value.id);
-        let query = `?${QUERY_PARAMS.LANGUAGE}=${language}`;
-        if (submodule) {
-          query += `&${QUERY_PARAMS.SUBMODULE}=${submodule}`;
-        }
-        return {
-          level: 2,
-          id: value.id,
-          title: value.displayName,
-          path: `${path}${query}${hash}`,
-          children: [],
-        };
-      });
-      if (childItems.length > 0) {
-        parentItem.children.push(...childItems);
-        items.push(parentItem);
-      }
-    }
-  }
-
-  return items;
-};
-
-export const useSectionItems = (): MenuItem[] => {
-  const { path } = useRouteMatch();
-  const { jsonDocs } = usePackageState();
-  const match = useRouteMatch<{ typeId: string }>(
-    `${path}/${API_URL_RESOURCE}/:typeId`
-  );
-  const typeId = match?.params.typeId;
-
-  const [language] = useLanguage();
-  const q = useQueryParams();
-  const submodule = q.get(QUERY_PARAMS.SUBMODULE) ?? "";
-
-  const { types, metadata } = useMemo(() => {
-    if (!jsonDocs.data) return { types: [] };
-
-    const apiReference = jsonDocs.data?.apiReference;
-    if (!apiReference) return { types: [] };
-
-    return {
-      types: [
-        ...apiReference.classes,
-        ...apiReference.constructs,
-        ...apiReference.interfaces,
-        ...apiReference.structs,
-        ...apiReference.enums,
-      ],
-      metadata: jsonDocs.data.metadata,
-    };
-  }, [jsonDocs]);
-
-  const typeInfo = types.find((type) => type.displayName === typeId);
-  return typeInfo && metadata
-    ? schemaToSectionItems(typeInfo, language, submodule)
-    : [];
 };
 
 export const PackageDocs: FunctionComponent = () => {
@@ -241,6 +74,7 @@ export const PackageDocs: FunctionComponent = () => {
       }}
       width="100%"
     >
+      {/* Primary Nav */}
       <StickyNavContainer
         borderRight="1px solid"
         borderRightColor="borderColor"
@@ -254,6 +88,8 @@ export const PackageDocs: FunctionComponent = () => {
           <NavTree data-event={PACKAGE_ANALYTICS.SCOPE} items={menuItems} />
         </Box>
       </StickyNavContainer>
+
+      {/* Docs */}
       <Box
         h="max-content"
         maxWidth="100%"
@@ -279,6 +115,8 @@ export const PackageDocs: FunctionComponent = () => {
           </Route>
         </Switch>
       </Box>
+
+      {/* Secondary Nav */}
       <StickyNavContainer
         borderLeft="1px solid"
         borderLeftColor="borderColor"

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Grid } from "@chakra-ui/react";
-import { FunctionComponent, useEffect } from "react";
+import { FunctionComponent, useEffect, useMemo } from "react";
 import {
   Route,
   Switch,
@@ -9,14 +9,18 @@ import {
 } from "react-router-dom";
 import { NavTree } from "../../components/NavTree";
 import { ChooseSubmodule } from "./ChooseSubmodule";
-import { API_URL_RESOURCE, PACKAGE_ANALYTICS } from "./constants";
+import {
+  API_URL_RESOURCE,
+  README_ITEM_ID,
+  PACKAGE_ANALYTICS,
+} from "./constants";
 import { NavDrawer } from "./NavDrawer";
 import { PackageReadme } from "./PackageReadme";
 import { usePackageState } from "./PackageState";
 import { PackageTypeDocs } from "./PackageTypeDocs";
 import { StickyNavContainer } from "./StickyNavContainer";
 import { useSectionItems } from "./useSectionItems";
-import { isApiPath } from "./util";
+import { isApiPath, MenuItem } from "./util";
 
 // We want the nav to be sticky, but it should account for the sticky heading as well, which is 72px
 const TOP_OFFSET = "4.5rem";
@@ -45,6 +49,21 @@ export const PackageDocs: FunctionComponent = () => {
   const sectionItems = useSectionItems();
 
   const { hash, pathname, search } = useLocation();
+
+  const primaryNavItems = useMemo(() => {
+    return menuItems.reduce((items, item, i) => {
+      // Omit README children which will be displayed on secondary nav
+      if (i === 0 && item?.id === README_ITEM_ID) {
+        const { children, ...readme } = item;
+
+        items.push({ ...readme, children: [] });
+      } else {
+        items.push(item);
+      }
+
+      return items;
+    }, [] as MenuItem[]);
+  }, [menuItems]);
 
   useEffect(() => {
     window.requestAnimationFrame(() => {
@@ -85,7 +104,10 @@ export const PackageDocs: FunctionComponent = () => {
       >
         <SubmoduleSelector />
         <Box overflowY="auto" py={4}>
-          <NavTree data-event={PACKAGE_ANALYTICS.SCOPE} items={menuItems} />
+          <NavTree
+            data-event={PACKAGE_ANALYTICS.SCOPE}
+            items={primaryNavItems}
+          />
         </Box>
       </StickyNavContainer>
 

--- a/src/views/Package/constants.ts
+++ b/src/views/Package/constants.ts
@@ -36,3 +36,5 @@ export const PACKAGE_ANALYTICS = {
 };
 
 export const API_URL_RESOURCE = "api";
+
+export const README_ITEM_ID = "Readme";

--- a/src/views/Package/constants.ts
+++ b/src/views/Package/constants.ts
@@ -34,3 +34,5 @@ export const PACKAGE_ANALYTICS = {
     ABUSE: packageEvent("Feedback", "Abuse"),
   },
 };
+
+export const API_URL_RESOURCE = "api";

--- a/src/views/Package/useSectionItems/index.ts
+++ b/src/views/Package/useSectionItems/index.ts
@@ -1,0 +1,1 @@
+export * from "./useSectionItems";

--- a/src/views/Package/useSectionItems/useSectionItems.ts
+++ b/src/views/Package/useSectionItems/useSectionItems.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+import { useRouteMatch } from "react-router-dom";
+import { QUERY_PARAMS } from "../../../constants/url";
+import { useLanguage } from "../../../hooks/useLanguage";
+import { useQueryParams } from "../../../hooks/useQueryParams";
+import { API_URL_RESOURCE } from "../constants";
+import { usePackageState } from "../PackageState";
+import type { MenuItem } from "../util";
+import { schemaToSectionItems } from "./util";
+
+export const useSectionItems = (): MenuItem[] => {
+  const { path } = useRouteMatch();
+  const { jsonDocs } = usePackageState();
+  const match = useRouteMatch<{ typeId: string }>(
+    `${path}/${API_URL_RESOURCE}/:typeId`
+  );
+  const typeId = match?.params.typeId;
+
+  const [language] = useLanguage();
+  const q = useQueryParams();
+  const submodule = q.get(QUERY_PARAMS.SUBMODULE) ?? "";
+
+  const { types, metadata } = useMemo(() => {
+    if (!jsonDocs.data) return { types: [] };
+
+    const apiReference = jsonDocs.data?.apiReference;
+    if (!apiReference) return { types: [] };
+
+    return {
+      types: [
+        ...apiReference.classes,
+        ...apiReference.constructs,
+        ...apiReference.interfaces,
+        ...apiReference.structs,
+        ...apiReference.enums,
+      ],
+      metadata: jsonDocs.data.metadata,
+    };
+  }, [jsonDocs]);
+
+  const typeInfo = types.find((type) => type.displayName === typeId);
+  return typeInfo && metadata
+    ? schemaToSectionItems(typeInfo, language, submodule)
+    : [];
+};

--- a/src/views/Package/useSectionItems/useSectionItems.ts
+++ b/src/views/Package/useSectionItems/useSectionItems.ts
@@ -1,16 +1,18 @@
 import { useMemo } from "react";
-import { useRouteMatch } from "react-router-dom";
+import { useLocation, useRouteMatch } from "react-router-dom";
 import { QUERY_PARAMS } from "../../../constants/url";
 import { useLanguage } from "../../../hooks/useLanguage";
 import { useQueryParams } from "../../../hooks/useQueryParams";
-import { API_URL_RESOURCE } from "../constants";
+import { API_URL_RESOURCE, README_ITEM_ID } from "../constants";
 import { usePackageState } from "../PackageState";
-import type { MenuItem } from "../util";
+import { isApiPath, MenuItem } from "../util";
 import { schemaToSectionItems } from "./util";
 
 export const useSectionItems = (): MenuItem[] => {
+  const { pathname } = useLocation();
   const { path } = useRouteMatch();
-  const { jsonDocs } = usePackageState();
+  const { menuItems, jsonDocs } = usePackageState();
+
   const match = useRouteMatch<{ typeId: string }>(
     `${path}/${API_URL_RESOURCE}/:typeId`
   );
@@ -37,6 +39,14 @@ export const useSectionItems = (): MenuItem[] => {
       metadata: jsonDocs.data.metadata,
     };
   }, [jsonDocs]);
+
+  if (!isApiPath(pathname)) {
+    const [readmeSection] = menuItems;
+    const readmeItems: MenuItem[] =
+      readmeSection?.id === README_ITEM_ID ? readmeSection.children : [];
+
+    return readmeItems;
+  }
 
   const typeInfo = types.find((type) => type.displayName === typeId);
   return typeInfo && metadata

--- a/src/views/Package/useSectionItems/util.ts
+++ b/src/views/Package/useSectionItems/util.ts
@@ -1,0 +1,125 @@
+import type {
+  ClassSchema,
+  EnumSchema,
+  InterfaceSchema,
+  StructSchema,
+} from "jsii-docgen";
+import { QUERY_PARAMS } from "../../../constants/url";
+import type { MenuItem } from "../util";
+
+/**
+ * Generate the path of the API that should be linked to in the nav tree based
+ * on the ID of the type or method or property etc.
+ *
+ * This method slices from the end of the ID rather than the beginning since the
+ * number of segments at the beginning can vary -- for example, a class name
+ * could be the second segment:
+ *   @aws-cdk/aws-s3.Bucket
+ * or the third segment:
+ *   aws-cdk-lib.aws_s3.Bucket (within a jsii submodule)
+ * or a fourth or later segment:
+ *   aws-cdk-lib.aws_s3.CfnBucket.AbortIncompleteMultipartUploadProperty (class that is defined within another class / namespace)
+ *
+ * Instead we assume that the number of segments from the end is always the same
+ * for the particular type of field, so for example a class method is always
+ * of the form `(rest of path).ClassName.method`.
+ *
+ * @example
+ * // getPathFromId("@aws-cdk/aws-s3.Bucket.Initializer.parameter.scope", 4")
+ * // => { path: "Bucket", hash: "#Initializer.parameter.scope" }
+ */
+const getPathHelper = (segments: number) => {
+  return (id: string): { path: string; hash: string } => {
+    const [path, ...rest] = id.split(".").slice(-segments);
+    return { path, hash: "#" + rest.join(".") };
+  };
+};
+
+/**
+ * Map from fields of `jsii-docgen.Schema` to data needed to extract values and
+ * render the right navigation sidebar. This is needed to make the information
+ * in the JSON docs play well with the existing markdown docs, but this could be
+ * refactored / dropped in the future.
+ */
+const docsSectionsMap = {
+  initializer: {
+    header: "Initializer Props",
+    getValues: (e: ClassSchema) => e.initializer?.parameters ?? [],
+    // @aws-cdk/aws-s3.Bucket.Initializer.parameter.scope => Bucket#Initializer.parameter.scope
+    getPath: getPathHelper(4),
+  },
+  instanceMethods: {
+    header: "Instance Methods",
+    getValues: (e: ClassSchema | InterfaceSchema) => e.instanceMethods,
+    // @aws-cdk/aws-s3.Bucket.addCorsRule => Bucket#addCorsRule
+    getPath: getPathHelper(2),
+  },
+  staticMethods: {
+    header: "Static Methods",
+    getValues: (e: ClassSchema) => e.staticMethods,
+    // @aws-cdk/aws-s3.Bucket.fromBucketArn => Bucket#fromBucketArn
+    getPath: getPathHelper(2),
+  },
+  properties: {
+    header: "Properties",
+    getValues: (e: ClassSchema | StructSchema | InterfaceSchema) =>
+      e.properties,
+    // @aws-cdk/aws-s3.Bucket.property.bucketArn => Bucket#property.bucketArn
+    getPath: getPathHelper(3),
+  },
+  constants: {
+    header: "Constants",
+    getValues: (e: ClassSchema) => e.constants,
+    // @aws-cdk/aws-s3.CfnAccessPoint.property.CFN_RESOURCE_TYPE_NAME => CfnAccessPoint#property.CFN_RESOURCE_TYPE_NAME
+    getPath: getPathHelper(3),
+  },
+  members: {
+    header: "Enum Members",
+    getValues: (e: EnumSchema) => e.members,
+    // @aws-cdk/aws-s3.BucketAccessControl#PRIVATE => BucketAccessControl#PRIVATE
+    getPath: getPathHelper(2),
+  },
+};
+
+export const schemaToSectionItems = (
+  type: ClassSchema | InterfaceSchema | StructSchema | EnumSchema,
+  language: string,
+  submodule?: string
+): MenuItem[] => {
+  const items: MenuItem[] = [];
+
+  for (const [schemaKey, props] of Object.entries(docsSectionsMap)) {
+    const { header, getValues, getPath } = props;
+    if (schemaKey in type) {
+      const parentItem: MenuItem = {
+        level: 1,
+        id: header,
+        title: header,
+        children: [],
+      };
+      // We aren't using a discriminated union, so the
+      // "if schemaKey in type" check doesn't give TypeScript enough
+      // information to infer this by itself.
+      const childItems: MenuItem[] = getValues(type as any).map((value) => {
+        const { path, hash } = getPath(value.id);
+        let query = `?${QUERY_PARAMS.LANGUAGE}=${language}`;
+        if (submodule) {
+          query += `&${QUERY_PARAMS.SUBMODULE}=${submodule}`;
+        }
+        return {
+          level: 2,
+          id: value.id,
+          title: value.displayName,
+          path: `${path}${query}${hash}`,
+          children: [],
+        };
+      });
+      if (childItems.length > 0) {
+        parentItem.children.push(...childItems);
+        items.push(parentItem);
+      }
+    }
+  }
+
+  return items;
+};

--- a/src/views/Package/util.ts
+++ b/src/views/Package/util.ts
@@ -2,7 +2,7 @@ import emoji from "node-emoji";
 import { Language } from "../../constants/languages";
 import { QUERY_PARAMS } from "../../constants/url";
 import { sanitize } from "../../util/sanitize-anchor";
-import { API_URL_RESOURCE } from "./constants";
+import { API_URL_RESOURCE, README_ITEM_ID } from "./constants";
 
 export interface MenuItem {
   id: string;
@@ -191,7 +191,7 @@ export const parseMarkdownStructure = (
   const readmeMenuItems = [
     {
       level: 1,
-      id: "Readme",
+      id: README_ITEM_ID,
       title: "Readme",
       path: baseReadmePath,
       children: readmeChildren,

--- a/src/views/Package/util.ts
+++ b/src/views/Package/util.ts
@@ -2,6 +2,7 @@ import emoji from "node-emoji";
 import { Language } from "../../constants/languages";
 import { QUERY_PARAMS } from "../../constants/url";
 import { sanitize } from "../../util/sanitize-anchor";
+import { API_URL_RESOURCE } from "./constants";
 
 export interface MenuItem {
   id: string;
@@ -235,4 +236,9 @@ export const parseMarkdownStructure = (
     apiReference: types,
     menuItems,
   };
+};
+
+export const isApiPath = (path: string) => {
+  const parts = path.split("/");
+  return parts[parts.length - 2] === API_URL_RESOURCE;
 };


### PR DESCRIPTION
Fixes #914 

This pull request moves README subitems from the primary doc navigation to the secondary nav. The first commit on this pull request re-organizes logical code from presentational code, while the second commit actually does the work to implement the feature.

While testing this feature, I've also observed that libraries which are missing readmes (common for submodules) have an unclear UX and we should try to add some messaging to clarify that scenario i.e "This {library or submodule} does not have a readme. Use the menu on the left to browse the API Reference"

![Screenshot 2022-02-15 at 11-36-28 projen 0 52 31 - Construct Hub](https://user-images.githubusercontent.com/8749859/154136494-fae037c5-a464-4a84-8f99-5f76a7b5798f.png)
