### PR TITLE
chore: upgrade GitHub actions versions

### DIFF
--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -14,21 +14,21 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cypress Run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         env:
           DEBUG: "@cypress/github-action"
         with:
           start: yarn proxy-server:ci
           wait-on: http://localhost:3000
           wait-on-timeout: 150
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -13,21 +13,21 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cypress Run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         env:
           DEBUG: "@cypress/github-action"
         with:
           start: yarn proxy-server:ci
           wait-on: http://localhost:3000
           wait-on-timeout: 150
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -132,11 +132,11 @@ project.npmignore.addPatterns("/.vscode/");
   const cypressRunSteps = [
     {
       name: "Checkout",
-      uses: "actions/checkout@v2",
+      uses: "actions/checkout@v3",
     },
     {
       name: "Cypress Run",
-      uses: "cypress-io/github-action@v2",
+      uses: "cypress-io/github-action@v3",
       env: {
         DEBUG: "@cypress/github-action",
       },
@@ -147,7 +147,7 @@ project.npmignore.addPatterns("/.vscode/");
       },
     },
     {
-      uses: "actions/upload-artifact@v2",
+      uses: "actions/upload-artifact@v3",
       if: "failure()",
       with: {
         name: "cypress-screenshots",
@@ -155,7 +155,7 @@ project.npmignore.addPatterns("/.vscode/");
       },
     },
     {
-      uses: "actions/upload-artifact@v2",
+      uses: "actions/upload-artifact@v3",
       if: "always()",
       with: {
         name: "cypress-videos",


### PR DESCRIPTION
Ideally there should be some way to have this self-managed by projen, though I haven't thought of what the best way to do this is yet. Ref: https://github.com/projen/projen/issues/1844

The main reason I'm submitting this is to see if perhaps upgrading the cypress actions version might resolve the weird time variance we have in our e2e-canary tests: https://github.com/cdklabs/construct-hub-webapp/actions/workflows/e2e-canary.yml