### PR TITLE
feat: highlight secondary nav items on scroll

### DIFF
--- a/src/components/NavTree/NavItem.tsx
+++ b/src/components/NavTree/NavItem.tsx
@@ -1,0 +1,132 @@
+import { ChevronDownIcon, ChevronRightIcon } from "@chakra-ui/icons";
+import { Box, Flex, IconButton, useDisclosure } from "@chakra-ui/react";
+import { FunctionComponent, useMemo } from "react";
+import { clickEvent, eventName, useAnalytics } from "../../contexts/Analytics";
+import { NavItemWrapper } from "./NavItemWrapper";
+import type { GetIsActiveItemFunction, NavItemConfig } from "./types";
+
+const navTreeEvent = (scope: string, event: string) =>
+  eventName(scope, "NavTree", event);
+
+const iconProps = {
+  color: "textTertiary",
+  h: 4,
+  w: 4,
+};
+
+export interface NavItemProps extends NavItemConfig {
+  // The following props don't need to be explicitly defined - they are passed internally
+  getIsActiveItem?: GetIsActiveItemFunction;
+  onOpen?: () => void;
+  level: number;
+  variant?: "sm" | "md";
+}
+export const NavItem: FunctionComponent<NavItemProps> = ({
+  children,
+  "data-event": dataEvent,
+  getIsActiveItem,
+  id,
+  title,
+  path,
+  level,
+  onOpen,
+  variant,
+}) => {
+  const { trackCustomEvent } = useAnalytics();
+  const defaultIsOpen = level < 2; // only show first two levels by default
+  const disclosure = useDisclosure({ onOpen, defaultIsOpen });
+
+  const linkIsActive =
+    getIsActiveItem?.({
+      id,
+      title,
+      path,
+      children,
+    }) ?? false;
+
+  const showToggle = (children?.length ?? 0) > 0;
+  const showChildren = disclosure.isOpen && showToggle;
+
+  const nestedItems = useMemo(
+    () =>
+      children?.map((item, idx) => {
+        return (
+          <NavItem
+            data-event={dataEvent}
+            {...item}
+            getIsActiveItem={getIsActiveItem}
+            key={idx}
+            level={level + 1}
+            onOpen={disclosure.onOpen}
+            variant={variant}
+          />
+        );
+      }),
+    [children, dataEvent, getIsActiveItem, level, disclosure.onOpen, variant]
+  );
+
+  return (
+    <Flex direction="column">
+      <Flex align="center" color={linkIsActive ? "link" : "textPrimary"}>
+        {showToggle && (
+          <IconButton
+            aria-label="expand-toggle"
+            borderRadius="md"
+            h={4}
+            icon={
+              disclosure.isOpen ? (
+                <ChevronDownIcon {...iconProps} />
+              ) : (
+                <ChevronRightIcon {...iconProps} />
+              )
+            }
+            ml={-1}
+            onClick={() => {
+              disclosure.onToggle();
+
+              if (dataEvent) {
+                trackCustomEvent(
+                  clickEvent({
+                    name: navTreeEvent(dataEvent, "Toggle"),
+                  })
+                );
+              }
+            }}
+            size="xs"
+            variant="link"
+            w={0}
+          />
+        )}
+        <NavItemWrapper
+          data-event={dataEvent ? navTreeEvent(dataEvent, "Link") : undefined}
+          path={path}
+          showToggle={showToggle}
+          title={title}
+          variant={variant}
+        >
+          {title}
+        </NavItemWrapper>
+      </Flex>
+      <Box
+        _before={{
+          // Creates a border without taking up any box space
+          // This is important to keep items perfectly aligned
+          bg: "borderColor",
+          bottom: 0,
+          content: `""`,
+          left: 0,
+          position: "absolute",
+          top: 0,
+          w: "1px",
+        }}
+        display={showChildren ? "initial" : "none"}
+        ml={2}
+        mr={2}
+        pl={2}
+        position="relative"
+      >
+        {nestedItems}
+      </Box>
+    </Flex>
+  );
+};

--- a/src/components/NavTree/NavItemWrapper.tsx
+++ b/src/components/NavTree/NavItemWrapper.tsx
@@ -1,0 +1,49 @@
+import { Text } from "@chakra-ui/react";
+import type { FunctionComponent, ReactNode } from "react";
+import { NavLink } from "../NavLink";
+
+interface NavItemWrapperProps {
+  "data-event"?: string;
+  path?: string;
+  title: string;
+  showToggle: boolean;
+  children: ReactNode;
+  variant?: "sm" | "md";
+}
+
+export const NavItemWrapper: FunctionComponent<NavItemWrapperProps> = ({
+  children,
+  "data-event": dataEvent,
+  path,
+  title,
+  showToggle,
+  variant,
+}) => {
+  const smProps = {
+    fontSize: "sm",
+  };
+  const mdProps = {
+    fontSize: "md",
+  };
+
+  const sharedProps = {
+    _hover: { bg: "rgba(0, 124, 253, 0.05)" },
+    overflow: "hidden",
+    pl: 1,
+    py: showToggle ? 2 : 1,
+    marginLeft: showToggle ? 0 : 1,
+    fontWeight: showToggle ? "bold" : undefined,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap" as const,
+    w: "100%",
+    ...(variant === "sm" ? smProps : mdProps),
+  };
+
+  return path ? (
+    <NavLink data-event={dataEvent} title={title} to={path} {...sharedProps}>
+      {children}
+    </NavLink>
+  ) : (
+    <Text {...sharedProps}>{children}</Text>
+  );
+};

--- a/src/components/NavTree/NavTree.tsx
+++ b/src/components/NavTree/NavTree.tsx
@@ -1,29 +1,14 @@
-import { ChevronDownIcon, ChevronRightIcon } from "@chakra-ui/icons";
-import { Box, Flex, IconButton, Text, useDisclosure } from "@chakra-ui/react";
-import { FunctionComponent, useMemo, ReactNode } from "react";
-import { useLocation } from "react-router-dom";
-import { clickEvent, eventName, useAnalytics } from "../../contexts/Analytics";
-import { NavLink } from "../NavLink";
-
-const navTreeEvent = (scope: string, event: string) =>
-  eventName(scope, "NavTree", event);
-
-export interface NavItemConfig {
-  "data-event"?: string;
-  children: NavItemConfig[];
-  title: string;
-  path?: string;
-}
-
-export interface NavItemProps extends NavItemConfig {
-  // The following props don't need to be explicitly defined - they are passed internally
-  onOpen?: () => void;
-  level: number;
-  variant?: "sm" | "md";
-}
+import { Flex } from "@chakra-ui/react";
+import { FunctionComponent } from "react";
+import { NavItem } from "./NavItem";
+import type { GetIsActiveItemFunction, NavItemConfig } from "./types";
 
 export interface NavTreeProps {
   "data-event"?: string;
+  /**
+   * Function to evaluate if an item is currently active
+   */
+  getIsActiveItem?: GetIsActiveItemFunction;
   /**
    * Items to render
    */
@@ -31,164 +16,9 @@ export interface NavTreeProps {
   variant?: "sm" | "md";
 }
 
-const iconProps = {
-  color: "textTertiary",
-  h: 4,
-  w: 4,
-};
-
-interface NavItemWrapperProps {
-  "data-event"?: string;
-  path?: string;
-  title: string;
-  showToggle: boolean;
-  children: ReactNode;
-  variant?: "sm" | "md";
-}
-
-const NavItemWrapper: FunctionComponent<NavItemWrapperProps> = ({
-  children,
-  "data-event": dataEvent,
-  path,
-  title,
-  showToggle,
-  variant,
-}) => {
-  const smProps = {
-    fontSize: "sm",
-  };
-  const mdProps = {
-    fontSize: "md",
-  };
-
-  const sharedProps = {
-    _hover: { bg: "rgba(0, 124, 253, 0.05)" },
-    overflow: "hidden",
-    pl: 1,
-    py: showToggle ? 2 : 1,
-    marginLeft: showToggle ? 0 : 1,
-    fontWeight: showToggle ? "bold" : undefined,
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap" as any,
-    w: "100%",
-    ...(variant === "sm" ? smProps : mdProps),
-  };
-
-  return path ? (
-    <NavLink data-event={dataEvent} title={title} to={path} {...sharedProps}>
-      {children}
-    </NavLink>
-  ) : (
-    <Text {...sharedProps}>{children}</Text>
-  );
-};
-
-export const NavItem: FunctionComponent<NavItemProps> = ({
-  children,
-  "data-event": dataEvent,
-  title,
-  path,
-  level,
-  onOpen,
-  variant,
-}) => {
-  const { trackCustomEvent } = useAnalytics();
-  const defaultIsOpen = level < 2; // only show first two levels by default
-  const disclosure = useDisclosure({ onOpen, defaultIsOpen });
-  const { hash, pathname } = useLocation();
-  const pathUrl = new URL(path ?? "", window.origin);
-  const linkIsActive = path?.includes("/api/")
-    ? pathUrl.pathname === pathname
-    : pathUrl.hash && hash && pathUrl.hash === hash;
-
-  const showToggle = (children?.length ?? 0) > 0;
-  const showChildren = disclosure.isOpen && showToggle;
-
-  const nestedItems = useMemo(
-    () =>
-      children?.map((item, idx) => {
-        return (
-          <NavItem
-            data-event={dataEvent}
-            {...item}
-            key={idx}
-            level={level + 1}
-            onOpen={disclosure.onOpen}
-            variant={variant}
-          />
-        );
-      }),
-    [children, dataEvent, disclosure.onOpen, variant, level]
-  );
-
-  return (
-    <Flex direction="column">
-      <Flex align="center" color={linkIsActive ? "link" : "textPrimary"}>
-        {showToggle && (
-          <IconButton
-            aria-label="expand-toggle"
-            borderRadius="md"
-            h={4}
-            icon={
-              disclosure.isOpen ? (
-                <ChevronDownIcon {...iconProps} />
-              ) : (
-                <ChevronRightIcon {...iconProps} />
-              )
-            }
-            ml={-1}
-            onClick={() => {
-              disclosure.onToggle();
-
-              if (dataEvent) {
-                trackCustomEvent(
-                  clickEvent({
-                    name: navTreeEvent(dataEvent, "Toggle"),
-                  })
-                );
-              }
-            }}
-            size="xs"
-            variant="link"
-            w={0}
-          />
-        )}
-        <NavItemWrapper
-          data-event={dataEvent ? navTreeEvent(dataEvent, "Link") : undefined}
-          path={path}
-          showToggle={showToggle}
-          title={title}
-          variant={variant}
-        >
-          {title}
-        </NavItemWrapper>
-      </Flex>
-      <Box
-        _before={{
-          // Creates a border without taking up any box space
-          // This is important to keep items perfectly aligned
-          bg: "borderColor",
-          bottom: 0,
-          content: `""`,
-          left: 0,
-          position: "absolute",
-          top: 0,
-          w: "1px",
-        }}
-        display={showChildren ? "initial" : "none"}
-        ml={2}
-        mr={2}
-        pl={2}
-        position="relative"
-      >
-        {nestedItems}
-      </Box>
-    </Flex>
-  );
-};
-
 export const NavTree: FunctionComponent<NavTreeProps> = ({
   "data-event": dataEvent,
+  getIsActiveItem,
   items,
   variant,
 }) => {
@@ -199,6 +29,7 @@ export const NavTree: FunctionComponent<NavTreeProps> = ({
           <NavItem
             {...item}
             data-event={dataEvent}
+            getIsActiveItem={getIsActiveItem}
             key={idx}
             level={0}
             onOpen={undefined}

--- a/src/components/NavTree/index.ts
+++ b/src/components/NavTree/index.ts
@@ -1,2 +1,3 @@
 export { NavTree } from "./NavTree";
-export type { NavItemConfig, NavTreeProps } from "./NavTree";
+export type { NavTreeProps } from "./NavTree";
+export type { GetIsActiveItemFunction, NavItemConfig } from "./types";

--- a/src/components/NavTree/types.ts
+++ b/src/components/NavTree/types.ts
@@ -1,0 +1,23 @@
+export interface NavItemConfig {
+  "data-event"?: string;
+  /**
+   * NavItems to be shown as a descendant of this NavItem
+   */
+  children: NavItemConfig[];
+  /**
+   * A unique identifier for the navItem
+   */
+  id: string;
+  /**
+   * The text to be displayed for the navItem
+   */
+  title: string;
+  /**
+   * An optional path for the navItem, allowing it to behave as a link
+   */
+  path?: string;
+}
+
+export type GetIsActiveItemFunction = (
+  item: Omit<NavItemConfig, "data-event">
+) => boolean;

--- a/src/views/Package/PackageDocs.tsx
+++ b/src/views/Package/PackageDocs.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Grid } from "@chakra-ui/react";
-import { FunctionComponent, useEffect, useMemo } from "react";
+import { FunctionComponent, useEffect } from "react";
 import {
   Route,
   Switch,
@@ -7,20 +7,15 @@ import {
   useLocation,
   Redirect,
 } from "react-router-dom";
-import { NavTree } from "../../components/NavTree";
 import { ChooseSubmodule } from "./ChooseSubmodule";
-import {
-  API_URL_RESOURCE,
-  README_ITEM_ID,
-  PACKAGE_ANALYTICS,
-} from "./constants";
+import { API_URL_RESOURCE } from "./constants";
 import { NavDrawer } from "./NavDrawer";
 import { PackageReadme } from "./PackageReadme";
 import { usePackageState } from "./PackageState";
 import { PackageTypeDocs } from "./PackageTypeDocs";
+import { PrimaryDocNavigation } from "./PrimaryDocNavigation";
+import { SecondaryDocNavigation } from "./SecondaryDocNavigation";
 import { StickyNavContainer } from "./StickyNavContainer";
-import { useSectionItems } from "./useSectionItems";
-import { isApiPath, MenuItem } from "./util";
 
 // We want the nav to be sticky, but it should account for the sticky heading as well, which is 72px
 const TOP_OFFSET = "4.5rem";
@@ -45,25 +40,9 @@ const SubmoduleSelector: FunctionComponent = () => {
 
 export const PackageDocs: FunctionComponent = () => {
   const { path } = useRouteMatch();
-  const { menuItems, markdownDocs } = usePackageState();
-  const sectionItems = useSectionItems();
+  const { markdownDocs } = usePackageState();
 
   const { hash, pathname, search } = useLocation();
-
-  const primaryNavItems = useMemo(() => {
-    return menuItems.reduce((items, item, i) => {
-      // Omit README children which will be displayed on secondary nav
-      if (i === 0 && item?.id === README_ITEM_ID) {
-        const { children, ...readme } = item;
-
-        items.push({ ...readme, children: [] });
-      } else {
-        items.push(item);
-      }
-
-      return items;
-    }, [] as MenuItem[]);
-  }, [menuItems]);
 
   useEffect(() => {
     window.requestAnimationFrame(() => {
@@ -72,9 +51,6 @@ export const PackageDocs: FunctionComponent = () => {
           `[data-heading-id="${hash}"]`
         ) as HTMLElement;
 
-        target?.scrollIntoView(true);
-      } else if (isApiPath(pathname)) {
-        const target = document.getElementById(DOCS_ROOT_ID) as HTMLElement;
         target?.scrollIntoView(true);
       } else {
         window.scrollTo(0, 0);
@@ -104,10 +80,7 @@ export const PackageDocs: FunctionComponent = () => {
       >
         <SubmoduleSelector />
         <Box overflowY="auto" py={4}>
-          <NavTree
-            data-event={PACKAGE_ANALYTICS.SCOPE}
-            items={primaryNavItems}
-          />
+          <PrimaryDocNavigation />
         </Box>
       </StickyNavContainer>
 
@@ -148,11 +121,7 @@ export const PackageDocs: FunctionComponent = () => {
         top={TOP_OFFSET}
       >
         <Box overflowY="auto" py={4}>
-          <NavTree
-            data-event={PACKAGE_ANALYTICS.SCOPE}
-            items={sectionItems}
-            variant="sm"
-          />
+          <SecondaryDocNavigation />
         </Box>
       </StickyNavContainer>
       <NavDrawer />

--- a/src/views/Package/PrimaryDocNavigation.tsx
+++ b/src/views/Package/PrimaryDocNavigation.tsx
@@ -1,0 +1,53 @@
+import { FunctionComponent, useCallback, useMemo } from "react";
+import { useLocation } from "react-router-dom";
+import { GetIsActiveItemFunction, NavTree } from "../../components/NavTree";
+import {
+  API_URL_RESOURCE,
+  PACKAGE_ANALYTICS,
+  README_ITEM_ID,
+} from "./constants";
+import { usePackageState } from "./PackageState";
+import type { MenuItem } from "./util";
+
+export const PrimaryDocNavigation: FunctionComponent = () => {
+  const { menuItems } = usePackageState();
+  const { pathname, hash } = useLocation();
+
+  const primaryNavItems = useMemo(
+    () =>
+      menuItems.reduce((items, item, i) => {
+        // Omit README children which will be displayed on secondary nav
+        if (i === 0 && item?.id === README_ITEM_ID) {
+          const { children, ...readme } = item;
+
+          items.push({ ...readme, children: [] });
+        } else {
+          items.push(item);
+        }
+
+        return items;
+      }, [] as MenuItem[]),
+    [menuItems]
+  );
+
+  const getIsActiveItem: GetIsActiveItemFunction = useCallback(
+    ({ path }) => {
+      const pathUrl = new URL(path ?? "", window.origin);
+
+      return Boolean(
+        path?.includes(`/${API_URL_RESOURCE}/`)
+          ? pathUrl.pathname === pathname
+          : pathUrl.hash && hash && pathUrl.hash === hash
+      );
+    },
+    [hash, pathname]
+  );
+
+  return (
+    <NavTree
+      data-event={PACKAGE_ANALYTICS.SCOPE}
+      getIsActiveItem={getIsActiveItem}
+      items={primaryNavItems}
+    />
+  );
+};

--- a/src/views/Package/SecondaryDocNavigation.tsx
+++ b/src/views/Package/SecondaryDocNavigation.tsx
@@ -1,0 +1,24 @@
+import { FunctionComponent, useCallback } from "react";
+import { GetIsActiveItemFunction, NavTree } from "../../components/NavTree";
+import { PACKAGE_ANALYTICS } from "./constants";
+import { normalizeId, useIntersectingHeader } from "./useIntersectingHeader";
+import { useSectionItems } from "./useSectionItems";
+
+export const SecondaryDocNavigation: FunctionComponent = () => {
+  const intersectingHeader = useIntersectingHeader();
+  const sectionItems = useSectionItems();
+
+  const getIsLinkActive: GetIsActiveItemFunction = useCallback(
+    ({ id }) => normalizeId(id) === intersectingHeader,
+    [intersectingHeader]
+  );
+
+  return (
+    <NavTree
+      data-event={PACKAGE_ANALYTICS.SCOPE}
+      getIsActiveItem={getIsLinkActive}
+      items={sectionItems}
+      variant="sm"
+    />
+  );
+};

--- a/src/views/Package/useIntersectingHeader/index.ts
+++ b/src/views/Package/useIntersectingHeader/index.ts
@@ -1,0 +1,2 @@
+export { useIntersectingHeader } from "./useIntersectingHeader";
+export * from "./util";

--- a/src/views/Package/useIntersectingHeader/useIntersectingHeader.ts
+++ b/src/views/Package/useIntersectingHeader/useIntersectingHeader.ts
@@ -1,0 +1,77 @@
+/**
+ * This hook is used to determine the most recently visible doc header
+ */
+import { useEffect, useMemo, useState } from "react";
+import { useSectionItems } from "../useSectionItems";
+import { getElementId, getItemIds } from "./util";
+
+const observerOptions = {
+  // Creates a margin for intersection boundary. For this margin, an entry will only be considered intersecting
+  // if it is below the top 15% of the viewport, and above the bottom 15% of the viewport
+  rootMargin: "-15% 0% -15% 0%",
+};
+
+/**
+ * A hook which implements the logic to track the currently scrolled header. The value will always be within the bounds
+ * of the right nav items, meaning it should never return undefined unless there are no right nav items.
+ */
+export const useIntersectingHeader = () => {
+  const sectionItems = useSectionItems();
+
+  // Create a set of section ids for faster lookups
+  // This set will be re-defined whenever the sectionItems change
+  const sectionIdSet = useMemo(() => {
+    const sectionIds = sectionItems.map(getItemIds).flat();
+
+    return new Set(sectionIds);
+  }, [sectionItems]);
+
+  // State to track currently intersecting header, defaults to first item in sectionIdsSet
+  const [intersectingHeader, setIntersectingHeader] = useState<
+    string | undefined
+  >([...sectionIdSet][0]);
+
+  // When sectionIdsSet changes, set intersectingHeader to first item, and initialize an intersection observer to watch
+  // for intersecting headers
+  useEffect(() => {
+    const [firstId] = sectionIdSet;
+    setIntersectingHeader(firstId);
+
+    // If no headers to observe, don't setup observer
+    if (sectionIdSet.size < 1) return;
+
+    // Only look for sections with in the section id set
+    const sections = [...document.querySelectorAll("[data-heading-id]")].filter(
+      (section) => sectionIdSet.has(getElementId(section))
+    );
+
+    if (!sections.length) return;
+
+    const observerHandler: IntersectionObserverCallback = (entries) => {
+      let entry: Element | undefined;
+
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          entry = e.target;
+        }
+      });
+
+      if (entry) {
+        setIntersectingHeader(getElementId(entry));
+      }
+    };
+
+    const observer = new IntersectionObserver(observerHandler, observerOptions);
+
+    sections.forEach((t) => {
+      observer.observe(t);
+    });
+
+    return () => {
+      setIntersectingHeader(undefined);
+      observer.disconnect();
+    };
+  }, [sectionIdSet]);
+
+  return intersectingHeader;
+};

--- a/src/views/Package/useIntersectingHeader/util.ts
+++ b/src/views/Package/useIntersectingHeader/util.ts
@@ -1,0 +1,18 @@
+import { MenuItem } from "../util";
+
+export const normalizeId = (id: string) => id.replace("#", "").toLowerCase();
+
+export const getItemIds = (item: MenuItem) => {
+  const ids = [normalizeId(item.id)];
+
+  item.children?.forEach((child) => {
+    if (child?.id) {
+      ids.push(...getItemIds(child));
+    }
+  });
+
+  return ids;
+};
+
+export const getElementId = (el: Element): string =>
+  normalizeId(el.getAttribute("data-heading-id") as string);

--- a/src/views/Package/useSectionItems/useSectionItems.ts
+++ b/src/views/Package/useSectionItems/useSectionItems.ts
@@ -40,16 +40,18 @@ export const useSectionItems = (): MenuItem[] => {
     };
   }, [jsonDocs]);
 
-  if (!isApiPath(pathname)) {
-    const [readmeSection] = menuItems;
-    const readmeItems: MenuItem[] =
-      readmeSection?.id === README_ITEM_ID ? readmeSection.children : [];
+  return useMemo(() => {
+    if (!isApiPath(pathname)) {
+      const [readmeSection] = menuItems;
+      const readmeItems: MenuItem[] =
+        readmeSection?.id === README_ITEM_ID ? readmeSection.children : [];
 
-    return readmeItems;
-  }
+      return readmeItems;
+    }
 
-  const typeInfo = types.find((type) => type.displayName === typeId);
-  return typeInfo && metadata
-    ? schemaToSectionItems(typeInfo, language, submodule)
-    : [];
+    const typeInfo = types.find((type) => type.displayName === typeId);
+    return typeInfo && metadata
+      ? schemaToSectionItems(typeInfo, language, submodule)
+      : [];
+  }, [language, menuItems, metadata, pathname, submodule, typeId, types]);
 };

--- a/src/views/Package/useSectionItems/util.ts
+++ b/src/views/Package/useSectionItems/util.ts
@@ -106,9 +106,10 @@ export const schemaToSectionItems = (
         if (submodule) {
           query += `&${QUERY_PARAMS.SUBMODULE}=${submodule}`;
         }
+
         return {
           level: 2,
-          id: value.id,
+          id: hash,
           title: value.displayName,
           path: `${path}${query}${hash}`,
           children: [],


### PR DESCRIPTION
Fixes #904 


This PR implements the functionality to highlight secondary navigation items on scroll, using the intersection observer API.

Changes:
- NavTree component is split up into separate files to make code more readable
- `getIsActiveItem` function prop added to NavTree component, to allow implementations of the NavTree to define the active item logic


https://user-images.githubusercontent.com/8749859/154369364-f5318262-bedc-4db9-92a2-78b884c1c082.mov

Known issues:
- Sometimes nav items won't track on scrolls. I believe this is caused by markdown rendering after the IntersectionObserver logic is initialized. Working on a fix