### PR TITLE
fix: badge color broken in safari

### DIFF
--- a/public/badge-dark.svg
+++ b/public/badge-dark.svg
@@ -3,7 +3,6 @@
   <mask id="m"><rect width="1300" height="200" rx="50" fill="#FFF"/></mask>
   <g mask="url(#m)">
     <rect width="1300" height="200" fill="rgb(40, 43, 52)"/>
-    <rect width="1300" height="200" fill="url(#a)"/>
   </g>
   <g aria-hidden="true" fill="rgb(212, 213, 214)" text-anchor="start" font-family='-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"' font-size="100">
     <text x="110" y="138" textLength="360" font-weight="500">View on</text>

--- a/public/badge-dynamic.svg
+++ b/public/badge-dynamic.svg
@@ -22,7 +22,6 @@
   <mask id="m"><rect width="1300" height="200" rx="50" fill="#FFF"/></mask>
   <g mask="url(#m)">
     <rect width="1300" height="200" class="bg"/>
-    <rect width="1300" height="200" fill="url(#a)"/>
   </g>
   <g aria-hidden="true" text-anchor="start" font-family='-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"' font-size="100">
     <text x="110" y="138" class="primary" textLength="360" font-weight="500">View on</text>

--- a/public/badge-light.svg
+++ b/public/badge-light.svg
@@ -3,7 +3,6 @@
   <mask id="m"><rect width="1300" height="200" rx="50" fill="#FFF"/></mask>
   <g mask="url(#m)">
     <rect width="1300" height="200" fill="rgb(237, 242, 247)"/>
-    <rect width="1300" height="200" fill="url(#a)"/>
   </g>
   <g aria-hidden="true" fill="rgb(26, 32, 44)" text-anchor="start" font-family='-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"' font-size="100">
     <text x="110" y="138" textLength="360" font-weight="500">View on</text>


### PR DESCRIPTION
On Safari, our Construct Hub badge SVG has a coloring issue:

<img width="379" alt="Screen Shot 2022-06-14 at 3 45 57 PM" src="https://user-images.githubusercontent.com/5008987/173701642-883257a4-b48c-45b7-b40f-21912d1784dd.png">

After some googling I initially thought this was caused by a bug in WebKit (https://bugs.webkit.org/show_bug.cgi?id=199134) -- but after diving a little deeper, it turns out this is caused by an erroneous line of code in the SVG. In Chrome/Firefox it seems that this erroneous line doesn't make a difference, but in Safari it causes coloring issues.

For consistency I've also updated the non-dynamically-colored SVGs with the same fix.