### PR TITLE
fix: missing go install instructions

### DIFF
--- a/src/views/Package/PackageHeader/Install.tsx
+++ b/src/views/Package/PackageHeader/Install.tsx
@@ -51,6 +51,12 @@ const getCodeSample = ({
     const packageId = assembly.targets?.dotnet?.packageId;
     if (!packageId) return undefined;
     return `dotnet add package ${packageId} --version ${version}`;
+  } else if (language === Language.Go) {
+    const repositoryUrl = assembly?.targets?.go?.moduleName;
+
+    if (!repositoryUrl) return undefined;
+
+    return `go get ${repositoryUrl}`;
   }
 
   return undefined;


### PR DESCRIPTION
Fixes missing install instructions for go packages.

Screenshot:
<img width="491" alt="Screen Shot 2022-04-15 at 9 35 12 AM" src="https://user-images.githubusercontent.com/5008987/163596747-4662e284-5cee-4088-b1c6-f5e09d84b8b4.png">
