### PR TITLE
fix: badge always links to constructs

### DIFF
--- a/src/views/Package/ShareInfo.tsx
+++ b/src/views/Package/ShareInfo.tsx
@@ -41,7 +41,7 @@ export const ShareInfo: FunctionComponent = () => {
         to light mode or dark mode based on whether the user&apos;s client has
         requested a light or dark theme.
       </Text>
-      <Link to="/packages/constructs">
+      <Link to={packagePath}>
         <Image src="/badge-dynamic.svg" />
       </Link>
 


### PR DESCRIPTION
Accidentally hard-coded the link to the package.