### PR TITLE
feat: add go support

### DIFF
--- a/src/constants/languages.ts
+++ b/src/constants/languages.ts
@@ -10,7 +10,7 @@ export enum Language {
   DotNet = "dotnet",
   TypeScript = "typescript",
   Python = "python",
-  Go = "golang",
+  Go = "go",
   Java = "java",
 }
 
@@ -46,6 +46,7 @@ export const TEMP_SUPPORTED_LANGUAGES: ReadonlySet<Language> = new Set([
   Language.TypeScript,
   Language.Java,
   Language.DotNet,
+  Language.Go,
 ]);
 
 export const LANGUAGE_RENDER_MAP: {
@@ -67,7 +68,7 @@ export const LANGUAGE_RENDER_MAP: {
     icon: DukeIcon,
   },
   [Language.Go]: {
-    name: LANGUAGE_NAME_MAP.golang,
+    name: LANGUAGE_NAME_MAP.go,
     icon: GoIcon,
   },
   [Language.DotNet]: {

--- a/src/hooks/useLanguage/useLanguage.test.ts
+++ b/src/hooks/useLanguage/useLanguage.test.ts
@@ -37,11 +37,11 @@ describe("useLanguage", () => {
   it("sets value to valid language from query params", () => {
     useLocation.mockReturnValue({
       ...baseLocation,
-      search: "lang=golang",
+      search: "lang=go",
     });
     const { result } = testRender();
 
-    expect(result.current[0]).toEqual("golang");
+    expect(result.current[0]).toEqual("go");
   });
 
   it("ignores invalid language from query params", () => {

--- a/src/util/url.test.ts
+++ b/src/util/url.test.ts
@@ -79,7 +79,7 @@ describe("getSearchPath", () => {
     });
 
     expect(result).toMatchInlineSnapshot(
-      `"/search?q=%40aws%2Fcdk&cdk=aws-cdk&cdkver=1&langs=dotnet%2Cgolang&sort=newest&offset=1"`
+      `"/search?q=%40aws%2Fcdk&cdk=aws-cdk&cdkver=1&langs=dotnet%2Cgo&sort=newest&offset=1"`
     );
   });
 });
@@ -109,7 +109,7 @@ describe("getPackagePath", () => {
     });
 
     expect(pathWithLanguage).toMatchInlineSnapshot(
-      `"/packages/@example/construct/v/1.0.0?lang=golang"`
+      `"/packages/@example/construct/v/1.0.0?lang=go"`
     );
 
     const pathWithApiRef = getPackagePath({ ...basePkg, api: "bar" });
@@ -126,7 +126,7 @@ describe("getPackagePath", () => {
     });
 
     expect(pathWithAllParams).toMatchInlineSnapshot(
-      `"/packages/@example/construct/v/1.0.0/api/bar?submodule=foo&lang=golang"`
+      `"/packages/@example/construct/v/1.0.0/api/bar?submodule=foo&lang=go"`
     );
   });
 });


### PR DESCRIPTION
Adds go to supported languages array so packages with generated Go
documentation will show Go in their languages list.

Fix: #953
