### PR TITLE
feat: add support for RSS/ATOM feed

### DIFF
--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -94,7 +94,7 @@ export interface FeaturedPackagesDetail {
 export interface FeatureFlags {}
 
 export interface Feed {
-  type: string;
+  mimeType: string;
   url: string;
 }
 

--- a/src/api/config/index.ts
+++ b/src/api/config/index.ts
@@ -93,6 +93,11 @@ export interface FeaturedPackagesDetail {
 
 export interface FeatureFlags {}
 
+export interface Feed {
+  type: string;
+  url: string;
+}
+
 export interface Config {
   featureFlags?: FeatureFlags;
   packageLinks?: PackageLinkConfig[];
@@ -100,6 +105,7 @@ export interface Config {
   packageTags?: PackageTagConfig[];
   packageTagGroups?: TagGroupConfig[];
   categories?: Category[];
+  feeds?: Feed[];
 }
 
 export const DEFAULT_FEATURED_PACKAGES = {

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -49,8 +49,8 @@ export const Page: FunctionComponent<PageProps> = ({
 
         <meta content="width=device-width, initial-scale=1" name="viewport" />
         <meta charSet="utf-8" />
-        {feedUrls.map(({ url, type }) => (
-          <link href={url} key={url} rel="alternate" type={type} />
+        {feedUrls.map(({ url, mimeType }) => (
+          <link href={url} key={url} rel="alternate" type={mimeType} />
         ))}
 
         <title>{formattedTitle}</title>

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -50,7 +50,7 @@ export const Page: FunctionComponent<PageProps> = ({
         <meta content="width=device-width, initial-scale=1" name="viewport" />
         <meta charSet="utf-8" />
         {feedUrls.map(({ url, type }) => (
-          <link href={url} key={url} rel="alternate" title="RSS" type={type} />
+          <link href={url} key={url} rel="alternate" type={type} />
         ))}
 
         <title>{formattedTitle}</title>

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { pageInfo } from "../../constants/pageInfo";
 import { usePageView } from "../../contexts/Analytics";
+import { useConfigValue } from "../../hooks/useConfigValue";
 
 export interface PageProps {
   pageName: keyof typeof pageInfo;
@@ -35,6 +36,7 @@ export const Page: FunctionComponent<PageProps> = ({
     trackPageView();
   }, [trackPageView]);
 
+  const feedUrls = useConfigValue("feeds") || [];
   const { suffix = true, title, description } = meta;
   const formattedTitle = suffix ? `${title} - Construct Hub` : title;
 
@@ -47,6 +49,9 @@ export const Page: FunctionComponent<PageProps> = ({
 
         <meta content="width=device-width, initial-scale=1" name="viewport" />
         <meta charSet="utf-8" />
+        {feedUrls.map(({ url, type }) => (
+          <link href={url} key={url} rel="alternate" title="RSS" type={type} />
+        ))}
 
         <title>{formattedTitle}</title>
         <meta content={formattedTitle} property="og:title" />


### PR DESCRIPTION
This change adds link tag in the frontend to support RSS/ATOM feeds for latest packages. 

re: https://github.com/cdklabs/construct-hub/pull/855/ 
