### PR TITLE
ci: run canary tests every 30 minutes

### DIFF
--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -3,7 +3,7 @@
 name: e2e-canary
 on:
   schedule:
-    - cron: 0 */3 * * *
+    - cron: "*/30 * * * *"
   workflow_dispatch: {}
 jobs:
   test:

--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Cypress Run
         uses: cypress-io/github-action@v2
+        env:
+          DEBUG: "@cypress/github-action"
         with:
           start: yarn proxy-server:ci
           wait-on: http://localhost:3000

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Cypress Run
         uses: cypress-io/github-action@v2
+        env:
+          DEBUG: "@cypress/github-action"
         with:
           start: yarn proxy-server:ci
           wait-on: http://localhost:3000

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -183,7 +183,7 @@ project.npmignore.addPatterns("/.vscode/");
   e2eCanary.on({
     schedule: [
       {
-        cron: "0 */3 * * *", // run every three hours
+        cron: "*/30 * * * *", // run every 30 minutes
       },
     ],
     workflowDispatch: {},

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -133,6 +133,9 @@ project.npmignore.addPatterns("/.vscode/");
     {
       name: "Cypress Run",
       uses: "cypress-io/github-action@v2",
+      env: {
+        DEBUG: "@cypress/github-action",
+      },
       with: {
         start: "yarn proxy-server:ci",
         "wait-on": "http://localhost:3000",


### PR DESCRIPTION
1. Run canary tests every 30 minutes instead of 3 hours
2. Add debug flags to investigate why cypress workflow takes longer sometimes