### PR TITLE
fix: layout bug on home page

### DIFF
--- a/src/views/Home/Info.tsx
+++ b/src/views/Home/Info.tsx
@@ -89,7 +89,7 @@ const IconLink = ({
 
 const ResponsiveDivider = () => (
   <>
-    <Divider display={{ xl: "none" }} mx={SECTION_PADDING.X} w="auto" />
+    <Divider display={{ xl: "none" }} w="auto" />
     <Divider
       display={{ base: "none", xl: "initial" }}
       h="auto"
@@ -108,6 +108,8 @@ const Row: FunctionComponent = ({ children }) => (
 export const Info: FunctionComponent = () => (
   <Flex bg="bgSecondary" data-testid={testIds.infoContainer} direction="column">
     <Grid
+      gap={SECTION_PADDING.Y}
+      paddingX={SECTION_PADDING.X}
       templateColumns={{ base: "1fr", xl: "1fr auto 1fr auto 1fr" }}
       templateRows={{ base: "1fr auto 1fr auto 1fr", xl: "auto" }}
     >

--- a/src/views/Home/InfoSection.tsx
+++ b/src/views/Home/InfoSection.tsx
@@ -17,7 +17,6 @@ export const InfoSection: FunctionComponent<InfoSectionProps> = ({
     color="textPrimary"
     data-testid={testIds.infoSection}
     direction="column"
-    px={SECTION_PADDING.X}
     py={SECTION_PADDING.Y}
   >
     <Heading


### PR DESCRIPTION
Fixes info column layout on the home page where content overflows at around 1280px breakpoint.

Fixes https://github.com/cdklabs/construct-hub/issues/973
