### PR TITLE
chore(deps): upgrade to v4 of actions/upload-artifact and actions/download-artifact

### DIFF
--- a/.github/workflows/e2e-canary.yml
+++ b/.github/workflows/e2e-canary.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress Run
         uses: cypress-io/github-action@v3
         env:
@@ -24,12 +24,12 @@ jobs:
           wait-on: http://localhost:3000
           wait-on-timeout: 150
       - if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       - if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: cypress/videos

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cypress Run
         uses: cypress-io/github-action@v3
         env:
@@ -23,12 +23,12 @@ jobs:
           wait-on: http://localhost:3000
           wait-on-timeout: 150
       - if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       - if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: cypress/videos

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -141,7 +141,7 @@ project.npmignore?.addPatterns("/.vscode/");
   const cypressRunSteps = [
     {
       name: "Checkout",
-      uses: "actions/checkout@v3",
+      uses: "actions/checkout@v4",
     },
     {
       name: "Cypress Run",
@@ -156,7 +156,7 @@ project.npmignore?.addPatterns("/.vscode/");
       },
     },
     {
-      uses: "actions/upload-artifact@v3",
+      uses: "actions/upload-artifact@v4",
       if: "failure()",
       with: {
         name: "cypress-screenshots",
@@ -164,7 +164,7 @@ project.npmignore?.addPatterns("/.vscode/");
       },
     },
     {
-      uses: "actions/upload-artifact@v3",
+      uses: "actions/upload-artifact@v4",
       if: "always()",
       with: {
         name: "cypress-videos",


### PR DESCRIPTION
v3 is deprecated and github actions choke.